### PR TITLE
fix(auth): prefer stable userId over sub in token exchange, add DELETE /users/:id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,6 +98,7 @@ cdp-vs-vnc-viability.md
 full-codebase-review.md
 aikido.md
 pr51-security-review.md
+platform-integration-setup.md
 
 
 # --- Claude ---

--- a/apps/api/src/modules/auth/token-exchange.service.spec.ts
+++ b/apps/api/src/modules/auth/token-exchange.service.spec.ts
@@ -36,9 +36,11 @@ function buildService(overrides: Record<string, any> = {}) {
   const auditService = overrides.auditService ?? createMockAuditService();
 
   const service = Object.create(TokenExchangeService.prototype);
+  (service as any).logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
   (service as any).idpRepo = idpRepo;
   (service as any).tenantRepo = tenantRepo;
   (service as any).identityRepo = identityRepo;
+  (service as any).userRepo = { findOne: jest.fn(), create: jest.fn(), save: jest.fn() };
   (service as any).jwksService = jwksService;
   (service as any).jwtService = jwtService;
   (service as any).auditService = auditService;
@@ -222,6 +224,37 @@ describe('TokenExchangeService', () => {
         subject_token: fakeJwt,
         subject_token_type: 'oidc_jwt',
       })).rejects.toThrow('Tenant not found');
+    });
+
+    it('prefers userId over sub for owner_user_id (API token fallback)', async () => {
+      const { service, idpRepo, jwksService, auditService } = buildService();
+
+      idpRepo.findOne.mockResolvedValue({
+        id: 'idp-1',
+        tenant_id: 'tenant-1',
+        tenant_id_claim: null,
+        issuer_url: 'https://auth.example.com',
+        audience: null,
+        user_id_claim: 'sub',
+        default_role: 'Operator',
+        allow_auto_provision: false,
+      });
+
+      jwksService.getPublicKey.mockResolvedValue('mock-pem');
+      (jwt.verify as jest.Mock).mockReturnValue({
+        iss: 'https://auth.example.com',
+        sub: 'app-scoped-id',
+        userId: 'stable-user-id',
+        type: 'userApiToken',
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      });
+
+      const result = await service.exchange({
+        subject_token: fakeJwt,
+        subject_token_type: 'oidc_jwt',
+      }, 'tenant-1');
+
+      expect(result.owner_user_id).toBe('stable-user-id');
     });
   });
 

--- a/apps/api/src/modules/auth/token-exchange.service.ts
+++ b/apps/api/src/modules/auth/token-exchange.service.ts
@@ -132,8 +132,11 @@ export class TokenExchangeService {
     // 4. JWT expiry is already validated by jsonwebtoken.verify() (checks exp claim)
     // No additional age check needed — Frontegg JWTs have 24h TTL and users stay logged in
 
-    // 5. Extract owner_user_id from configured claim
-    const ownerUserId = String(verifiedPayload[idp.user_id_claim] || verifiedPayload.sub || '');
+    // 5. Extract owner_user_id — prefer stable cross-app userId (Frontegg API tokens
+    // have a different `sub` per application, but `userId` is always the real user ID)
+    this.logger.log(`Token exchange claims: sub=${verifiedPayload.sub}, userId=${(verifiedPayload as any).userId}, type=${verifiedPayload.type}`);
+    const ownerUserId = String((verifiedPayload as any).userId || verifiedPayload[idp.user_id_claim] || verifiedPayload.sub || '');
+    this.logger.log(`Resolved ownerUserId: ${ownerUserId}`);
     if (!ownerUserId) {
       throw new UnauthorizedException('JWT missing user identifier claim');
     }

--- a/apps/api/src/modules/users/users.controller.ts
+++ b/apps/api/src/modules/users/users.controller.ts
@@ -1,6 +1,7 @@
 import {
-  Controller, Post, Get, Body, Query, Req, UseGuards, HttpCode,
+  Controller, Post, Get, Delete, Param, Body, Query, Req, UseGuards, HttpCode,
 } from '@nestjs/common';
+import { ApiParam } from '@nestjs/swagger';
 import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse, ApiProperty } from '@nestjs/swagger';
 import { IsEmail, IsString, MinLength, IsIn, IsUUID, Matches } from 'class-validator';
 import { JwtAuthGuard, RolesGuard, Roles } from '../../common/guards/roles.guard';
@@ -59,5 +60,14 @@ export class UsersController {
     @Req() req: any,
   ) {
     return this.usersService.findAll(req.user.tenant_id, query.limit, query.offset);
+  }
+
+  @Delete(':id')
+  @Roles('Admin')
+  @ApiOperation({ summary: 'Delete user and all owned resources', description: 'Deletes a user and cascades to all their sessions, apps, profiles, and artifacts. Admin role required.' })
+  @ApiParam({ name: 'id', description: 'User ID' })
+  @ApiResponse({ status: 200, description: 'User deleted with summary of cleaned resources' })
+  async remove(@Param('id') id: string, @Req() req: any) {
+    return this.usersService.remove(id, req.user.user_id);
   }
 }

--- a/apps/api/src/modules/users/users.service.ts
+++ b/apps/api/src/modules/users/users.service.ts
@@ -1,8 +1,8 @@
 import {
-  Injectable, BadRequestException, ConflictException,
+  Injectable, BadRequestException, ConflictException, NotFoundException, Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, DataSource } from 'typeorm';
 import { UserEntity } from '../../entities';
 import { AuthService } from '../auth/auth.service';
 import { AuditService } from '../audit/audit.service';
@@ -10,11 +10,14 @@ import { DEFAULTS, PASSWORD_RULES } from '@browser-hitl/shared';
 
 @Injectable()
 export class UsersService {
+  private readonly logger = new Logger(UsersService.name);
+
   constructor(
     @InjectRepository(UserEntity)
     private readonly userRepo: Repository<UserEntity>,
     private readonly authService: AuthService,
     private readonly auditService: AuditService,
+    private readonly dataSource: DataSource,
   ) {}
 
   async create(
@@ -68,5 +71,70 @@ export class UsersService {
     });
 
     return { data, total, limit, offset };
+  }
+
+  async remove(id: string, actorId: string): Promise<{ deleted: Record<string, number> }> {
+    const user = await this.userRepo.findOne({ where: { id } });
+    if (!user) throw new NotFoundException('User not found');
+
+    const deleted: Record<string, number> = {};
+    const qr = this.dataSource.createQueryRunner();
+    await qr.connect();
+    await qr.startTransaction();
+
+    try {
+      const tables = [
+        'session_batons',
+        'interventions',
+        'artifact_bundles',
+        'sessions',
+        'service_profiles',
+        'applications',
+      ];
+
+      for (const table of tables) {
+        let result;
+        if (table === 'session_batons') {
+          result = await qr.query(
+            `DELETE FROM session_batons WHERE session_id IN (SELECT id FROM sessions WHERE owner_user_id = $1)`,
+            [id],
+          );
+        } else if (table === 'interventions' || table === 'artifact_bundles') {
+          result = await qr.query(
+            `DELETE FROM ${table} WHERE session_id IN (SELECT id FROM sessions WHERE owner_user_id = $1)`,
+            [id],
+          );
+        } else {
+          result = await qr.query(`DELETE FROM ${table} WHERE owner_user_id = $1`, [id]);
+        }
+        const count = result[1] ?? result?.rowCount ?? 0;
+        if (count > 0) {
+          deleted[table] = count;
+          this.logger.log(`Deleted ${count} rows from ${table} for user ${id}`);
+        }
+      }
+
+      await qr.query(`DELETE FROM user_identities WHERE user_id = $1`, [id]);
+      await qr.query(`DELETE FROM users WHERE id = $1`, [id]);
+      deleted['users'] = 1;
+
+      await qr.commitTransaction();
+    } catch (err) {
+      await qr.rollbackTransaction();
+      this.logger.error(`User deletion rolled back for ${id}: ${(err as Error).message}`);
+      throw err;
+    } finally {
+      await qr.release();
+    }
+
+    await this.auditService.log({
+      tenant_id: user.tenant_id,
+      actor_type: 'human',
+      actor_id: actorId,
+      event_type: 'user.deleted',
+      payload: { user_id: id, email: user.email, deleted },
+    });
+
+    return { deleted };
   }
 }


### PR DESCRIPTION
## Summary

Fixes a user identity mismatch when Frontegg API tokens are used (MCP Configurator path) vs normal JWT login (Copilot path). Adds a user delete endpoint for cleanup.

## Problem

Frontegg generates different `sub` values per application for the same user. When a user authenticates via API token (MCP Configurator), the `sub` in the JWT is application-scoped and differs from the `sub` in a normal login JWT. This caused:
- Sessions created with the wrong `owner_user_id`
- VNC OAuth redirect loop (cookie owner never matches session owner)
- Duplicate user provisioning attempts

## Fix

Token exchange now prefers the stable `userId` field (present in Frontegg API tokens) over `sub`:

```typescript
const ownerUserId = String(verifiedPayload.userId || verifiedPayload[idp.user_id_claim] || verifiedPayload.sub || '');
```

- API token JWT: has `userId: "52554bab"` (stable) + `sub: "a66f7f0f"` (app-scoped) → uses `userId`
- Normal login JWT: no `userId` field → falls back to `sub` (which is already the correct stable ID)

## New endpoint

`DELETE /users/:id` — Admin only, transactional cascade. Deletes user + all owned resources (session_batons → interventions → artifacts → sessions → profiles → apps → user_identities → user). Returns `{ deleted: { table: count } }`.

## Files changed

- `apps/api/src/modules/auth/token-exchange.service.ts` — userId fallback + debug logs
- `apps/api/src/modules/users/users.controller.ts` — DELETE endpoint
- `apps/api/src/modules/users/users.service.ts` — remove() with transactional cascade
- `.gitignore` — added platform-integration-setup.md