### PR TITLE
fix(ci): read TFY_HOST directly in step so it picks up environment-scoped variable

### DIFF
--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -17,7 +17,6 @@ env:
   NODE_VERSION: "20"
   REGISTRY: ghcr.io/adoptai/tabby
   CHART_REGISTRY: ghcr.io/adoptai/charts
-  TFY_HOST: ${{ vars.TFY_HOST }}
 
 jobs:
   # ── Manual trigger guard ──────────────────────────────────────────────────────
@@ -292,7 +291,7 @@ jobs:
       - run: pip install "truefoundry<1.0.0"
 
       - name: Login to TrueFoundry
-        run: tfy login --host ${{ env.TFY_HOST }} --api-key ${{ secrets.TFY_API_KEY }}
+        run: tfy login --host ${{ vars.TFY_HOST }} --api-key ${{ secrets.TFY_API_KEY }}
 
       - name: Generate manifest from template
         run: envsubst < infra/tfy/deploy.yaml > /tmp/tfy-manifest.yaml

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -13,7 +13,6 @@ env:
   NODE_VERSION: "20"
   REGISTRY: ghcr.io/adoptai/tabby
   CHART_REGISTRY: ghcr.io/adoptai/charts
-  TFY_HOST: ${{ vars.TFY_HOST }}
 
 jobs:
   # ── Quality Gates ─────────────────────────────────────────────────────────────
@@ -272,7 +271,7 @@ jobs:
       - run: pip install "truefoundry<1.0.0"
 
       - name: Login to TrueFoundry
-        run: tfy login --host ${{ env.TFY_HOST }} --api-key ${{ secrets.TFY_API_KEY }}
+        run: tfy login --host ${{ vars.TFY_HOST }} --api-key ${{ secrets.TFY_API_KEY }}
 
       - name: Generate manifest from template
         run: envsubst < infra/tfy/deploy.yaml > /tmp/tfy-manifest.yaml


### PR DESCRIPTION
## Problem

The last \`deploy-staging\` run failed with:

\`\`\`
Run tfy login --host  --api-key ***
Usage: tfy login [OPTIONS]
Try 'tfy login -h' for help
Error: Got unexpected extra argument (eyJhbG...)
\`\`\`

Note the empty \`--host\` — `TFY_HOST` was expanding to nothing.

## Root cause

PR #29 introduced:

\`\`\`yaml
env:
  TFY_HOST: \${{ vars.TFY_HOST }}   # workflow-level
\`\`\`

…and the deploy step used \`\${{ env.TFY_HOST }}\`.

Workflow-level \`env:\` blocks resolve **before** any job's environment context is loaded. That means \`\${{ vars.TFY_HOST }}\` at workflow level only reads **repository-level** variables — it cannot see variables scoped to a GitHub **Environment** (\`staging\`, \`production\`).

The variable was set in the Environments, so workflow-level \`env\` got an empty string, and \`tfy login --host\` had no value.

(The same job was still able to resolve \`\${{ secrets.TFY_API_KEY }}\` fine, because that reference is inside a step, which runs with the environment context loaded.)

## Fix

Read \`vars.TFY_HOST\` directly in the step (same scope as \`secrets.TFY_API_KEY\`):

\`\`\`diff
 env:
-  TFY_HOST: \${{ vars.TFY_HOST }}
 ...
-  run: tfy login --host \${{ env.TFY_HOST }} --api-key \${{ secrets.TFY_API_KEY }}
+  run: tfy login --host \${{ vars.TFY_HOST }} --api-key \${{ secrets.TFY_API_KEY }}
\`\`\`

Applied to both \`deploy-staging.yaml\` and \`deploy-production.yaml\`.

This works regardless of whether \`TFY_HOST\` is configured at the repo level, the environment level, or both.

## Test plan

- [x] YAML parses cleanly
- [x] \`git grep TFY_HOST\` shows only the two step-level references
- [ ] Merge → next \`deploy-staging\` run succeeds on \`tfy login\`