### PR TITLE
ci: commitlint, auto chart versioning, managed service overrides

### DIFF
--- a/.github/workflows/DEPLOYMENT.md
+++ b/.github/workflows/DEPLOYMENT.md
@@ -1,6 +1,6 @@
 # Tabby Deployment Guide
 
-How the CI/CD pipelines work, what they deploy, and what you need to configure manually.
+How the CI/CD pipelines work, what they deploy, and what you need to configure.
 
 ---
 
@@ -11,13 +11,13 @@ Tabby is a monorepo with 7 services. Each service has its own Dockerfile and run
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
 │                          EXTERNAL TRAFFIC                               │
-│                         (Ingress / TLS)                                 │
+│                  (Istio VirtualService / TLS)                           │
 └──────────┬──────────────────────┬───────────────────────┬───────────────┘
            │                      │                       │
     ┌──────▼──────┐       ┌───────▼──────┐       ┌───────▼──────┐
     │  Admin UI   │       │   API        │       │ Egress Proxy │
-    │  :3000      │──────▶│   :8080      │       │ :3128        │
-    │  Express    │ calls │   NestJS     │       │ FQDN filter  │
+    │  :8000      │──────▶│   :8000      │       │ :3128        │
+    │  Next.js    │ calls │   NestJS     │       │ FQDN filter  │
     └─────────────┘       └──┬───┬───┬───┘       └──────┬───────┘
                              │   │   │                   │
               ┌──────────────┘   │   └──────────┐       │
@@ -35,24 +35,11 @@ Tabby is a monorepo with 7 services. Each service has its own Dockerfile and run
     └──────────────────────────────────────────────┘ through proxy
 ```
 
-### Service Roles
+### Service Ports
 
+All services use port **8000** (API, Admin UI). Controller: **8090**, Worker health: **8091**. Do NOT use 3000 or 8080.
 
-| Service          | Image                        | Port | What it does                                                                                                                                                                  |
-| ---------------- | ---------------------------- | ---- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **API**          | `Dockerfile.api`             | 8080 | Central REST API — auth, CRUD, HITL operations, streaming, metrics. All clients talk to this.                                                                                 |
-| **Controller**   | `Dockerfile.controller`      | 8090 | Watches session state in DB, creates/destroys Worker pods in K8s. Calls egress proxy admin API to set per-session allowlists.                                                 |
-| **Worker**       | `Dockerfile.worker`          | 8091 | Ephemeral pod (1 per session). Runs Playwright + CloakBrowser, executes Login DSL, extracts artifacts. Heaviest resource consumer.                                            |
-| **Slack Bot**    | `Dockerfile.slack-bot`       | —    | Subscribes to NATS events, posts HITL notifications to Slack, relays OTP codes from operators.                                                                                |
-| **Teams Bot**    | `Dockerfile.teams-bot`       | 3978 | Same as Slack Bot but for Microsoft Teams via Bot Framework.                                                                                                                  |
-| **Admin UI**     | `Dockerfile.admin-ui`        | 3000 | Express server rendering the admin dashboard. Proxies API calls to the API service internally.                                                                                |
-| **Egress Proxy** | ConfigMap + `node:20-alpine` | 3128 | FQDN allowlist enforcement. All browser traffic from Worker pods routes through this. No custom Docker image — it's `node:20-alpine` running a ConfigMap-mounted `server.js`. |
-
-
-### Infrastructure (not built by CI)
-
-These are off-the-shelf images deployed by the Helm chart:
-
+### Infrastructure (deployed by Helm chart)
 
 | Service       | Image                | Purpose                                                            |
 | ------------- | -------------------- | ------------------------------------------------------------------ |
@@ -61,191 +48,204 @@ These are off-the-shelf images deployed by the Helm chart:
 | NATS 2.10     | `nats:2.10-alpine`   | Durable event bus (JetStream) — HITL events, session state changes |
 | MinIO         | `minio/minio`        | S3-compatible object storage for encrypted artifact bundles        |
 
-
-> **Production:** Replace PostgreSQL, Redis, and MinIO with managed services (RDS, ElastiCache, S3). Only NATS runs in-cluster.
-
----
-
-## What the Workflows Build vs. What You Configure
-
-### What CI/CD handles automatically
-
-- Lint, test, security audit on every PR
-- Docker image builds for all 7 services (parallel, cached)
-- Push to GHCR (`ghcr.io/adoptai/tabby/<service>`)
-- TrueFoundry `patch-application` to trigger deployment
-- Post-deploy health checks
-
-### What you must configure manually
-
-The workflows build and deploy the containers, but they **do not** manage secrets, environment variables, or infrastructure. You need to set these up in your deployment platform (TrueFoundry, Helm, or whatever orchestrates the pods).
+> **Production:** Replace with managed services (RDS, ElastiCache, S3). See [Managed Services](#managed-services).
 
 ---
 
-## Required Secrets (GitHub Actions)
+## Workflows
 
-Set these in **Settings → Secrets and variables → Actions**:
+| File                     | Trigger               | What it does                                                              |
+| ------------------------ | --------------------- | ------------------------------------------------------------------------- |
+| `ci.yaml`                | PR to dev/main        | Commitlint → Lint → Test → Build check → Security audit → Helm lint      |
+| `deploy-staging.yaml`    | Push to dev           | CI gates → Build images → Auto-bump chart → Push chart → tfy apply → Health check |
+| `deploy-production.yaml` | Push to main / manual | CI gates → Build images → Push chart → tfy apply (with approval) → Health check   |
 
+### Image Tag Convention
 
-| Secret               | Required | Purpose                                                                  |
-| -------------------- | -------- | ------------------------------------------------------------------------ |
-| `TFY_API_KEY`        | Yes      | TrueFoundry API key for deployments                                      |
-| `STAGING_API_URL`    | No       | e.g. `https://tabby-staging.example.com` — for post-deploy health checks |
-| `PRODUCTION_API_URL` | No       | e.g. `https://tabby.example.com` — for post-deploy health checks         |
-
-
-`GITHUB_TOKEN` is provided automatically (used for GHCR push).
+- **Staging:** `staging-{sha7}` (e.g., `staging-abc1234`), plus `staging-latest`
+- **Production:** `prod-{sha7}` (e.g., `prod-abc1234`), plus `latest`
 
 ---
 
-## Required Environment Variables (per service)
+## GH_PAT (GitHub Personal Access Token)
 
-These must be configured in your deployment platform (TrueFoundry app settings, Helm values, or K8s ConfigMaps/Secrets).
+The workflows use `GH_PAT` instead of the default `GITHUB_TOKEN` because:
+- `GITHUB_TOKEN` cannot push commits that trigger other workflows (the version bump commit needs `[skip ci]`)
+- `GITHUB_TOKEN` cannot push to GHCR with write access to packages in some org configurations
 
-### All services need
+### Required permissions
 
+- `repo` (full control of private repositories)
+- `write:packages` (push Docker images and Helm charts to GHCR)
 
-| Variable                | Example                                         | Notes                                         |
-| ----------------------- | ----------------------------------------------- | --------------------------------------------- |
-| `DATABASE_URL`          | `postgresql://user:pass@host:5432/browser_hitl` | Managed DB in prod                            |
-| `REDIS_URL`             | `redis://host:6379`                             | Managed Redis in prod                         |
-| `NATS_URL`              | `nats://browser-hitl-nats:4222`                 | In-cluster NATS                               |
-| `JWT_SIGNING_KEY`       | 48+ char random string                          | **Must be identical** across API and all bots |
-| `TENANT_ENCRYPTION_KEY` | 64-char hex (`openssl rand -hex 32`)            | Per-tenant AES-256-GCM key for artifacts      |
-| `NODE_ENV`              | `production`                                    | Enables production optimizations              |
+### How to create
 
+1. Go to **GitHub → Settings → Developer settings → Personal access tokens → Fine-grained tokens**
+2. Select the repository scope
+3. Grant `Contents: Read and write` and `Packages: Read and write`
+4. Set expiration (recommend 90 days) and add to your rotation calendar
 
-### API-specific
+### Where to set it
 
+**Settings → Secrets and variables → Actions → Repository secrets** → `GH_PAT`
 
-| Variable                                                   | Example                     | Notes                                             |
-| ---------------------------------------------------------- | --------------------------- | ------------------------------------------------- |
-| `ADMIN_BOOTSTRAP_EMAIL`                                    | `admin@yourdomain.com`      | First admin account (created on first startup)    |
-| `ADMIN_BOOTSTRAP_PASSWORD`                                 | strong random               | Change after first login                          |
-| `MINIO_ENDPOINT` / `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` | —                           | Or S3 credentials in prod                         |
-| `CORS_ORIGIN`                                              | `https://tabby.example.com` | **Not** `*` in production                         |
-| `METRICS_AUTH_TOKEN`                                       | random hex                  | Protects `/metrics` endpoint                      |
-| `STREAM_HOST`                                              | `tabby.example.com`         | Used to build VNC stream URLs returned to clients |
-| `SERVICE_AUTH_CLIENT_ID` / `SERVICE_AUTH_CLIENT_SECRET`    | —                           | For bot → API service token auth                  |
+---
 
+## GitHub Environments
 
-### Slack Bot
+Create two environments: `staging` and `production`.
 
+**Settings → Environments → New environment**
 
-| Variable               | Example                        | Notes                        |
-| ---------------------- | ------------------------------ | ---------------------------- |
-| `SLACK_BOT_TOKEN`      | `xoxb-...`                     | Bot User OAuth Token         |
-| `SLACK_SIGNING_SECRET` | from Slack app                 | For request verification     |
-| `SLACK_APP_TOKEN`      | `xapp-...`                     | For Socket Mode              |
-| `SLACK_CHANNEL`        | `tabby-alerts`                 | Default notification channel |
-| `API_BASE_URL`         | `http://browser-hitl-api:8080` | Internal API address         |
+- **staging**: No protection rules needed
+- **production**: Add required reviewers (at least 1 team member must approve deploys)
 
+### Secrets by scope
 
-### Teams Bot
+#### Repository-level secrets (Settings → Secrets → Actions)
 
+| Secret    | Required | Purpose                                    |
+| --------- | -------- | ------------------------------------------ |
+| `GH_PAT`  | Yes      | GitHub PAT for checkout + push (see above) |
 
-| Variable                 | Example        | Notes                |
-| ------------------------ | -------------- | -------------------- |
-| `MICROSOFT_APP_ID`       | from Azure Bot | Bot Framework app ID |
-| `MICROSOFT_APP_PASSWORD` | from Azure Bot | Bot Framework secret |
+#### Environment-level secrets (per environment)
 
+| Secret                      | Required | Env     | Purpose                                               |
+| --------------------------- | -------- | ------- | ----------------------------------------------------- |
+| `TFY_API_KEY`               | Yes      | Both    | TrueFoundry API key for `tfy apply`                   |
+| `TFY_APP_NAME`              | Yes      | Both    | TrueFoundry application name                          |
+| `TFY_WORKSPACE_FQN`         | Yes      | Both    | TrueFoundry workspace FQN                             |
+| `API_HOST`                  | Yes      | Both    | Public hostname (e.g., `tabby-api.adoptai.dev`)       |
+| `ADMIN_HOST`                | Yes      | Both    | Admin UI hostname (e.g., `tabby-admin.adoptai.dev`)   |
+| `POSTGRES_PASSWORD`         | Yes      | Both    | PostgreSQL password                                   |
+| `JWT_SIGNING_KEY`           | Yes      | Both    | JWT signing key (48+ chars, same across all services) |
+| `TENANT_ENCRYPTION_KEY`     | Yes      | Both    | 64-char hex for AES-256-GCM (`openssl rand -hex 32`) |
+| `MINIO_ACCESS_KEY`          | Yes      | Both    | MinIO / S3 access key                                 |
+| `MINIO_SECRET_KEY`          | Yes      | Both    | MinIO / S3 secret key                                 |
+| `ADMIN_BOOTSTRAP_PASSWORD`  | Yes      | Both    | First admin account password                          |
+| `EGRESS_PROXY_ADMIN_TOKEN`  | Yes      | Both    | Auth for controller → proxy admin API                 |
+| `EGRESS_PROXY_SESSION_KEY`  | Yes      | Both    | Signs per-session proxy credentials                   |
+| `SERVICE_AUTH_CLIENT_ID`    | Yes      | Both    | Bot → API service auth client ID                      |
+| `SERVICE_AUTH_CLIENT_SECRET`| Yes      | Both    | Bot → API service auth client secret                  |
+| `SLACK_BOT_TOKEN`           | Yes      | Both    | Slack Bot User OAuth Token (`xoxb-...`)               |
+| `SLACK_SIGNING_SECRET`      | Yes      | Both    | Slack request verification                            |
+| `SLACK_APP_TOKEN`           | Yes      | Both    | Slack Socket Mode token (`xapp-...`)                  |
+| `METRICS_AUTH_TOKEN`        | Yes      | Both    | Protects `/metrics` endpoint                          |
+| `NATS_AUTH_TOKEN`           | Yes      | Both    | NATS authentication token                             |
 
-### Admin UI
+#### Optional managed service overrides
 
+| Secret             | Default    | Purpose                                          |
+| ------------------ | ---------- | ------------------------------------------------ |
+| `DATABASE_URL`     | (in-cluster) | External PostgreSQL URL (e.g., RDS)            |
+| `REDIS_URL`        | (in-cluster) | External Redis URL (e.g., ElastiCache)         |
+| `NATS_URL`         | (in-cluster) | External NATS URL                              |
+| `MINIO_ENDPOINT`   | (in-cluster) | External S3-compatible endpoint                |
+| `POSTGRES_ENABLED` | `true`     | Set to `false` when using managed PostgreSQL     |
+| `REDIS_ENABLED`    | `true`     | Set to `false` when using managed Redis          |
+| `NATS_ENABLED`     | `true`     | Set to `false` when using managed NATS           |
+| `MINIO_ENABLED`    | `true`     | Set to `false` when using managed object storage |
 
-| Variable              | Example                     | Notes                                                  |
-| --------------------- | --------------------------- | ------------------------------------------------------ |
-| `NEXT_PUBLIC_API_URL` | `https://tabby.example.com` | **Browser-facing** API URL (not internal service name) |
+When a secret is not set, it defaults to empty string → Helm `default` function falls back to the in-cluster service URL. No changes needed for staging.
 
+---
 
-### Controller
+## Managed Services
 
-No extra env vars beyond the shared ones. It discovers other services via K8s DNS:
+For production, replace in-cluster StatefulSets with managed services:
 
-- API: `http://browser-hitl-api:8080`
-- Egress proxy admin: `http://browser-hitl-egress-proxy:8095`
+| In-cluster | Managed replacement | Config override   | Disable flag          |
+| ---------- | ------------------- | ----------------- | --------------------- |
+| PostgreSQL | AWS RDS / Azure DB  | `DATABASE_URL`    | `POSTGRES_ENABLED=false` |
+| Redis      | ElastiCache / Azure Cache | `REDIS_URL` | `REDIS_ENABLED=false`    |
+| NATS       | (usually in-cluster) | `NATS_URL`       | `NATS_ENABLED=false`     |
+| MinIO      | S3 / Azure Blob     | `MINIO_ENDPOINT`  | `MINIO_ENABLED=false`    |
+
+**How it works:**
+1. Set `DATABASE_URL=postgresql://...` in the production environment secrets
+2. Set `POSTGRES_ENABLED=false` to skip deploying the in-cluster PostgreSQL StatefulSet
+3. The Helm configmap template uses `default $constructedUrl .Values.config.databaseUrl` — when the override is set, it wins
 
 ### Egress Proxy
 
-
-| Variable                         | Example                 | Notes                                      |
-| -------------------------------- | ----------------------- | ------------------------------------------ |
-| `EGRESS_PROXY_ADMIN_TOKEN`       | random hex              | Authenticates controller → proxy admin API |
-| `EGRESS_PROXY_SESSION_KEY`       | random hex              | Signs per-session proxy credentials        |
-| `EGRESS_PROXY_DEFAULT_ALLOWLIST` | comma-separated domains | Baseline domains allowed for all sessions  |
-
+The egress proxy allowlist is hardcoded in `infra/tfy/deploy.yaml` (~95 domains). This is intentional:
+- The list rarely changes
+- It's not secret (just domain patterns)
+- Changes are reviewable in PRs
+- The proxy must run in-cluster (workers route all browser traffic through it)
 
 ---
 
-## Deployment Checklist
+## Conventional Commits
 
-### Staging
+All commits must follow [Conventional Commits](https://www.conventionalcommits.org/):
 
-- TrueFoundry applications created for: api, controller, worker, slack-bot, admin-ui
-- TrueFoundry FQNs updated in `deploy-staging.yaml` matrix
-- `TFY_API_KEY` secret set in GitHub
-- All env vars configured in TrueFoundry for each service
-- PostgreSQL, Redis, NATS, MinIO/S3 accessible from staging cluster
-- Egress proxy allowlist includes all target portal domains
-- `STAGING_API_URL` secret set (optional, for health checks)
+```
+type(scope): description
 
-### Production
+feat: add OTP retry logic
+fix: handle empty allowlist in egress proxy
+chore: update dependencies
+ci: add commitlint to PR checks
+```
 
-- Same as staging, plus:
-- GitHub environment `production` created with required reviewers
-- TLS enabled (cert-manager + `letsencrypt-prod`)
-- NATS auth enabled (`nats.auth.enabled: true`)
-- Network policies enabled
-- `CORS_ORIGIN` set to exact domain (not `*`)
-- Managed PostgreSQL with automated backups
-- Managed Redis with persistence
-- Managed S3/GCS instead of MinIO
-- `PRODUCTION_API_URL` secret set (optional, for health checks)
-- Monitoring: kube-prometheus-stack + PrometheusRules enabled
+Enforced by:
+- **Local:** Husky `commit-msg` hook runs commitlint
+- **CI:** `commitlint` job in `ci.yaml` validates all PR commits
+
+### Chart Version Auto-Bump
+
+On push to `dev`, the staging workflow automatically bumps the chart version:
+
+- `feat:` or `feat(scope):` → **minor** bump (0.X+1.0)
+- Everything else (`fix:`, `chore:`, `ci:`, etc.) → **patch** bump (0.0.X+1)
+
+The bump commit uses `[skip ci]` to prevent re-triggering the workflow.
+
+**Important:** Enforce squash merges on the `dev` branch so the commit message is the PR title (which must be conventional). Production reads whatever version is in Chart.yaml — no auto-bump.
+
+---
+
+## Verification Commands
+
+### Check deployed version
+
+```bash
+curl -s https://tabby-api.adoptai.dev/health/live | jq .
+# Returns: { "status": "ok", "version": "0.1.6", "commit": "abc1234..." }
+```
+
+### Check pods
+
+```bash
+kubectl get pods -n azure-ws -l app.kubernetes.io/instance=tabby-dev
+kubectl logs -n azure-ws deploy/tabby-dev-browser-hitl-api --tail=50
+```
+
+### Verify Helm release
+
+```bash
+kubectl get applications.argoproj.io tabby-dev -n azure-ws -o jsonpath='{.spec.source.targetRevision}'
+```
+
+### Local Helm validation
+
+```bash
+helm lint charts/browser-hitl/
+helm template tabby-dev charts/browser-hitl/ | grep -c "kind:"
+```
 
 ---
 
 ## Common Gotchas
 
-
-| Problem                                       | Cause                                                                                                    | Fix                                                                       |
-| --------------------------------------------- | -------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| Admin UI shows `ERR_NAME_NOT_RESOLVED`        | `NEXT_PUBLIC_API_URL` set to internal K8s DNS (`http://browser-hitl-api:8080`) instead of the public URL | Set it to the external URL the **browser** can reach                      |
-| Stream URLs return `http://localhost/vnc/...` | `STREAM_HOST` not set on API                                                                             | Set to public hostname (e.g. `tabby.example.com`)                         |
-| Slack bot silent after deploy                 | NATS wasn't ready when bot started — connection fails permanently                                        | Restart the bot pod after NATS is healthy                                 |
-| Worker pods crash-loop                        | Egress proxy is down → controller can't set allowlists → kills worker                                    | Restart egress proxy first, then controller                               |
-| `JWT_SIGNING_KEY` mismatch                    | API and bots have different keys → tokens from API are invalid for bot → 401                             | Ensure **all services** share the exact same `JWT_SIGNING_KEY`            |
-| Helm upgrade breaks env overrides             | `kubectl set env` overrides are lost on `helm upgrade`                                                   | Use Helm values or TrueFoundry config instead of manual `kubectl set env` |
-| Security audit fails CI                       | `pnpm audit` found high/critical vulnerability                                                           | Update the dependency or add to `.pnpmfile.cjs` audit overrides           |
-
-
----
-
-## TrueFoundry Application FQNs
-
-Update these in the workflow files once applications are created:
-
-
-| Service    | Staging FQN                                             | Production FQN                                        |
-| ---------- | ------------------------------------------------------- | ----------------------------------------------------- |
-| API        | `tfy-dev-cluster:adopt-dev-ws:tabby-api-staging`        | `tfy-dev-cluster:adopt-prod-ws:tabby-api-prod`        |
-| Controller | `tfy-dev-cluster:adopt-dev-ws:tabby-controller-staging` | `tfy-dev-cluster:adopt-prod-ws:tabby-controller-prod` |
-| Worker     | `tfy-dev-cluster:adopt-dev-ws:tabby-worker-staging`     | `tfy-dev-cluster:adopt-prod-ws:tabby-worker-prod`     |
-| Slack Bot  | `tfy-dev-cluster:adopt-dev-ws:tabby-slack-bot-staging`  | `tfy-dev-cluster:adopt-prod-ws:tabby-slack-bot-prod`  |
-| Admin UI   | `tfy-dev-cluster:adopt-dev-ws:tabby-admin-ui-staging`   | `tfy-dev-cluster:adopt-prod-ws:tabby-admin-ui-prod`   |
-
-
-> **Note:** Teams Bot and noVNC sidecar are not deployed standalone via TrueFoundry. The noVNC sidecar is bundled into Worker pods by the Controller. Teams Bot can be added when needed.
-
----
-
-## Workflow File Reference
-
-
-| File                     | Trigger               | What it does                                                                                 |
-| ------------------------ | --------------------- | -------------------------------------------------------------------------------------------- |
-| `ci.yaml`                | PR to dev/main        | Lint → Test → Build check → Security audit → Helm lint                                       |
-| `deploy-staging.yaml`    | Push to dev           | CI gates → Build 7 images (GHCR) → TrueFoundry staging → Health check                        |
-| `deploy-production.yaml` | Push to main / manual | CI gates (strict) → Build images → TrueFoundry prod (with approval) → Health check → Summary |
-
-
+| Problem                                       | Cause                                                              | Fix                                                                       |
+| --------------------------------------------- | ------------------------------------------------------------------ | ------------------------------------------------------------------------- |
+| Admin UI shows `ERR_NAME_NOT_RESOLVED`        | `NEXT_PUBLIC_API_URL` points to internal K8s DNS                   | Set to the external URL the **browser** can reach                         |
+| Stream URLs return `http://localhost/vnc/...`  | `STREAM_HOST` not set on API                                       | Set to public hostname (e.g., `tabby-api.adoptai.dev`)                    |
+| Slack bot silent after deploy                  | NATS wasn't ready when bot started — no retry                      | Restart the bot pod after NATS is healthy                                 |
+| Worker pods crash-loop                         | Egress proxy down → controller can't set allowlists                | Restart egress proxy first, then controller                               |
+| `JWT_SIGNING_KEY` mismatch                     | API and bots have different keys → 401s                            | All services must share the exact same key                                |
+| Helm upgrade breaks env overrides              | `kubectl set env` overrides lost on upgrade                        | Use Helm values or TrueFoundry config                                     |
+| Postgres password unchanged after values edit  | PVC retains old password from init                                 | Delete PVC + pod to re-init                                               |
+| Chart push fails "already exists"              | Version wasn't bumped (manual push or prod re-push)                | Production uses `\|\| echo "already exists"` — this is expected           |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,26 @@ env:
   NODE_VERSION: "20"
 
 jobs:
+  commitlint:
+    name: Commit Messages
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile --ignore-scripts
+      - name: Validate commit messages
+        run: npx commitlint --from ${{ github.event.pull_request.base.sha }} --to ${{ github.event.pull_request.head.sha }} --verbose
+
   lint:
     name: Lint & Type-check
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -243,6 +243,16 @@ jobs:
     env:
       IMAGE_TAG: ${{ needs.push-chart.outputs.image_tag }}
       CHART_VERSION: ${{ needs.push-chart.outputs.chart_version }}
+      COMMIT_SHA: ${{ github.sha }}
+      # Managed service overrides (optional — defaults to in-cluster)
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      REDIS_URL: ${{ secrets.REDIS_URL }}
+      NATS_URL: ${{ secrets.NATS_URL }}
+      MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+      POSTGRES_ENABLED: ${{ secrets.POSTGRES_ENABLED || 'true' }}
+      REDIS_ENABLED: ${{ secrets.REDIS_ENABLED || 'true' }}
+      NATS_ENABLED: ${{ secrets.NATS_ENABLED || 'true' }}
+      MINIO_ENABLED: ${{ secrets.MINIO_ENABLED || 'true' }}
       TFY_APP_NAME: ${{ secrets.TFY_APP_NAME }}
       TFY_WORKSPACE_FQN: ${{ secrets.TFY_WORKSPACE_FQN }}
       API_HOST: ${{ secrets.API_HOST }}

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -153,6 +153,7 @@ jobs:
     timeout-minutes: 10
     needs: [build-images]
     permissions:
+      contents: write
       packages: write
     outputs:
       chart_version: ${{ steps.version.outputs.version }}
@@ -161,14 +162,37 @@ jobs:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_PAT }}
+          fetch-depth: 2
 
       - uses: azure/setup-helm@v4
         with:
           version: v3.14.0
 
-      - name: Get chart version
+      - name: Auto-bump chart version
         id: version
-        run: echo "version=$(grep '^version:' charts/browser-hitl/Chart.yaml | awk '{print $2}')" >> $GITHUB_OUTPUT
+        run: |
+          CURRENT=$(grep '^version:' charts/browser-hitl/Chart.yaml | awk '{print $2}')
+          COMMIT_MSG=$(git log -1 --pretty=%s)
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+          if echo "$COMMIT_MSG" | grep -qE '^feat(\(.+\))?!?:'; then
+            MINOR=$((MINOR + 1))
+            PATCH=0
+          else
+            PATCH=$((PATCH + 1))
+          fi
+          NEW_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+          sed -i "s/^version: .*/version: ${NEW_VERSION}/" charts/browser-hitl/Chart.yaml
+          sed -i "s/^appVersion: .*/appVersion: \"${NEW_VERSION}\"/" charts/browser-hitl/Chart.yaml
+          echo "version=${NEW_VERSION}" >> $GITHUB_OUTPUT
+          echo "Bumped chart version: ${CURRENT} → ${NEW_VERSION} (commit: ${COMMIT_MSG})"
+
+      - name: Commit version bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add charts/browser-hitl/Chart.yaml
+          git commit -m "chore: bump chart version to ${{ steps.version.outputs.version }} [skip ci]" || echo "No changes to commit"
+          git push
 
       - name: Get image tag
         id: tag
@@ -200,6 +224,15 @@ jobs:
       # App config (from environment secrets)
       API_HOST: ${{ secrets.API_HOST }}
       ADMIN_HOST: ${{ secrets.ADMIN_HOST }}
+      # Managed service overrides (optional — defaults to in-cluster)
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      REDIS_URL: ${{ secrets.REDIS_URL }}
+      NATS_URL: ${{ secrets.NATS_URL }}
+      MINIO_ENDPOINT: ${{ secrets.MINIO_ENDPOINT }}
+      POSTGRES_ENABLED: ${{ secrets.POSTGRES_ENABLED || 'true' }}
+      REDIS_ENABLED: ${{ secrets.REDIS_ENABLED || 'true' }}
+      NATS_ENABLED: ${{ secrets.NATS_ENABLED || 'true' }}
+      MINIO_ENABLED: ${{ secrets.MINIO_ENABLED || 'true' }}
       # App secrets (from environment secrets)
       POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
       JWT_SIGNING_KEY: ${{ secrets.JWT_SIGNING_KEY }}

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+npx --no -- commitlint --edit $1

--- a/charts/browser-hitl/templates/configmap.yaml
+++ b/charts/browser-hitl/templates/configmap.yaml
@@ -11,7 +11,8 @@ metadata:
 data:
   # Per spec section 15.4 - Runtime Configuration (Env Vars)
   {{- $dbPassword := .Values.secrets.postgresPassword | default "changeme" }}
-  DATABASE_URL: {{ printf "postgresql://%s:%s@%s-postgres:%v/%s" .Values.postgres.auth.username $dbPassword (include "browser-hitl.fullname" .) (.Values.postgres.port | int) .Values.postgres.auth.database | quote }}
+  {{- $defaultDatabaseUrl := printf "postgresql://%s:%s@%s-postgres:%v/%s" .Values.postgres.auth.username $dbPassword (include "browser-hitl.fullname" .) (.Values.postgres.port | int) .Values.postgres.auth.database }}
+  DATABASE_URL: {{ default $defaultDatabaseUrl .Values.config.databaseUrl | quote }}
   {{- $defaultRedisUrl := printf "redis://%s-redis:%v" (include "browser-hitl.fullname" .) (.Values.redis.port | int) }}
   REDIS_URL: {{ default $defaultRedisUrl .Values.config.redisUrl | quote }}
   {{- $defaultNatsUrl := printf "nats://%s-nats:%v" (include "browser-hitl.fullname" .) (.Values.nats.port | int) }}

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,1 @@
+module.exports = { extends: ['@commitlint/config-conventional'] };

--- a/infra/tfy/deploy.yaml
+++ b/infra/tfy/deploy.yaml
@@ -59,24 +59,30 @@ values:
     streamHost: "${API_HOST}"
     streamProtocol: "wss"
     commitSha: "${COMMIT_SHA}"
+    # Managed service overrides — when set, Helm uses these instead of constructing
+    # URLs from in-cluster service names. Leave empty to use in-cluster defaults.
+    databaseUrl: "${DATABASE_URL}"
+    redisUrl: "${REDIS_URL}"
+    natsUrl: "${NATS_URL}"
+    minioEndpoint: "${MINIO_ENDPOINT}"
 
   postgres:
-    enabled: true
+    enabled: ${POSTGRES_ENABLED}
     persistence:
       size: 20Gi
 
   redis:
-    enabled: true
+    enabled: ${REDIS_ENABLED}
     persistence:
       size: 5Gi
 
   nats:
-    enabled: true
+    enabled: ${NATS_ENABLED}
     persistence:
       size: 10Gi
 
   minio:
-    enabled: true
+    enabled: ${MINIO_ENABLED}
     persistence:
       size: 50Gi
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "prepare": "husky"
   },
   "devDependencies": {
+    "@commitlint/cli": "^20.5.0",
+    "@commitlint/config-conventional": "^20.5.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
     "nx": "^21.1.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,12 @@ importers:
 
   .:
     devDependencies:
+      '@commitlint/cli':
+        specifier: ^20.5.0
+        version: 20.5.0(@types/node@25.2.3)(conventional-commits-parser@6.3.0)(typescript@5.9.3)
+      '@commitlint/config-conventional':
+        specifier: ^20.5.0
+        version: 20.5.0
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -611,6 +617,87 @@ packages:
     resolution: {integrity: sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==}
     engines: {node: '>=0.1.90'}
 
+  '@commitlint/cli@20.5.0':
+    resolution: {integrity: sha512-yNkyN/tuKTJS3wdVfsZ2tXDM4G4Gi7z+jW54Cki8N8tZqwKBltbIvUUrSbT4hz1bhW/h0CdR+5sCSpXD+wMKaQ==}
+    engines: {node: '>=v18'}
+    hasBin: true
+
+  '@commitlint/config-conventional@20.5.0':
+    resolution: {integrity: sha512-t3Ni88rFw1XMa4nZHgOKJ8fIAT9M2j5TnKyTqJzsxea7FUetlNdYFus9dz+MhIRZmc16P0PPyEfh6X2d/qw8SA==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/config-validator@20.5.0':
+    resolution: {integrity: sha512-T/Uh6iJUzyx7j35GmHWdIiGRQB+ouZDk0pwAaYq4SXgB54KZhFdJ0vYmxiW6AMYICTIWuyMxDBl1jK74oFp/Gw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/ensure@20.5.0':
+    resolution: {integrity: sha512-IpHqAUesBeW1EDDdjzJeaOxU9tnogLAyXLRBn03SHlj1SGENn2JGZqSWGkFvBJkJzfXAuCNtsoYzax+ZPS+puw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/execute-rule@20.0.0':
+    resolution: {integrity: sha512-xyCoOShoPuPL44gVa+5EdZsBVao/pNzpQhkzq3RdtlFdKZtjWcLlUFQHSWBuhk5utKYykeJPSz2i8ABHQA+ZZw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/format@20.5.0':
+    resolution: {integrity: sha512-TI9EwFU/qZWSK7a5qyXMpKPPv3qta7FO4tKW+Wt2al7sgMbLWTsAcDpX1cU8k16TRdsiiet9aOw0zpvRXNJu7Q==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/is-ignored@20.5.0':
+    resolution: {integrity: sha512-JWLarAsurHJhPozbuAH6GbP4p/hdOCoqS9zJMfqwswne+/GPs5V0+rrsfOkP68Y8PSLphwtFXV0EzJ+GTXTTGg==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/lint@20.5.0':
+    resolution: {integrity: sha512-jiM3hNUdu04jFBf1VgPdjtIPvbuVfDTBAc6L98AWcoLjF5sYqkulBHBzlVWll4rMF1T5zeQFB6r//a+s+BBKlA==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/load@20.5.0':
+    resolution: {integrity: sha512-sLhhYTL/KxeOTZjjabKDhwidGZan84XKK1+XFkwDYL/4883kIajcz/dZFAhBJmZPtL8+nBx6bnkzA95YxPeDPw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/message@20.4.3':
+    resolution: {integrity: sha512-6akwCYrzcrFcTYz9GyUaWlhisY4lmQ3KvrnabmhoeAV8nRH4dXJAh4+EUQ3uArtxxKQkvxJS78hNX2EU3USgxQ==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/parse@20.5.0':
+    resolution: {integrity: sha512-SeKWHBMk7YOTnnEWUhx+d1a9vHsjjuo6Uo1xRfPNfeY4bdYFasCH1dDpAv13Lyn+dDPOels+jP6D2GRZqzc5fA==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/read@20.5.0':
+    resolution: {integrity: sha512-JDEIJ2+GnWpK8QqwfmW7O42h0aycJEWNqcdkJnyzLD11nf9dW2dWLTVEa8Wtlo4IZFGLPATjR5neA5QlOvIH1w==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/resolve-extends@20.5.0':
+    resolution: {integrity: sha512-3SHPWUW2v0tyspCTcfSsYml0gses92l6TlogwzvM2cbxDgmhSRc+fldDjvGkCXJrjSM87BBaWYTPWwwyASZRrg==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/rules@20.5.0':
+    resolution: {integrity: sha512-5NdQXQEdnDPT5pK8O39ZA7HohzPRHEsDGU23cyVCNPQy4WegAbAwrQk3nIu7p2sl3dutPk8RZd91yKTrMTnRkQ==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/to-lines@20.0.0':
+    resolution: {integrity: sha512-2l9gmwiCRqZNWgV+pX1X7z4yP0b3ex/86UmUFgoRt672Ez6cAM2lOQeHFRUTuE6sPpi8XBCGnd8Kh3bMoyHwJw==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/top-level@20.4.3':
+    resolution: {integrity: sha512-qD9xfP6dFg5jQ3NMrOhG0/w5y3bBUsVGyJvXxdWEwBm8hyx4WOk3kKXw28T5czBYvyeCVJgJJ6aoJZUWDpaacQ==}
+    engines: {node: '>=v18'}
+
+  '@commitlint/types@20.5.0':
+    resolution: {integrity: sha512-ZJoS8oSq2CAZEpc/YI9SulLrdiIyXeHb/OGqGrkUP6Q7YV+0ouNAa7GjqRdXeQPncHQIDz/jbCTlHScvYvO/gA==}
+    engines: {node: '>=v18'}
+
+  '@conventional-changelog/git-client@2.6.0':
+    resolution: {integrity: sha512-T+uPDciKf0/ioNNDpMGc8FDsehJClZP0yR3Q5MN6wE/Y/1QZ7F+80OgznnTCOlMEG4AV0LvH2UJi3C/nBnaBUg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      conventional-commits-filter: ^5.0.0
+      conventional-commits-parser: ^6.3.0
+    peerDependenciesMeta:
+      conventional-commits-filter:
+        optional: true
+      conventional-commits-parser:
+        optional: true
+
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
@@ -1178,6 +1265,14 @@ packages:
   '@scarf/scarf@1.4.0':
     resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
 
+  '@simple-libs/child-process-utils@1.0.2':
+    resolution: {integrity: sha512-/4R8QKnd/8agJynkNdJmNw2MBxuFTRcNFnE5Sg/G+jkSsV8/UBgULMzhizWWW42p8L5H7flImV2ATi79Ove2Tw==}
+    engines: {node: '>=18'}
+
+  '@simple-libs/stream-utils@1.2.0':
+    resolution: {integrity: sha512-KxXvfapcixpz6rVEB6HPjOUZT22yN6v0vI0urQSk1L8MlEWPDFCZkhw2xmkyoTGYeFw7tWTZd7e3lVzRZRN/EA==}
+    engines: {node: '>=18'}
+
   '@sinclair/typebox@0.27.10':
     resolution: {integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==}
 
@@ -1608,6 +1703,9 @@ packages:
   array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
 
+  array-ify@1.0.0:
+    resolution: {integrity: sha512-c5AMf34bKdvPhQ7tBGhqkgKNUzMr4WUs+WDtC2ZUGOUncbxKMTvqxYctiseW3+L4bA8ec+GcZ6/A/FW4m8ukng==}
+
   array-timsort@1.0.3:
     resolution: {integrity: sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==}
 
@@ -1981,6 +2079,9 @@ packages:
     resolution: {integrity: sha512-bKw/r35jR3HGt5PEPm1ljsQQGyCrR8sFGNiN5L+ykDHdpO8Smxkrkla9Yi6NkQyUrb8V54PGhfMs6NrIwtxtdw==}
     engines: {node: '>= 6'}
 
+  compare-func@2.0.0:
+    resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
@@ -1999,6 +2100,19 @@ packages:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
 
+  conventional-changelog-angular@8.3.0:
+    resolution: {integrity: sha512-DOuBwYSqWzfwuRByY9O4oOIvDlkUCTDzfbOgcSbkY+imXXj+4tmrEFao3K+FxemClYfYnZzsvudbwrhje9VHDA==}
+    engines: {node: '>=18'}
+
+  conventional-changelog-conventionalcommits@9.3.0:
+    resolution: {integrity: sha512-kYFx6gAyjSIMwNtASkI3ZE99U1fuVDJr0yTYgVy+I2QG46zNZfl2her+0+eoviG82c5WQvW1jMt1eOQTeJLodA==}
+    engines: {node: '>=18'}
+
+  conventional-commits-parser@6.3.0:
+    resolution: {integrity: sha512-RfOq/Cqy9xV9bOA8N+ZH6DlrDR+5S3Mi0B5kACEjESpE+AviIpAptx9a9cFpWCCvgRtWT+0BbUw+e1BZfts9jg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
@@ -2016,8 +2130,25 @@ packages:
     resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
     engines: {node: '>= 0.10'}
 
+  cosmiconfig-typescript-loader@6.2.0:
+    resolution: {integrity: sha512-GEN39v7TgdxgIoNcdkRE3uiAzQt3UXLyHbRHD6YoL048XAeOomyxaP+Hh/+2C6C2wYjxJ2onhJcsQp+L4YEkVQ==}
+    engines: {node: '>=v18'}
+    peerDependencies:
+      '@types/node': '*'
+      cosmiconfig: '>=9'
+      typescript: '>=5'
+
   cosmiconfig@8.3.6:
     resolution: {integrity: sha512-kcZ6+W5QzcJ3P1Mt+83OUv/oHFqZHIx8DuxG6eZ5RGMERoLqp4BuGjhHLYGK+Kf5XVkQvqBSmAy/nGWN3qDgEA==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      typescript: '>=4.9.5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  cosmiconfig@9.0.1:
+    resolution: {integrity: sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==}
     engines: {node: '>=14'}
     peerDependencies:
       typescript: '>=4.9.5'
@@ -2170,6 +2301,10 @@ packages:
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
+  dot-prop@5.3.0:
+    resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
+    engines: {node: '>=8'}
+
   dotenv-expand@11.0.7:
     resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
     engines: {node: '>=12'}
@@ -2229,6 +2364,10 @@ packages:
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
+
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
 
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
@@ -2526,6 +2665,11 @@ packages:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
 
+  git-raw-commits@5.0.1:
+    resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -2546,6 +2690,10 @@ packages:
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  global-directory@4.0.1:
+    resolution: {integrity: sha512-wHTUcDUoZ1H5/0iVqEudYW4/kAlN5cZ3j/bXn0Dpbizl9iaUVeWSHqiOjsgk6OW2bkLclbBjzewBz6weQ1zA2Q==}
+    engines: {node: '>=18'}
 
   globalthis@1.0.4:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
@@ -2649,6 +2797,9 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
@@ -2659,6 +2810,10 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ini@4.1.1:
+    resolution: {integrity: sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g==}
+    engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
   inquirer@8.2.6:
     resolution: {integrity: sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==}
@@ -2796,6 +2951,14 @@ packages:
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
+
+  is-obj@2.0.0:
+    resolution: {integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==}
+    engines: {node: '>=8'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
@@ -3038,6 +3201,10 @@ packages:
       node-notifier:
         optional: true
 
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
 
@@ -3147,6 +3314,9 @@ packages:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
 
+  lodash.camelcase@4.3.0:
+    resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
+
   lodash.defaults@4.2.0:
     resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
 
@@ -3171,11 +3341,26 @@ packages:
   lodash.isstring@4.0.1:
     resolution: {integrity: sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==}
 
+  lodash.kebabcase@4.1.1:
+    resolution: {integrity: sha512-N8XRTIMMqqDgSy4VLKPnJ/+hpGZN+PHQiJnSenYqPaVV/NCqEogTnAdZLQiGKhxX+JCs8waWq2t1XHWKOmlY8g==}
+
   lodash.memoize@4.1.2:
     resolution: {integrity: sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==}
 
+  lodash.mergewith@4.6.2:
+    resolution: {integrity: sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==}
+
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
+
+  lodash.snakecase@4.1.1:
+    resolution: {integrity: sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==}
+
+  lodash.startcase@4.4.0:
+    resolution: {integrity: sha512-+WKqsK294HMSc2jEbNgpHpd0JfIBhp7rEV4aqXWqFr6AlXov+SlcgB1Fv01y2kGe3Gc8nMW7VA0SrGuSkRfIEg==}
+
+  lodash.upperfirst@4.3.1:
+    resolution: {integrity: sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==}
 
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
@@ -3223,6 +3408,10 @@ packages:
   memfs@3.5.3:
     resolution: {integrity: sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==}
     engines: {node: '>= 4.0.0'}
+
+  meow@13.2.0:
+    resolution: {integrity: sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==}
+    engines: {node: '>=18'}
 
   merge-descriptors@1.0.3:
     resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
@@ -4186,6 +4375,10 @@ packages:
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
+  tinyexec@1.0.4:
+    resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
+    engines: {node: '>=18'}
+
   tmp@0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
     engines: {node: '>=0.6.0'}
@@ -4960,6 +5153,128 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
+  '@commitlint/cli@20.5.0(@types/node@25.2.3)(conventional-commits-parser@6.3.0)(typescript@5.9.3)':
+    dependencies:
+      '@commitlint/format': 20.5.0
+      '@commitlint/lint': 20.5.0
+      '@commitlint/load': 20.5.0(@types/node@25.2.3)(typescript@5.9.3)
+      '@commitlint/read': 20.5.0(conventional-commits-parser@6.3.0)
+      '@commitlint/types': 20.5.0
+      tinyexec: 1.0.4
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - conventional-commits-filter
+      - conventional-commits-parser
+      - typescript
+
+  '@commitlint/config-conventional@20.5.0':
+    dependencies:
+      '@commitlint/types': 20.5.0
+      conventional-changelog-conventionalcommits: 9.3.0
+
+  '@commitlint/config-validator@20.5.0':
+    dependencies:
+      '@commitlint/types': 20.5.0
+      ajv: 8.18.0
+
+  '@commitlint/ensure@20.5.0':
+    dependencies:
+      '@commitlint/types': 20.5.0
+      lodash.camelcase: 4.3.0
+      lodash.kebabcase: 4.1.1
+      lodash.snakecase: 4.1.1
+      lodash.startcase: 4.4.0
+      lodash.upperfirst: 4.3.1
+
+  '@commitlint/execute-rule@20.0.0': {}
+
+  '@commitlint/format@20.5.0':
+    dependencies:
+      '@commitlint/types': 20.5.0
+      picocolors: 1.1.1
+
+  '@commitlint/is-ignored@20.5.0':
+    dependencies:
+      '@commitlint/types': 20.5.0
+      semver: 7.7.4
+
+  '@commitlint/lint@20.5.0':
+    dependencies:
+      '@commitlint/is-ignored': 20.5.0
+      '@commitlint/parse': 20.5.0
+      '@commitlint/rules': 20.5.0
+      '@commitlint/types': 20.5.0
+
+  '@commitlint/load@20.5.0(@types/node@25.2.3)(typescript@5.9.3)':
+    dependencies:
+      '@commitlint/config-validator': 20.5.0
+      '@commitlint/execute-rule': 20.0.0
+      '@commitlint/resolve-extends': 20.5.0
+      '@commitlint/types': 20.5.0
+      cosmiconfig: 9.0.1(typescript@5.9.3)
+      cosmiconfig-typescript-loader: 6.2.0(@types/node@25.2.3)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3)
+      is-plain-obj: 4.1.0
+      lodash.mergewith: 4.6.2
+      picocolors: 1.1.1
+    transitivePeerDependencies:
+      - '@types/node'
+      - typescript
+
+  '@commitlint/message@20.4.3': {}
+
+  '@commitlint/parse@20.5.0':
+    dependencies:
+      '@commitlint/types': 20.5.0
+      conventional-changelog-angular: 8.3.0
+      conventional-commits-parser: 6.3.0
+
+  '@commitlint/read@20.5.0(conventional-commits-parser@6.3.0)':
+    dependencies:
+      '@commitlint/top-level': 20.4.3
+      '@commitlint/types': 20.5.0
+      git-raw-commits: 5.0.1(conventional-commits-parser@6.3.0)
+      minimist: 1.2.8
+      tinyexec: 1.0.4
+    transitivePeerDependencies:
+      - conventional-commits-filter
+      - conventional-commits-parser
+
+  '@commitlint/resolve-extends@20.5.0':
+    dependencies:
+      '@commitlint/config-validator': 20.5.0
+      '@commitlint/types': 20.5.0
+      global-directory: 4.0.1
+      import-meta-resolve: 4.2.0
+      lodash.mergewith: 4.6.2
+      resolve-from: 5.0.0
+
+  '@commitlint/rules@20.5.0':
+    dependencies:
+      '@commitlint/ensure': 20.5.0
+      '@commitlint/message': 20.4.3
+      '@commitlint/to-lines': 20.0.0
+      '@commitlint/types': 20.5.0
+
+  '@commitlint/to-lines@20.0.0': {}
+
+  '@commitlint/top-level@20.4.3':
+    dependencies:
+      escalade: 3.2.0
+
+  '@commitlint/types@20.5.0':
+    dependencies:
+      conventional-commits-parser: 6.3.0
+      picocolors: 1.1.1
+
+  '@conventional-changelog/git-client@2.6.0(conventional-commits-parser@6.3.0)':
+    dependencies:
+      '@simple-libs/child-process-utils': 1.0.2
+      '@simple-libs/stream-utils': 1.2.0
+      semver: 7.7.4
+    optionalDependencies:
+      conventional-commits-parser: 6.3.0
+
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
@@ -5620,6 +5935,12 @@ snapshots:
 
   '@scarf/scarf@1.4.0': {}
 
+  '@simple-libs/child-process-utils@1.0.2':
+    dependencies:
+      '@simple-libs/stream-utils': 1.2.0
+
+  '@simple-libs/stream-utils@1.2.0': {}
+
   '@sinclair/typebox@0.27.10': {}
 
   '@sinclair/typebox@0.34.48': {}
@@ -6174,6 +6495,8 @@ snapshots:
 
   array-flatten@1.1.1: {}
 
+  array-ify@1.0.0: {}
+
   array-timsort@1.0.3: {}
 
   array.prototype.map@1.0.8:
@@ -6635,6 +6958,11 @@ snapshots:
       has-own-prop: 2.0.0
       repeat-string: 1.6.1
 
+  compare-func@2.0.0:
+    dependencies:
+      array-ify: 1.0.0
+      dot-prop: 5.3.0
+
   concat-map@0.0.1: {}
 
   concat-stream@2.0.0:
@@ -6652,6 +6980,19 @@ snapshots:
 
   content-type@1.0.5: {}
 
+  conventional-changelog-angular@8.3.0:
+    dependencies:
+      compare-func: 2.0.0
+
+  conventional-changelog-conventionalcommits@9.3.0:
+    dependencies:
+      compare-func: 2.0.0
+
+  conventional-commits-parser@6.3.0:
+    dependencies:
+      '@simple-libs/stream-utils': 1.2.0
+      meow: 13.2.0
+
   convert-source-map@2.0.0: {}
 
   cookie-signature@1.0.7: {}
@@ -6665,6 +7006,13 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
+  cosmiconfig-typescript-loader@6.2.0(@types/node@25.2.3)(cosmiconfig@9.0.1(typescript@5.9.3))(typescript@5.9.3):
+    dependencies:
+      '@types/node': 25.2.3
+      cosmiconfig: 9.0.1(typescript@5.9.3)
+      jiti: 2.6.1
+      typescript: 5.9.3
+
   cosmiconfig@8.3.6(typescript@5.7.2):
     dependencies:
       import-fresh: 3.3.1
@@ -6673,6 +7021,15 @@ snapshots:
       path-type: 4.0.0
     optionalDependencies:
       typescript: 5.7.2
+
+  cosmiconfig@9.0.1(typescript@5.9.3):
+    dependencies:
+      env-paths: 2.2.1
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      parse-json: 5.2.0
+    optionalDependencies:
+      typescript: 5.9.3
 
   create-jest@29.7.0(@types/node@22.19.11)(ts-node@10.9.2(@types/node@22.19.11)(typescript@5.9.3)):
     dependencies:
@@ -6823,6 +7180,10 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 5.0.3
 
+  dot-prop@5.3.0:
+    dependencies:
+      is-obj: 2.0.0
+
   dotenv-expand@11.0.7:
     dependencies:
       dotenv: 16.4.7
@@ -6871,6 +7232,8 @@ snapshots:
       ansi-colors: 4.1.3
 
   entities@4.5.0: {}
+
+  env-paths@2.2.1: {}
 
   environment@1.1.0: {}
 
@@ -7267,6 +7630,14 @@ snapshots:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
 
+  git-raw-commits@5.0.1(conventional-commits-parser@6.3.0):
+    dependencies:
+      '@conventional-changelog/git-client': 2.6.0(conventional-commits-parser@6.3.0)
+      meow: 13.2.0
+    transitivePeerDependencies:
+      - conventional-commits-filter
+      - conventional-commits-parser
+
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -7299,6 +7670,10 @@ snapshots:
       minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
+
+  global-directory@4.0.1:
+    dependencies:
+      ini: 4.1.1
 
   globalthis@1.0.4:
     dependencies:
@@ -7399,6 +7774,8 @@ snapshots:
       pkg-dir: 4.2.0
       resolve-cwd: 3.0.0
 
+  import-meta-resolve@4.2.0: {}
+
   imurmurhash@0.1.4: {}
 
   inflight@1.0.6:
@@ -7407,6 +7784,8 @@ snapshots:
       wrappy: 1.0.2
 
   inherits@2.0.4: {}
+
+  ini@4.1.1: {}
 
   inquirer@8.2.6:
     dependencies:
@@ -7569,6 +7948,10 @@ snapshots:
       has-tostringtag: 1.0.2
 
   is-number@7.0.0: {}
+
+  is-obj@2.0.0: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-regex@1.2.1:
     dependencies:
@@ -8102,6 +8485,8 @@ snapshots:
       - supports-color
       - ts-node
 
+  jiti@2.6.1: {}
+
   jose@6.1.3: {}
 
   js-tokens@4.0.0: {}
@@ -8228,6 +8613,8 @@ snapshots:
     dependencies:
       p-locate: 4.1.0
 
+  lodash.camelcase@4.3.0: {}
+
   lodash.defaults@4.2.0: {}
 
   lodash.includes@4.3.0: {}
@@ -8244,9 +8631,19 @@ snapshots:
 
   lodash.isstring@4.0.1: {}
 
+  lodash.kebabcase@4.1.1: {}
+
   lodash.memoize@4.1.2: {}
 
+  lodash.mergewith@4.6.2: {}
+
   lodash.once@4.1.1: {}
+
+  lodash.snakecase@4.1.1: {}
+
+  lodash.startcase@4.4.0: {}
+
+  lodash.upperfirst@4.3.1: {}
 
   lodash@4.17.23: {}
 
@@ -8292,6 +8689,8 @@ snapshots:
   memfs@3.5.3:
     dependencies:
       fs-monkey: 1.1.0
+
+  meow@13.2.0: {}
 
   merge-descriptors@1.0.3: {}
 
@@ -9351,6 +9750,8 @@ snapshots:
       readable-stream: 3.6.2
 
   through@2.3.8: {}
+
+  tinyexec@1.0.4: {}
 
   tmp@0.0.33:
     dependencies:


### PR DESCRIPTION
## Summary

- **Commitlint + Conventional Commits**: Added `@commitlint/cli` + `@commitlint/config-conventional` with a husky `commit-msg` hook for local enforcement and a `commitlint` CI job that validates all PR commits against the [Conventional Commits](https://www.conventionalcommits.org/) spec.

- **Auto Chart Version Bump** (staging only): On push to `dev`, the `push-chart` job reads the last commit message and bumps the Helm chart version automatically — `feat:` → minor (0.X+1.0), everything else → patch (0.0.X+1). The bump commit uses `[skip ci]` to prevent infinite loops. Production reads whatever version is already in `Chart.yaml`.

- **Managed Service Config Overrides**: Added `DATABASE_URL` override to `configmap.yaml` (same `default`/override pattern as Redis, NATS, MinIO). Added `databaseUrl`, `redisUrl`, `natsUrl`, `minioEndpoint` placeholders and `postgres/redis/nats/minio.enabled` flags to `deploy.yaml`. Both deploy workflows pass these as env vars with safe defaults (`true` for enabled flags, empty string for URLs → Helm `default` falls back to in-cluster). **No new secrets needed for staging** — only production sets these when using RDS/ElastiCache/S3.

- **DEPLOYMENT.md Rewrite**: Removed stale TrueFoundry FQN table and old port numbers (3000/8080 → 8000). Added: GH_PAT setup guide, GitHub Environments configuration, secrets tables split by repo-level vs environment-level, managed services section explaining how overrides work, egress proxy note, conventional commits + auto-bump docs, and post-deploy verification commands.

## Files Changed

| File | What changed |
|------|-------------|
| `package.json` / `pnpm-lock.yaml` | Added `@commitlint/cli`, `@commitlint/config-conventional` |
| `commitlint.config.js` | New — commitlint configuration |
| `.husky/commit-msg` | New — local commit message validation hook |
| `.github/workflows/ci.yaml` | Added `commitlint` job (validates PR commits) |
| `.github/workflows/deploy-staging.yaml` | Auto-bump chart version in `push-chart` job; added managed service env vars |
| `.github/workflows/deploy-production.yaml` | Added managed service env vars with defaults |
| `charts/browser-hitl/templates/configmap.yaml` | `DATABASE_URL` now uses `default $constructed .Values.config.databaseUrl` pattern |
| `infra/tfy/deploy.yaml` | Added config overrides (`databaseUrl`, `redisUrl`, etc.) and `enabled` flags via envsubst |
| `.github/workflows/DEPLOYMENT.md` | Full rewrite — current architecture, secrets guide, managed services, conventional commits |

## Test plan

- [x] `helm lint charts/browser-hitl/` passes
- [x] `helm template` with no overrides → `DATABASE_URL` falls back to constructed in-cluster URL
- [x] `helm template --set config.databaseUrl=postgresql://rds:5432/db` → uses override
- [x] `envsubst` with empty managed service vars → produces empty strings (Helm `default` kicks in)
- [x] `envsubst` with `POSTGRES_ENABLED=false` + `DATABASE_URL=...` → correct production behavior
- [x] `echo "bad" | npx commitlint` fails; `echo "fix: good" | npx commitlint` passes
- [x] `pnpm run build && pnpm run test` — 460/460 tests pass, 24 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)