### PR TITLE
feat: generic IdP trust config + OAuth browser login

### DIFF
--- a/apps/admin-ui/server.js
+++ b/apps/admin-ui/server.js
@@ -191,12 +191,16 @@ const html = `<!doctype html>
       <div class="grid">
         <section class="card">
           <h2>Login</h2>
-          <label for="email">Email</label>
-          <input id="email" value="admin@browser-hitl.local" />
-          <label for="password">Password</label>
-          <input id="password" type="password" value="" />
-          <button id="loginBtn">Login</button>
-          <button id="loadBtn" class="secondary">Load Sessions</button>
+          <div id="oauthProviders" style="margin-bottom: 12px;"></div>
+          <details id="pwdLoginDetails">
+            <summary style="cursor:pointer; color: var(--btn-secondary); margin-bottom: 8px;">Sign in with email/password</summary>
+            <label for="email">Email</label>
+            <input id="email" value="admin@browser-hitl.local" />
+            <label for="password">Password</label>
+            <input id="password" type="password" value="" />
+            <button id="loginBtn">Login</button>
+          </details>
+          <button id="loadBtn" class="secondary" style="margin-top: 8px;">Load Sessions</button>
           <div id="status" class="status"></div>
           <p class="mono">Token: <span id="tokenState">not set</span></p>
         </section>
@@ -262,6 +266,47 @@ const html = `<!doctype html>
         const statusEl = document.getElementById('status');
         const tokenStateEl = document.getElementById('tokenState');
         const logEl = document.getElementById('log');
+
+        // ── OAuth token from redirect callback ─────────────────────
+        (function extractOAuthToken() {
+          const params = new URLSearchParams(window.location.search);
+          const t = params.get('_token');
+          if (t) {
+            token = t;
+            tokenStateEl.textContent = token.slice(0, 20) + '…';
+            // Remove _token from URL without reload
+            params.delete('_token');
+            const newSearch = params.toString();
+            history.replaceState({}, '', newSearch ? '?' + newSearch : window.location.pathname);
+            appendLog('Signed in via OAuth ✓');
+          }
+        })();
+
+        // ── Load OAuth providers ────────────────────────────────────
+        (async function loadOAuthProviders() {
+          try {
+            const resp = await fetch(apiBase + '/auth/oauth/providers');
+            if (!resp.ok) return;
+            const providers = await resp.json();
+            const container = document.getElementById('oauthProviders');
+            providers.forEach(function(p) {
+              const btn = document.createElement('button');
+              btn.textContent = 'Sign in with ' + p.name;
+              btn.style.marginBottom = '6px';
+              btn.style.width = '100%';
+              btn.addEventListener('click', function() {
+                const callbackUrl = window.location.origin + window.location.pathname;
+                window.location.href = apiBase + '/auth/oauth/' + p.id + '/login?redirect_uri=' + encodeURIComponent(callbackUrl);
+              });
+              container.appendChild(btn);
+            });
+            if (providers.length > 0) {
+              document.getElementById('pwdLoginDetails').open = false;
+            }
+          } catch (e) {
+            // No OAuth providers configured — email/password only
+          }
+        })();
         const rowsEl = document.getElementById('sessionRows');
         const emailEl = document.getElementById('email');
         const passwordEl = document.getElementById('password');

--- a/apps/api/src/data-source.ts
+++ b/apps/api/src/data-source.ts
@@ -17,6 +17,7 @@ import { AddAppTemplates1708300000012 } from './migrations/1708300000012-AddAppT
 import { AddIdleShutdown1708300000013 } from './migrations/1708300000013-AddIdleShutdown';
 import { AddAppOwnerUserId1708300000014 } from './migrations/1708300000014-AddAppOwnerUserId';
 import { MultiTenantCloud1708300000015 } from './migrations/1708300000015-MultiTenantCloud';
+import { GenericOAuth1708300000016 } from './migrations/1708300000016-GenericOAuth';
 
 export const dataSourceOptions: DataSourceOptions = {
   type: 'postgres',
@@ -24,7 +25,7 @@ export const dataSourceOptions: DataSourceOptions = {
     testDefault: 'postgresql://postgres:postgres@localhost:5432/browser_hitl',
   }),
   entities: Object.values(entities),
-  migrations: [InitialSchema1708300000000, WorkerRLS1708300000001, AgentClients1708300000002, AuthRequests1708300000003, LoginQueue1708300000004, AccountLockout1708300000005, ArtifactCascadeDelete1708300000006, ServiceProfiles1708300000007, ProfileAppLink1708300000008, GenericHumanInput1708300000009, AddIdentityProviders1708300000010, AddOwnerUserIds1708300000011, AddAppTemplates1708300000012, AddIdleShutdown1708300000013, AddAppOwnerUserId1708300000014, MultiTenantCloud1708300000015],
+  migrations: [InitialSchema1708300000000, WorkerRLS1708300000001, AgentClients1708300000002, AuthRequests1708300000003, LoginQueue1708300000004, AccountLockout1708300000005, ArtifactCascadeDelete1708300000006, ServiceProfiles1708300000007, ProfileAppLink1708300000008, GenericHumanInput1708300000009, AddIdentityProviders1708300000010, AddOwnerUserIds1708300000011, AddAppTemplates1708300000012, AddIdleShutdown1708300000013, AddAppOwnerUserId1708300000014, MultiTenantCloud1708300000015, GenericOAuth1708300000016],
   migrationsRun: true, // Run migrations on startup per spec section 15.13
   synchronize: false,   // Never auto-sync; use migrations only
   logging: process.env.NODE_ENV === 'development' ? ['error', 'warn', 'migration'] : ['error'],

--- a/apps/api/src/entities/identity-provider.entity.ts
+++ b/apps/api/src/entities/identity-provider.entity.ts
@@ -35,6 +35,30 @@ export class IdentityProviderEntity {
   @Column({ type: 'varchar', nullable: true })
   client_id: string | null;
 
+  /** Encrypted OAuth client secret (browser path only). Use IdentityProvidersService to set/read. */
+  @Column({ type: 'varchar', nullable: true })
+  client_secret: string | null;
+
+  @Column({ type: 'varchar', nullable: true })
+  auth_url: string | null;
+
+  @Column({ type: 'varchar', nullable: true })
+  token_url: string | null;
+
+  @Column({ type: 'varchar', nullable: true })
+  userinfo_url: string | null;
+
+  @Column({ type: 'varchar', nullable: true })
+  sign_out_url: string | null;
+
+  /** Comma-separated OAuth scopes, e.g. "openid,email,profile" */
+  @Column({ type: 'varchar', nullable: true })
+  scopes: string | null;
+
+  /** Email domains that get Admin role on auto-provision, e.g. ["adopt.ai"] */
+  @Column({ type: 'jsonb', nullable: true })
+  admin_domains: string[] | null;
+
   // Claim mapping
   @Column({ type: 'varchar', nullable: true })
   tenant_id_claim: string | null;
@@ -44,6 +68,9 @@ export class IdentityProviderEntity {
 
   @Column({ type: 'varchar', default: 'email' })
   email_claim: string;
+
+  @Column({ type: 'varchar', default: 'name' })
+  name_claim: string;
 
   @Column({ type: 'jsonb', nullable: true })
   claim_mappings: Record<string, string> | null;

--- a/apps/api/src/migrations/1708300000016-GenericOAuth.ts
+++ b/apps/api/src/migrations/1708300000016-GenericOAuth.ts
@@ -1,0 +1,33 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class GenericOAuth1708300000016 implements MigrationInterface {
+  name = 'GenericOAuth1708300000016';
+
+  async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "identity_providers"
+        ADD COLUMN IF NOT EXISTS "client_secret"  VARCHAR    NULL,
+        ADD COLUMN IF NOT EXISTS "auth_url"        VARCHAR    NULL,
+        ADD COLUMN IF NOT EXISTS "token_url"       VARCHAR    NULL,
+        ADD COLUMN IF NOT EXISTS "userinfo_url"    VARCHAR    NULL,
+        ADD COLUMN IF NOT EXISTS "sign_out_url"    VARCHAR    NULL,
+        ADD COLUMN IF NOT EXISTS "scopes"          VARCHAR    NULL,
+        ADD COLUMN IF NOT EXISTS "admin_domains"   JSONB      NULL,
+        ADD COLUMN IF NOT EXISTS "name_claim"      VARCHAR    NOT NULL DEFAULT 'name'
+    `);
+  }
+
+  async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "identity_providers"
+        DROP COLUMN IF EXISTS "client_secret",
+        DROP COLUMN IF EXISTS "auth_url",
+        DROP COLUMN IF EXISTS "token_url",
+        DROP COLUMN IF EXISTS "userinfo_url",
+        DROP COLUMN IF EXISTS "sign_out_url",
+        DROP COLUMN IF EXISTS "scopes",
+        DROP COLUMN IF EXISTS "admin_domains",
+        DROP COLUMN IF EXISTS "name_claim"
+    `);
+  }
+}

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -1,12 +1,16 @@
 import {
   Controller, Post, Get, Delete, Body, Param, HttpCode,
-  UseGuards, Req, ParseUUIDPipe, UnauthorizedException,
+  UseGuards, Req, Res, ParseUUIDPipe, UnauthorizedException, Query, BadRequestException,
 } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth, ApiProperty, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { AuthGuard } from '@nestjs/passport';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import * as crypto from 'crypto';
 import { AuthService } from './auth.service';
 import { TokenBlacklistService } from './token-blacklist.service';
 import { TokenExchangeService } from './token-exchange.service';
+import { OAuthProviderService } from './oauth-provider.service';
 import {
   IsEmail, IsString, MinLength, IsUUID, IsOptional,
   IsArray, ArrayMinSize, IsInt, Min, Max, Matches,
@@ -15,6 +19,10 @@ import { DEFAULTS } from '@browser-hitl/shared';
 import { AuditService } from '../audit/audit.service';
 import { Throttle } from '@nestjs/throttler';
 import { Roles, RolesGuard, JwtAuthGuard } from '../../common/guards/roles.guard';
+import { IdentityProviderEntity } from '../../entities/identity-provider.entity';
+import { TenantEntity } from '../../entities/tenant.entity';
+import { JwtService } from '@nestjs/jwt';
+import { JwtPayload } from './auth.service';
 
 // =====================================================================
 // DTOs
@@ -134,6 +142,10 @@ class TokenExchangeDto {
 // Controller
 // =====================================================================
 
+// In-memory PKCE state store (state → { codeVerifier, idpId, redirectUri, expiresAt })
+// A Redis-backed store would be better for multi-instance but this is sufficient for now.
+const oauthStateStore = new Map<string, { codeVerifier: string; idpId: string; redirectUri: string; expiresAt: number }>();
+
 @ApiTags('Authentication')
 @ApiBearerAuth()
 @Controller()
@@ -143,6 +155,12 @@ export class AuthController {
     private readonly auditService: AuditService,
     private readonly tokenBlacklist: TokenBlacklistService,
     private readonly tokenExchangeService: TokenExchangeService,
+    private readonly oauthProvider: OAuthProviderService,
+    private readonly jwtService: JwtService,
+    @InjectRepository(IdentityProviderEntity)
+    private readonly idpRepo: Repository<IdentityProviderEntity>,
+    @InjectRepository(TenantEntity)
+    private readonly tenantRepo: Repository<TenantEntity>,
   ) {}
 
   // =================================================================
@@ -387,5 +405,132 @@ export class AuthController {
       requested_ttl_seconds: dto.requested_ttl_seconds,
       agent_payload: agentPayload,
     }, tenantId);
+  }
+
+  // =================================================================
+  // Generic OAuth — browser login for admin-UI
+  // =================================================================
+
+  @ApiOperation({ summary: 'List OAuth-configured IdPs', description: 'Returns IdPs that have auth_url configured — these can be used for browser-based login.' })
+  @Get('auth/oauth/providers')
+  @ApiResponse({ status: 200, description: 'List of OAuth providers available for login' })
+  async listOAuthProviders() {
+    // Only return IdPs that have browser OAuth configured (have auth_url)
+    const idps = await this.idpRepo.find({ where: { enabled: true } });
+    return idps
+      .filter(idp => idp.auth_url && idp.client_id)
+      .map(idp => ({
+        id: idp.id,
+        name: idp.name,
+        // Never expose client_secret
+      }));
+  }
+
+  @ApiOperation({ summary: 'Start OAuth login flow', description: 'Redirects the browser to the IdP authorization endpoint. Used by the admin-UI login page.' })
+  @Get('auth/oauth/:idpId/login')
+  @ApiResponse({ status: 302, description: 'Redirects to IdP' })
+  async oauthLogin(
+    @Param('idpId', ParseUUIDPipe) idpId: string,
+    @Query('redirect_uri') redirectUri: string,
+    @Res() res: any,
+  ) {
+    if (!redirectUri) throw new BadRequestException('redirect_uri is required');
+
+    const idp = await this.idpRepo.findOne({ where: { id: idpId, enabled: true } });
+    if (!idp || !idp.auth_url) throw new BadRequestException('IdP not found or not OAuth-configured');
+
+    const state = crypto.randomUUID();
+    const codeVerifier = this.oauthProvider.generateCodeVerifier();
+    const codeChallenge = this.oauthProvider.computeCodeChallenge(codeVerifier);
+
+    // Store state (5-min TTL)
+    oauthStateStore.set(state, { codeVerifier, idpId, redirectUri, expiresAt: Date.now() + 5 * 60_000 });
+    // Prune expired entries opportunistically
+    for (const [k, v] of oauthStateStore) {
+      if (v.expiresAt < Date.now()) oauthStateStore.delete(k);
+    }
+
+    const authUrl = this.oauthProvider.buildAuthorizationUrl(idp, redirectUri, state, codeChallenge);
+    return res.redirect(authUrl);
+  }
+
+  @ApiOperation({ summary: 'OAuth callback', description: 'Handles the IdP redirect after successful authentication. Exchanges code for tokens, issues Tabby JWT, and redirects to admin-UI.' })
+  @Get('auth/oauth/:idpId/callback')
+  @ApiResponse({ status: 302, description: 'Redirects to admin-UI with token' })
+  async oauthCallback(
+    @Param('idpId', ParseUUIDPipe) idpId: string,
+    @Query('code') code: string,
+    @Query('state') state: string,
+    @Query('error') error: string,
+    @Res() res: any,
+  ) {
+    if (error) throw new UnauthorizedException(`OAuth error: ${error}`);
+    if (!code || !state) throw new BadRequestException('Missing code or state');
+
+    const stored = oauthStateStore.get(state);
+    if (!stored || stored.idpId !== idpId || stored.expiresAt < Date.now()) {
+      throw new UnauthorizedException('Invalid or expired OAuth state');
+    }
+    oauthStateStore.delete(state);
+
+    const idp = await this.idpRepo.findOne({ where: { id: idpId, enabled: true } });
+    if (!idp) throw new UnauthorizedException('IdP not found');
+
+    // Exchange auth code for tokens
+    const tokens = await this.oauthProvider.exchangeCode(idp, code, stored.codeVerifier, stored.redirectUri);
+
+    // Fetch user info
+    const claims = await this.oauthProvider.fetchUserInfo(idp, tokens.access_token);
+    const { userId, email, name, tenantIdClaimValue } = this.oauthProvider.extractIdentity(idp, claims);
+
+    if (!userId) throw new UnauthorizedException('Could not extract user identity from userinfo');
+
+    // Resolve or auto-provision tenant
+    let resolvedTenantId: string = idp.tenant_id;
+    if (tenantIdClaimValue && idp.tenant_id_claim) {
+      const tenant = await this.tenantRepo.findOne({ where: { id: tenantIdClaimValue } });
+      if (!tenant) {
+        if (idp.allow_auto_provision) {
+          const created = this.tenantRepo.create({ id: tenantIdClaimValue, name: tenantIdClaimValue });
+          const saved = await this.tenantRepo.save(created);
+          resolvedTenantId = saved.id;
+        } else {
+          throw new UnauthorizedException(`Tenant not found: ${tenantIdClaimValue}`);
+        }
+      } else {
+        resolvedTenantId = tenant.id;
+      }
+    }
+
+    // Determine role
+    const role = this.oauthProvider.resolveRole(idp, email);
+
+    // Issue Tabby JWT
+    const jti = crypto.randomUUID();
+    const payload: JwtPayload = {
+      sub: `federated:${userId}`,
+      tenant_id: resolvedTenantId,
+      role,
+      jti,
+      kid: process.env.JWT_SIGNING_KEY_ID || 'v1',
+      token_type: 'federated',
+      owner_user_id: userId,
+      idp_id: idp.id,
+    };
+    const token = this.jwtService.sign(payload, { expiresIn: 24 * 3600 });
+
+    await this.auditService.log({
+      tenant_id: resolvedTenantId,
+      actor_type: 'human',
+      actor_id: `federated:${userId}`,
+      event_type: 'auth.oauth.login',
+      payload: { idp_id: idp.id, owner_user_id: userId, email, role },
+    });
+
+    // Redirect to admin-UI with token in query param
+    // The admin-UI JS reads _token, stores it, and removes it from URL via history.replaceState
+    const baseUrl = stored.redirectUri.split('?')[0].split('#')[0];
+    const adminUiBase = new URL(baseUrl).origin;
+    return res.redirect(`${adminUiBase}/?_token=${encodeURIComponent(token)}`);
   }
 }

--- a/apps/api/src/modules/auth/auth.module.ts
+++ b/apps/api/src/modules/auth/auth.module.ts
@@ -9,6 +9,7 @@ import { JwtStrategy } from './jwt.strategy';
 import { TokenBlacklistService } from './token-blacklist.service';
 import { ExternalJwksService } from './external-jwks.service';
 import { TokenExchangeService } from './token-exchange.service';
+import { OAuthProviderService } from './oauth-provider.service';
 import { AuditModule } from '../audit/audit.module';
 import { resolveJwtSigningKey } from './jwt-config';
 
@@ -23,7 +24,7 @@ import { resolveJwtSigningKey } from './jwt-config';
     AuditModule,
   ],
   controllers: [AuthController],
-  providers: [AuthService, JwtStrategy, TokenBlacklistService, ExternalJwksService, TokenExchangeService],
-  exports: [AuthService, JwtModule, TokenBlacklistService, ExternalJwksService, TokenExchangeService],
+  providers: [AuthService, JwtStrategy, TokenBlacklistService, ExternalJwksService, TokenExchangeService, OAuthProviderService],
+  exports: [AuthService, JwtModule, TokenBlacklistService, ExternalJwksService, TokenExchangeService, OAuthProviderService],
 })
 export class AuthModule {}

--- a/apps/api/src/modules/auth/bootstrap.service.ts
+++ b/apps/api/src/modules/auth/bootstrap.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, OnModuleInit, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { randomUUID } from 'crypto';
 import { Repository } from 'typeorm';
 import { TenantEntity, UserEntity } from '../../entities';
 import { AuthService } from './auth.service';
@@ -42,7 +43,7 @@ export class BootstrapService implements OnModuleInit {
 
     this.logger.log(`Bootstrapping tenant: ${tenantName}, admin: ${adminEmail}`);
 
-    const tenant = this.tenantRepo.create({ name: tenantName });
+    const tenant = this.tenantRepo.create({ id: randomUUID(), name: tenantName });
     const savedTenant = await this.tenantRepo.save(tenant);
 
     const passwordHash = await this.authService.hashPassword(adminPassword);

--- a/apps/api/src/modules/auth/jwt.strategy.ts
+++ b/apps/api/src/modules/auth/jwt.strategy.ts
@@ -1,29 +1,128 @@
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import * as jwt from 'jsonwebtoken';
 import { JwtPayload } from './auth.service';
 import { resolveJwtSigningKey } from './jwt-config';
 import { TokenBlacklistService } from './token-blacklist.service';
+import { ExternalJwksService } from './external-jwks.service';
+import { IdentityProviderEntity } from '../../entities/identity-provider.entity';
+import { TenantEntity } from '../../entities/tenant.entity';
+import { OAuthProviderService } from './oauth-provider.service';
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
   constructor(
     private readonly tokenBlacklist: TokenBlacklistService,
+    private readonly jwksService: ExternalJwksService,
+    private readonly oauthProvider: OAuthProviderService,
+    @InjectRepository(IdentityProviderEntity)
+    private readonly idpRepo: Repository<IdentityProviderEntity>,
+    @InjectRepository(TenantEntity)
+    private readonly tenantRepo: Repository<TenantEntity>,
   ) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
-      secretOrKey: resolveJwtSigningKey(),
-    });
+      passReqToCallback: true,
+      secretOrKeyProvider: async (request: any, rawJwtToken: string, done: Function) => {
+        try {
+          // Decode header + payload (unverified) to read iss
+          const parts = rawJwtToken.split('.');
+          if (parts.length !== 3) {
+            return done(null, resolveJwtSigningKey());
+          }
+
+          let header: { kid?: string };
+          let unverified: { iss?: string };
+          try {
+            header = JSON.parse(Buffer.from(parts[0], 'base64url').toString());
+            unverified = JSON.parse(Buffer.from(parts[1], 'base64url').toString());
+          } catch {
+            return done(null, resolveJwtSigningKey());
+          }
+
+          const iss = unverified?.iss;
+          if (iss) {
+            // Check if this is a JWT from a registered external IdP
+            const idp = await this.idpRepo.findOne({ where: { issuer_url: iss, enabled: true } });
+            if (idp) {
+              // Tag the request so validate() knows this is an external JWT
+              request._tabbyExternalIdp = idp;
+              try {
+                const kid = header?.kid;
+                const publicKey = kid
+                  ? await this.jwksService.getPublicKey(iss, kid)
+                  : await this.getFirstPublicKey(iss);
+                return done(null, publicKey);
+              } catch (err) {
+                return done(new UnauthorizedException('JWKS fetch failed for issuer: ' + iss));
+              }
+            }
+          }
+
+          // Fall back to Tabby-issued JWT (signed with JWT_SIGNING_KEY)
+          return done(null, resolveJwtSigningKey());
+        } catch (err) {
+          return done(null, resolveJwtSigningKey());
+        }
+      },
+      // Support both HS256 (Tabby-issued) and RS/ES (external IdP)
+      algorithms: ['HS256', 'HS384', 'HS512', 'RS256', 'RS384', 'RS512', 'ES256', 'ES384', 'ES512'],
+    } as any);
   }
 
-  async validate(payload: JwtPayload) {
-    // Check token revocation (C1 remediation)
+  async validate(req: any, payload: any): Promise<Record<string, unknown>> {
+    const idp: IdentityProviderEntity | undefined = req?._tabbyExternalIdp;
+
+    if (idp) {
+      // ── External IdP JWT ───────────────────────────────────────────────
+      const ownerUserId = String(payload[idp.user_id_claim] || payload.sub || '');
+      if (!ownerUserId) throw new UnauthorizedException('JWT missing user identifier claim');
+
+      const email = String(payload[idp.email_claim] || payload.email || '');
+      const role = this.oauthProvider.resolveRole(idp, email);
+
+      // Resolve tenant from claim
+      let resolvedTenantId: string;
+      if (idp.tenant_id_claim) {
+        const claimValue = String(payload[idp.tenant_id_claim] || '');
+        if (!claimValue) throw new UnauthorizedException(`JWT missing tenant claim: ${idp.tenant_id_claim}`);
+        const tenant = await this.tenantRepo.findOne({ where: { id: claimValue } });
+        if (!tenant) {
+          if (idp.allow_auto_provision) {
+            // Auto-provision tenant using claim value as ID
+            const created = this.tenantRepo.create({ id: claimValue, name: claimValue });
+            const saved = await this.tenantRepo.save(created);
+            resolvedTenantId = saved.id;
+          } else {
+            throw new UnauthorizedException(`Tenant not found: ${claimValue}`);
+          }
+        } else {
+          resolvedTenantId = tenant.id;
+        }
+      } else {
+        resolvedTenantId = idp.tenant_id;
+      }
+
+      return {
+        user_id: `federated:${ownerUserId}`,
+        tenant_id: resolvedTenantId,
+        role,
+        token_type: 'federated',
+        owner_user_id: ownerUserId,
+        idp_id: idp.id,
+        allowed_profiles: [],
+        jti: null,
+      };
+    }
+
+    // ── Tabby-issued JWT ────────────────────────────────────────────────
     if (payload.jti) {
       const revoked = await this.tokenBlacklist.isRevoked(payload.jti);
-      if (revoked) {
-        throw new UnauthorizedException('Token has been revoked');
-      }
+      if (revoked) throw new UnauthorizedException('Token has been revoked');
     }
 
     return {
@@ -37,5 +136,11 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       owner_user_id: payload.owner_user_id ?? null,
       idp_id: payload.idp_id ?? null,
     };
+  }
+
+  private async getFirstPublicKey(issuerUrl: string): Promise<string> {
+    const keys = await this.jwksService['getJwks'](issuerUrl);
+    if (!keys.length) throw new Error(`No keys in JWKS for ${issuerUrl}`);
+    return this.jwksService['jwkToPem'](keys[0]);
   }
 }

--- a/apps/api/src/modules/auth/oauth-provider.service.ts
+++ b/apps/api/src/modules/auth/oauth-provider.service.ts
@@ -1,0 +1,212 @@
+import { Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import * as crypto from 'crypto';
+import { IdentityProviderEntity } from '../../entities/identity-provider.entity';
+
+/**
+ * Handles the browser-side Generic OAuth flow for the admin-UI login.
+ * Mirrors Grafana's "Generic OAuth" provider pattern:
+ *   auth_url → token_url → userinfo_url → Tabby session
+ *
+ * Also owns client_secret encryption/decryption so the secret is never stored
+ * in plaintext. Uses AES-256-GCM with the TENANT_ENCRYPTION_KEY.
+ *
+ * API path (backend-to-backend) does NOT use this service — it uses
+ * ExternalJwksService + JwtStrategy directly.
+ */
+@Injectable()
+export class OAuthProviderService {
+  private readonly logger = new Logger(OAuthProviderService.name);
+
+  // ─── Secret encryption ────────────────────────────────────────────────────
+
+  /** Encrypt a plaintext client_secret for storage. Returns base64url ciphertext. */
+  encryptSecret(plaintext: string): string {
+    const key = this.getEncryptionKey();
+    const iv = crypto.randomBytes(12);
+    const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+    const encrypted = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+    const tag = cipher.getAuthTag();
+    // Layout: iv(12) + tag(16) + ciphertext
+    return Buffer.concat([iv, tag, encrypted]).toString('base64url');
+  }
+
+  /** Decrypt a stored client_secret. Returns plaintext. */
+  decryptSecret(ciphertext: string): string {
+    const key = this.getEncryptionKey();
+    const buf = Buffer.from(ciphertext, 'base64url');
+    const iv = buf.subarray(0, 12);
+    const tag = buf.subarray(12, 28);
+    const encrypted = buf.subarray(28);
+    const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+    decipher.setAuthTag(tag);
+    return decipher.update(encrypted) + decipher.final('utf8');
+  }
+
+  // ─── PKCE helpers ─────────────────────────────────────────────────────────
+
+  /** Generate a PKCE code_verifier (43-128 chars, URL-safe). */
+  generateCodeVerifier(): string {
+    return crypto.randomBytes(32).toString('base64url');
+  }
+
+  /** Derive the code_challenge (S256) from a verifier. */
+  computeCodeChallenge(verifier: string): string {
+    return crypto.createHash('sha256').update(verifier).digest('base64url');
+  }
+
+  // ─── OAuth browser flow ───────────────────────────────────────────────────
+
+  /**
+   * Build the authorization URL to redirect the user to.
+   * Returns the URL string.
+   */
+  buildAuthorizationUrl(
+    idp: IdentityProviderEntity,
+    redirectUri: string,
+    state: string,
+    codeChallenge: string,
+  ): string {
+    if (!idp.auth_url) {
+      throw new UnauthorizedException('IdP does not have auth_url configured');
+    }
+
+    const scopes = idp.scopes || 'openid email profile';
+    const params = new URLSearchParams({
+      response_type: 'code',
+      client_id: idp.client_id || '',
+      redirect_uri: redirectUri,
+      scope: scopes.replace(/,/g, ' '),
+      state,
+      code_challenge: codeChallenge,
+      code_challenge_method: 'S256',
+    });
+
+    return `${idp.auth_url}?${params.toString()}`;
+  }
+
+  /**
+   * Exchange an authorization code for tokens.
+   * Returns { access_token, id_token? }.
+   */
+  async exchangeCode(
+    idp: IdentityProviderEntity,
+    code: string,
+    codeVerifier: string,
+    redirectUri: string,
+  ): Promise<{ access_token: string; id_token?: string; expires_in?: number }> {
+    if (!idp.token_url || !idp.client_id || !idp.client_secret) {
+      throw new UnauthorizedException('IdP missing token_url, client_id, or client_secret');
+    }
+
+    const plainSecret = this.decryptSecret(idp.client_secret);
+
+    const body = new URLSearchParams({
+      grant_type: 'authorization_code',
+      code,
+      redirect_uri: redirectUri,
+      client_id: idp.client_id,
+      client_secret: plainSecret,
+      code_verifier: codeVerifier,
+    });
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 10_000);
+
+    try {
+      const resp = await fetch(idp.token_url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded', 'Accept': 'application/json' },
+        body: body.toString(),
+        signal: controller.signal,
+      });
+
+      if (!resp.ok) {
+        const text = await resp.text().catch(() => '');
+        throw new UnauthorizedException(`Token endpoint returned ${resp.status}: ${text}`);
+      }
+
+      const data = await resp.json() as Record<string, unknown>;
+      if (!data.access_token) {
+        throw new UnauthorizedException('Token endpoint did not return access_token');
+      }
+
+      return {
+        access_token: String(data.access_token),
+        id_token: data.id_token ? String(data.id_token) : undefined,
+        expires_in: data.expires_in ? Number(data.expires_in) : undefined,
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  /**
+   * Fetch user profile from the userinfo endpoint using an access token.
+   * Returns the raw claims object.
+   */
+  async fetchUserInfo(idp: IdentityProviderEntity, accessToken: string): Promise<Record<string, unknown>> {
+    if (!idp.userinfo_url) {
+      throw new UnauthorizedException('IdP does not have userinfo_url configured');
+    }
+
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 5_000);
+
+    try {
+      const resp = await fetch(idp.userinfo_url, {
+        headers: { Authorization: `Bearer ${accessToken}` },
+        signal: controller.signal,
+      });
+
+      if (!resp.ok) {
+        throw new UnauthorizedException(`Userinfo endpoint returned ${resp.status}`);
+      }
+
+      return await resp.json() as Record<string, unknown>;
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  /**
+   * Extract user identity fields from userinfo claims using the IdP's configured claim names.
+   */
+  extractIdentity(
+    idp: IdentityProviderEntity,
+    claims: Record<string, unknown>,
+  ): { userId: string; email: string; name: string; tenantIdClaimValue: string | null } {
+    const userId = String(claims[idp.user_id_claim] || claims['sub'] || '');
+    const email = String(claims[idp.email_claim] || claims['email'] || '');
+    const name = String(claims[idp.name_claim] || claims['name'] || email);
+    const tenantIdClaimValue = idp.tenant_id_claim
+      ? (claims[idp.tenant_id_claim] ? String(claims[idp.tenant_id_claim]) : null)
+      : null;
+
+    return { userId, email, name, tenantIdClaimValue };
+  }
+
+  /**
+   * Determine the Tabby role for a user based on their email domain.
+   * Emails in admin_domains get Admin; everyone else gets default_role.
+   */
+  resolveRole(idp: IdentityProviderEntity, email: string): string {
+    const domain = email.split('@')[1] || '';
+    if (domain && idp.admin_domains?.includes(domain)) {
+      return 'Admin';
+    }
+    return idp.default_role || 'Operator';
+  }
+
+  // ─── Private ──────────────────────────────────────────────────────────────
+
+  private getEncryptionKey(): Buffer {
+    const raw = process.env.TENANT_ENCRYPTION_KEY || '';
+    if (!raw) {
+      if (process.env.NODE_ENV === 'test') {
+        return Buffer.from('0'.repeat(64), 'hex');
+      }
+      throw new Error('TENANT_ENCRYPTION_KEY must be configured');
+    }
+    return Buffer.from(raw, 'hex');
+  }
+}

--- a/apps/api/src/modules/auth/token-exchange.service.ts
+++ b/apps/api/src/modules/auth/token-exchange.service.ts
@@ -144,18 +144,32 @@ export class TokenExchangeService {
       }
       const tenant = await this.tenantRepo.findOne({ where: { id: claimValue } });
       if (!tenant) {
-        throw new UnauthorizedException(`Tenant not found: ${claimValue}`);
+        if (idp.allow_auto_provision) {
+          // Auto-provision tenant using claim value as ID
+          const created = this.tenantRepo.create({ id: claimValue, name: claimValue });
+          const saved = await this.tenantRepo.save(created);
+          this.logger.log(`Auto-provisioned tenant: ${saved.id}`);
+          resolvedTenantId = saved.id;
+        } else {
+          throw new UnauthorizedException(`Tenant not found: ${claimValue}`);
+        }
+      } else {
+        resolvedTenantId = tenant.id;
       }
-      resolvedTenantId = tenant.id;
     }
 
     // 7. Issue Tabby JWT
     const ttl = params.requested_ttl_seconds || 3600;
     const jti = crypto.randomUUID();
+    const email = String(verifiedPayload[idp.email_claim] || verifiedPayload.email || '');
+    const emailDomain = email.split('@')[1] || '';
+    const role = (idp.admin_domains?.length && emailDomain && idp.admin_domains.includes(emailDomain))
+      ? 'Admin'
+      : (idp.default_role || 'Operator');
     const payload: JwtPayload = {
       sub: `federated:${ownerUserId}`,
       tenant_id: resolvedTenantId,
-      role: idp.default_role,
+      role,
       jti,
       kid: process.env.JWT_SIGNING_KEY_ID || 'v1',
       token_type: 'federated',

--- a/apps/api/src/modules/credentials/credentials.service.ts
+++ b/apps/api/src/modules/credentials/credentials.service.ts
@@ -248,10 +248,15 @@ export class CredentialsService {
             return provisioned;
           }
         } catch (err) {
-          // Race condition: another request already provisioned. Retry the lookup.
+          // Race condition: another request already provisioned. Retry the lookup
+          // with relaxed filters (any version_state, correct owner_user_id).
           if ((err as any)?.code === '23505' || (err as any)?.message?.includes('duplicate key')) {
             this.logger.warn(`Duplicate key during auto-provision for "${profileId}" user=${ownerUserId} — retrying lookup`);
-            const retryProfiles = await this.profileRepo.find({ where });
+            // Small delay to let the winning request commit its transaction
+            await new Promise(r => setTimeout(r, 200));
+            const retryProfiles = await this.profileRepo.find({
+              where: { tenant_id: tenantId, profile_id: profileId, owner_user_id: ownerUserId },
+            });
             if (retryProfiles.length > 0) {
               const active = retryProfiles.find(p => p.version_state === ProfileVersionState.ACTIVE);
               return active || retryProfiles[0];

--- a/apps/api/src/modules/credentials/credentials.service.ts
+++ b/apps/api/src/modules/credentials/credentials.service.ts
@@ -242,9 +242,22 @@ export class CredentialsService {
     if (profiles.length === 0) {
       // Auto-provision from template if federated user has no profile yet
       if (ownerUserId) {
-        const provisioned = await this.autoProvisionFromTemplate(tenantId, profileId, ownerUserId);
-        if (provisioned) {
-          return provisioned;
+        try {
+          const provisioned = await this.autoProvisionFromTemplate(tenantId, profileId, ownerUserId);
+          if (provisioned) {
+            return provisioned;
+          }
+        } catch (err) {
+          // Race condition: another request already provisioned. Retry the lookup.
+          if ((err as any)?.code === '23505' || (err as any)?.message?.includes('duplicate key')) {
+            this.logger.warn(`Duplicate key during auto-provision for "${profileId}" user=${ownerUserId} — retrying lookup`);
+            const retryProfiles = await this.profileRepo.find({ where });
+            if (retryProfiles.length > 0) {
+              const active = retryProfiles.find(p => p.version_state === ProfileVersionState.ACTIVE);
+              return active || retryProfiles[0];
+            }
+          }
+          throw err;
         }
       }
       throw new NotFoundException(`No active profile found for "${profileId}"`);

--- a/apps/api/src/modules/identity-providers/identity-providers.controller.ts
+++ b/apps/api/src/modules/identity-providers/identity-providers.controller.ts
@@ -3,7 +3,7 @@ import {
   UseGuards, HttpCode, ParseUUIDPipe,
 } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth, ApiProperty, ApiOperation, ApiResponse } from '@nestjs/swagger';
-import { IsString, MinLength, IsOptional, IsBoolean, IsIn } from 'class-validator';
+import { IsString, MinLength, IsOptional, IsBoolean, IsIn, IsArray } from 'class-validator';
 import { Roles, RolesGuard, JwtAuthGuard } from '../../common/guards/roles.guard';
 import { IdentityProvidersService } from './identity-providers.service';
 
@@ -24,15 +24,45 @@ class CreateIdpDto {
   @IsOptional() @IsString()
   jwks_uri?: string;
 
-  @ApiProperty({ required: false })
+  @ApiProperty({ required: false, description: 'Platform\'s client_id registered at the IdP. Used as the expected aud claim value.' })
   @IsOptional() @IsString()
   audience?: string;
 
-  @ApiProperty({ required: false })
+  // ── Browser OAuth fields (admin-UI Generic OAuth) ──────────────────
+  @ApiProperty({ required: false, description: 'OAuth client_id registered for Tabby at the IdP.' })
   @IsOptional() @IsString()
   client_id?: string;
 
-  @ApiProperty({ required: false, example: 'tenantId', description: 'JWT claim containing the tenant ID. When set, enables dynamic tenant routing from the JWT instead of using the IdP\'s fixed tenant.' })
+  @ApiProperty({ required: false, description: 'OAuth client_secret (plaintext). Stored encrypted. Send only when setting/rotating.' })
+  @IsOptional() @IsString()
+  client_secret?: string;
+
+  @ApiProperty({ required: false, example: 'https://auth.adopt.ai/oauth/authorize' })
+  @IsOptional() @IsString()
+  auth_url?: string;
+
+  @ApiProperty({ required: false, example: 'https://auth.adopt.ai/oauth/token' })
+  @IsOptional() @IsString()
+  token_url?: string;
+
+  @ApiProperty({ required: false, example: 'https://auth.adopt.ai/identity/resources/users/v2/me' })
+  @IsOptional() @IsString()
+  userinfo_url?: string;
+
+  @ApiProperty({ required: false, example: 'https://auth.adopt.ai/oauth/account/logout' })
+  @IsOptional() @IsString()
+  sign_out_url?: string;
+
+  @ApiProperty({ required: false, example: 'openid,email,profile', description: 'Comma-separated OAuth scopes.' })
+  @IsOptional() @IsString()
+  scopes?: string;
+
+  @ApiProperty({ required: false, example: ['adopt.ai'], description: 'Email domains that are granted Admin role on auto-provision.' })
+  @IsOptional() @IsArray() @IsString({ each: true })
+  admin_domains?: string[];
+
+  // ── Claim mappings ─────────────────────────────────────────────────
+  @ApiProperty({ required: false, example: 'tenantId', description: 'JWT claim containing the tenant ID. Enables dynamic multi-tenant routing.' })
   @IsOptional() @IsString()
   tenant_id_claim?: string;
 
@@ -44,10 +74,15 @@ class CreateIdpDto {
   @IsOptional() @IsString()
   email_claim?: string;
 
+  @ApiProperty({ required: false, example: 'name' })
+  @IsOptional() @IsString()
+  name_claim?: string;
+
   @ApiProperty({ required: false })
   @IsOptional()
   claim_mappings?: Record<string, string>;
 
+  // ── Behavior ───────────────────────────────────────────────────────
   @ApiProperty({ required: false })
   @IsOptional() @IsBoolean()
   enabled?: boolean;
@@ -56,7 +91,7 @@ class CreateIdpDto {
   @IsOptional() @IsBoolean()
   allow_auto_provision?: boolean;
 
-  @ApiProperty({ required: false })
+  @ApiProperty({ required: false, example: 'Operator' })
   @IsOptional() @IsString()
   default_role?: string;
 
@@ -75,9 +110,10 @@ export class IdentityProvidersController {
   @Post()
   @Roles('Admin')
   @HttpCode(201)
-  @ApiOperation({ summary: 'Register an identity provider', description: 'Register an OIDC or SAML identity provider for tenant-scoped federated authentication.' })
+  @ApiOperation({ summary: 'Register an identity provider', description: 'Register an OIDC or SAML identity provider. Supports both API-path (JWKS validation) and browser-path (Generic OAuth) fields.' })
   async create(@Body() dto: CreateIdpDto, @Req() req: any) {
-    return this.idpService.create(req.user.tenant_id, dto, req.user.user_id);
+    const { client_secret, ...rest } = dto;
+    return this.idpService.create(req.user.tenant_id, { ...rest, client_secret_plaintext: client_secret } as any, req.user.user_id);
   }
 
   @Get()
@@ -98,7 +134,8 @@ export class IdentityProvidersController {
   @Roles('Admin')
   @ApiOperation({ summary: 'Update identity provider' })
   async update(@Param('id', ParseUUIDPipe) id: string, @Body() dto: CreateIdpDto, @Req() req: any) {
-    return this.idpService.update(req.user.tenant_id, id, dto, req.user.user_id);
+    const { client_secret, ...rest } = dto;
+    return this.idpService.update(req.user.tenant_id, id, { ...rest, client_secret_plaintext: client_secret } as any, req.user.user_id);
   }
 
   @Delete(':id')

--- a/apps/api/src/modules/identity-providers/identity-providers.service.ts
+++ b/apps/api/src/modules/identity-providers/identity-providers.service.ts
@@ -4,6 +4,7 @@ import { Repository } from 'typeorm';
 import { IdentityProviderEntity } from '../../entities';
 import { AuditService } from '../audit/audit.service';
 import { ExternalJwksService } from '../auth/external-jwks.service';
+import { OAuthProviderService } from '../auth/oauth-provider.service';
 
 @Injectable()
 export class IdentityProvidersService {
@@ -12,9 +13,10 @@ export class IdentityProvidersService {
     private readonly idpRepo: Repository<IdentityProviderEntity>,
     private readonly auditService: AuditService,
     private readonly jwksService: ExternalJwksService,
+    private readonly oauthProvider: OAuthProviderService,
   ) {}
 
-  async create(tenantId: string, data: Partial<IdentityProviderEntity>, actorId: string) {
+  async create(tenantId: string, data: Partial<IdentityProviderEntity> & { client_secret_plaintext?: string }, actorId: string) {
     const existing = await this.idpRepo.findOne({
       where: { tenant_id: tenantId, name: data.name },
     });
@@ -22,7 +24,13 @@ export class IdentityProvidersService {
       throw new ConflictException(`IdP with name "${data.name}" already exists`);
     }
 
-    const idp = this.idpRepo.create({ ...data, tenant_id: tenantId });
+    const toSave = { ...data, tenant_id: tenantId };
+    if (data.client_secret_plaintext) {
+      toSave.client_secret = this.oauthProvider.encryptSecret(data.client_secret_plaintext);
+    }
+    delete (toSave as any).client_secret_plaintext;
+
+    const idp = this.idpRepo.create(toSave);
     const saved = await this.idpRepo.save(idp);
 
     await this.auditService.log({
@@ -37,10 +45,11 @@ export class IdentityProvidersService {
   }
 
   async findAll(tenantId: string) {
-    return this.idpRepo.find({
+    const idps = await this.idpRepo.find({
       where: { tenant_id: tenantId },
       order: { created_at: 'DESC' },
     });
+    return idps.map(this.maskSecret);
   }
 
   async findOne(tenantId: string, id: string) {
@@ -48,12 +57,22 @@ export class IdentityProvidersService {
       where: { id, tenant_id: tenantId },
     });
     if (!idp) throw new NotFoundException('Identity provider not found');
-    return idp;
+    return this.maskSecret(idp);
   }
 
-  async update(tenantId: string, id: string, data: Partial<IdentityProviderEntity>, actorId: string) {
+  /** Replace stored encrypted secret with a safe placeholder in API responses. */
+  private maskSecret(idp: IdentityProviderEntity): IdentityProviderEntity {
+    return { ...idp, client_secret: idp.client_secret ? '***' : null } as IdentityProviderEntity;
+  }
+
+  async update(tenantId: string, id: string, data: Partial<IdentityProviderEntity> & { client_secret_plaintext?: string }, actorId: string) {
     const idp = await this.findOne(tenantId, id);
-    Object.assign(idp, data);
+    const toApply: any = { ...data };
+    if (data.client_secret_plaintext) {
+      toApply.client_secret = this.oauthProvider.encryptSecret(data.client_secret_plaintext);
+    }
+    delete toApply.client_secret_plaintext;
+    Object.assign(idp, toApply);
     const saved = await this.idpRepo.save(idp);
 
     await this.auditService.log({

--- a/apps/api/src/modules/sessions/sessions.controller.ts
+++ b/apps/api/src/modules/sessions/sessions.controller.ts
@@ -52,7 +52,9 @@ export class SessionsController {
     @Query() query: PaginationQueryDto,
     @Req() req: any,
   ) {
-    return this.sessionsService.findAll(req.user.tenant_id, query.limit, query.offset);
+    // Admins see all; Operators and Viewers see only their own sessions
+    const ownerFilter = req.user.role === 'Admin' ? null : req.user.owner_user_id;
+    return this.sessionsService.findAll(req.user.tenant_id, query.limit, query.offset, ownerFilter);
   }
 
   @Get('sessions/:id')

--- a/apps/api/src/modules/sessions/sessions.service.ts
+++ b/apps/api/src/modules/sessions/sessions.service.ts
@@ -66,9 +66,15 @@ export class SessionsService {
     tenantId: string,
     limit: number,
     offset: number,
+    ownerUserId?: string | null,
   ): Promise<{ data: SessionEntity[]; total: number; limit: number; offset: number }> {
+    // Admins see all sessions in the tenant; non-Admins see only their own
+    const where: any = ownerUserId
+      ? { tenant_id: tenantId, owner_user_id: ownerUserId }
+      : { tenant_id: tenantId };
+
     const [data, total] = await this.sessionRepo.findAndCount({
-      where: { tenant_id: tenantId },
+      where,
       relations: ['application'],
       take: limit,
       skip: offset,


### PR DESCRIPTION
## Summary

Implements Tabby as a proper OAuth Resource Server with provider-agnostic Generic OAuth for the admin-UI browser login (same pattern as Grafana's Generic OAuth).

**API path (backend-to-backend) — no client_secret needed:**
- `JwtStrategy` now accepts any JWT whose `iss` matches a registered IdP, validated against the IdP's JWKS (public keys). No separate token-exchange call required.
- `token-exchange` still works unchanged — existing platform integration not affected.

**Browser path (admin-UI SSO):**
- New `GET /auth/oauth/:idpId/login` → PKCE redirect to IdP
- New `GET /auth/oauth/:idpId/callback` → code exchange → Tabby JWT → redirect to admin-UI
- Admin-UI shows "Sign in with [IdP name]" button; email/password moved to collapsible fallback.

**Multi-tenant routing:**
- Tenant and user identity resolved from JWT claims at runtime (no per-user config).
- Auto-provision: tenants created automatically from `tenant_id_claim` when `allow_auto_provision=true`.

**Role assignment:**
- `admin_domains` on IdP config → email domain match → Admin role; everyone else → `default_role`.

**Session scoping in admin-UI:**
- `GET /sessions`: Admin sees all in tenant; Operator/Viewer sees only their own (`owner_user_id` filter).

## Test plan
- [ ] Register IdP via `POST /admin/identity-providers` with `issuer_url` + `audience` + `tenant_id_claim`
- [ ] Call `GET /sessions` with platform JWT (not Tabby token) → 200
- [ ] Token-exchange flow still returns federated token → 200
- [ ] OAuth login in admin-UI: click button → IdP redirect → auto-login → sessions load
- [ ] `admin_domains: ["adopt.ai"]` → `@adopt.ai` user gets Admin; other domain gets Operator
- [ ] Two users from same org → isolated sessions
- [ ] `GET /sessions` as Operator → only own sessions visible