### PR TITLE
fix(app-templates): carry execute_enabled through templates and auto-provisioning

### DIFF
--- a/apps/api/src/data-source.ts
+++ b/apps/api/src/data-source.ts
@@ -25,6 +25,7 @@ import { AddTemplateLineage1708300000020 } from './migrations/1708300000020-AddT
 import { DropIdpSecrets1708300000021 } from './migrations/1708300000021-DropIdpSecrets';
 import { AddExecuteEnabled1708300000022 } from './migrations/1708300000022-AddExecuteEnabled';
 import { ControllerScaling1708300000023 } from './migrations/1708300000023-ControllerScaling';
+import { AddTemplateExecuteEnabled1708300000024 } from './migrations/1708300000024-AddTemplateExecuteEnabled';
 
 const poolSize = Number(process.env.DB_POOL_SIZE) || 20;
 
@@ -34,7 +35,7 @@ export const dataSourceOptions: DataSourceOptions = {
     testDefault: 'postgresql://postgres:postgres@localhost:5432/browser_hitl',
   }),
   entities: Object.values(entities),
-  migrations: [InitialSchema1708300000000, WorkerRLS1708300000001, AgentClients1708300000002, AuthRequests1708300000003, LoginQueue1708300000004, AccountLockout1708300000005, ArtifactCascadeDelete1708300000006, ServiceProfiles1708300000007, ProfileAppLink1708300000008, GenericHumanInput1708300000009, AddIdentityProviders1708300000010, AddOwnerUserIds1708300000011, AddAppTemplates1708300000012, AddIdleShutdown1708300000013, AddAppOwnerUserId1708300000014, MultiTenantCloud1708300000015, GenericOAuth1708300000016, NullablePasswordHash1708300000017, GlobalIdp1708300000018, AddRestartRequested1708300000019, AddTemplateLineage1708300000020, DropIdpSecrets1708300000021, AddExecuteEnabled1708300000022, ControllerScaling1708300000023],
+  migrations: [InitialSchema1708300000000, WorkerRLS1708300000001, AgentClients1708300000002, AuthRequests1708300000003, LoginQueue1708300000004, AccountLockout1708300000005, ArtifactCascadeDelete1708300000006, ServiceProfiles1708300000007, ProfileAppLink1708300000008, GenericHumanInput1708300000009, AddIdentityProviders1708300000010, AddOwnerUserIds1708300000011, AddAppTemplates1708300000012, AddIdleShutdown1708300000013, AddAppOwnerUserId1708300000014, MultiTenantCloud1708300000015, GenericOAuth1708300000016, NullablePasswordHash1708300000017, GlobalIdp1708300000018, AddRestartRequested1708300000019, AddTemplateLineage1708300000020, DropIdpSecrets1708300000021, AddExecuteEnabled1708300000022, ControllerScaling1708300000023, AddTemplateExecuteEnabled1708300000024],
   migrationsRun: true,
   synchronize: false,
   logging: process.env.NODE_ENV === 'development' ? ['error', 'warn', 'migration'] : ['error'],

--- a/apps/api/src/entities/app-template.entity.ts
+++ b/apps/api/src/entities/app-template.entity.ts
@@ -41,6 +41,16 @@ export class AppTemplateEntity {
   @Column({ type: 'varchar', default: 'manual:' })
   credential_ref_default: string;
 
+  /**
+   * Whether apps auto-provisioned from this template have the execute capability
+   * (POST /execute/fetch | /execute/browser). The controller only provisions the
+   * worker Service + NetworkPolicy ingress + JWT_SIGNING_KEY when the app's
+   * execute_enabled is true, so this must be carried onto each cloned app or the
+   * per-user connection can never run execute calls. Mirrors applications.execute_enabled.
+   */
+  @Column({ type: 'boolean', default: false })
+  execute_enabled: boolean;
+
   @Column({ type: 'integer', nullable: true })
   idle_shutdown_seconds: number | null;
 

--- a/apps/api/src/migrations/1708300000024-AddTemplateExecuteEnabled.ts
+++ b/apps/api/src/migrations/1708300000024-AddTemplateExecuteEnabled.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddTemplateExecuteEnabled1708300000024 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "app_templates" ADD COLUMN "execute_enabled" boolean NOT NULL DEFAULT false`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "app_templates" DROP COLUMN "execute_enabled"`,
+    );
+  }
+}

--- a/apps/api/src/modules/app-templates/app-templates.controller.ts
+++ b/apps/api/src/modules/app-templates/app-templates.controller.ts
@@ -3,7 +3,7 @@ import {
   UseGuards, HttpCode, ParseUUIDPipe,
 } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth, ApiProperty, ApiOperation, ApiQuery } from '@nestjs/swagger';
-import { IsString, MinLength, IsOptional, IsObject, IsInt, Min } from 'class-validator';
+import { IsString, MinLength, IsOptional, IsObject, IsInt, IsBoolean, Min } from 'class-validator';
 import { Roles, RolesGuard, JwtAuthGuard } from '../../common/guards/roles.guard';
 import { AppTemplatesService } from './app-templates.service';
 
@@ -43,6 +43,10 @@ class CreateAppTemplateDto {
   @ApiProperty({ required: false, example: 'manual:', description: 'Default credential_ref for auto-provisioned apps' })
   @IsOptional() @IsString()
   credential_ref_default?: string;
+
+  @ApiProperty({ required: false, default: false, description: 'Whether apps auto-provisioned from this template can run POST /execute/fetch | /execute/browser. Carried onto each cloned app so the controller provisions the worker Service + JWT_SIGNING_KEY.' })
+  @IsOptional() @IsBoolean()
+  execute_enabled?: boolean;
 
   @ApiProperty({ required: false, description: 'Auto-shutdown session after N seconds idle' })
   @IsOptional() @IsInt() @Min(60)

--- a/apps/api/src/modules/app-templates/app-templates.service.spec.ts
+++ b/apps/api/src/modules/app-templates/app-templates.service.spec.ts
@@ -17,6 +17,7 @@ function makeTemplate(overrides: Partial<AppTemplateEntity> = {}): AppTemplateEn
     browser_policy: { downloads: false, clipboard: false, file_chooser: false },
     notification_config: {},
     credential_ref_default: 'manual:',
+    execute_enabled: false,
     idle_shutdown_seconds: null,
     created_at: new Date(),
     updated_at: new Date(),
@@ -92,10 +93,33 @@ describe('AppTemplatesService — propagation', () => {
         keepalive_config: template.keepalive_config,
         export_policy: template.export_policy,
         notification_config: template.notification_config,
+        execute_enabled: template.execute_enabled,
       };
 
       expect(appRepo.update).toHaveBeenCalledWith('app-1', expectedPayload);
       expect(appRepo.update).toHaveBeenCalledWith('app-2', expectedPayload);
+    });
+
+    it('propagates execute_enabled toggles to linked apps', async () => {
+      const template = makeTemplate({ execute_enabled: true });
+
+      const { service, appRepo } = buildService({
+        templateRepo: {
+          findOne: jest.fn().mockResolvedValue(template),
+          save: jest.fn().mockResolvedValue(template),
+        },
+        appRepo: {
+          find: jest.fn().mockResolvedValue([{ id: 'app-1' }]),
+          update: jest.fn().mockResolvedValue(undefined),
+        },
+      });
+
+      await service.update('tenant-1', 'tpl-uuid-1', { execute_enabled: true }, 'actor-1');
+
+      expect(appRepo.update).toHaveBeenCalledWith(
+        'app-1',
+        expect.objectContaining({ execute_enabled: true }),
+      );
     });
 
     it('apps without template_id are not affected (find by template_id filters them out)', async () => {

--- a/apps/api/src/modules/app-templates/app-templates.service.ts
+++ b/apps/api/src/modules/app-templates/app-templates.service.ts
@@ -83,7 +83,7 @@ export class AppTemplatesService {
 
   private static readonly PROPAGATED_FIELDS = [
     'browser_policy', 'login_config', 'keepalive_config',
-    'export_policy', 'notification_config',
+    'export_policy', 'notification_config', 'execute_enabled',
   ] as const;
 
   private async propagateToLinkedApps(template: AppTemplateEntity): Promise<number> {

--- a/apps/api/src/modules/apps/apps.dto.ts
+++ b/apps/api/src/modules/apps/apps.dto.ts
@@ -1,5 +1,5 @@
 import {
-  IsString, IsArray, IsObject, IsOptional, IsInt, IsUUID, Min, MinLength, ArrayMinSize,
+  IsString, IsArray, IsObject, IsOptional, IsInt, IsBoolean, IsUUID, Min, MinLength, ArrayMinSize,
 } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
@@ -7,7 +7,7 @@ import { Type } from 'class-transformer';
 export const APP_SELECTABLE_FIELDS = [
   'id', 'name', 'tenant_id', 'target_urls', 'login_config', 'keepalive_config',
   'export_policy', 'notification_config', 'browser_policy', 'desired_session_count',
-  'credential_last_validated_at', 'credential_rotation_reminder_days',
+  'execute_enabled', 'credential_last_validated_at', 'credential_rotation_reminder_days',
   'created_at', 'updated_at',
 ] as const;
 
@@ -78,6 +78,11 @@ export class CreateAppDto {
   @IsObject()
   browser_policy?: Record<string, unknown>;
 
+  @ApiProperty({ description: 'Whether the app can run POST /execute/fetch | /execute/browser. The controller only provisions the worker Service + NetworkPolicy ingress + JWT_SIGNING_KEY when true.', required: false, default: false })
+  @IsOptional()
+  @IsBoolean()
+  execute_enabled?: boolean;
+
   @ApiProperty({ description: 'Target tenant UUID. Admin only — defaults to caller tenant if omitted.', required: false })
   @IsOptional()
   @IsUUID()
@@ -128,4 +133,9 @@ export class UpdateAppDto {
   @IsOptional()
   @IsObject()
   browser_policy?: Record<string, unknown>;
+
+  @ApiProperty({ description: 'Whether the app can run POST /execute/fetch | /execute/browser. The controller only provisions the worker Service + NetworkPolicy ingress + JWT_SIGNING_KEY when true.', required: false })
+  @IsOptional()
+  @IsBoolean()
+  execute_enabled?: boolean;
 }

--- a/apps/api/src/modules/apps/apps.service.ts
+++ b/apps/api/src/modules/apps/apps.service.ts
@@ -27,6 +27,7 @@ interface CreateAppInput {
   notification_config?: Record<string, unknown>;
   desired_session_count?: number;
   browser_policy?: Record<string, unknown>;
+  execute_enabled?: boolean;
 }
 
 @Injectable()
@@ -97,6 +98,7 @@ export class AppsService {
       notification_config: input.notification_config ?? { channels: [] },
       desired_session_count: input.desired_session_count ?? 1,
       browser_policy: input.browser_policy ?? { downloads: false, clipboard: false, file_chooser: false },
+      execute_enabled: input.execute_enabled ?? false,
     });
     const saved = await this.appRepo.save(app);
 
@@ -179,6 +181,7 @@ export class AppsService {
       ...(input.notification_config !== undefined && { notification_config: input.notification_config }),
       ...(input.desired_session_count !== undefined && { desired_session_count: input.desired_session_count }),
       ...(input.browser_policy !== undefined && { browser_policy: input.browser_policy }),
+      ...(input.execute_enabled !== undefined && { execute_enabled: input.execute_enabled }),
     });
 
     const saved = await this.appRepo.save(app);

--- a/apps/api/src/modules/credentials/credentials.service.ts
+++ b/apps/api/src/modules/credentials/credentials.service.ts
@@ -307,6 +307,10 @@ export class CredentialsService {
       export_policy: template.export_policy as any,
       notification_config: template.notification_config as any,
       browser_policy: template.browser_policy as any,
+      // Carry the template's execute capability onto the cloned app — without it the
+      // controller never provisions the worker Service + JWT_SIGNING_KEY, so the
+      // per-user connection could never run /execute/fetch | /execute/browser.
+      execute_enabled: template.execute_enabled,
       desired_session_count: 0, // Start with 0, scale up after profile is created
     }, tenantId, actorId);
 

--- a/apps/api/src/modules/credentials/credentials.spec.ts
+++ b/apps/api/src/modules/credentials/credentials.spec.ts
@@ -1080,6 +1080,55 @@ describe('CredentialsService (ADR-013 + Sprint 3b)', () => {
     });
   });
 
+  describe('autoProvisionFromTemplate — execute_enabled propagation', () => {
+    function wireAutoProvision(service: CredentialsService, template: any) {
+      const appsService = { create: jest.fn().mockResolvedValue({ app_id: 'auto-app-1' }) };
+      const profilesService = { create: jest.fn().mockResolvedValue({ id: 'auto-profile-1' }) };
+      const sessionsService = { scale: jest.fn().mockResolvedValue(undefined) };
+      (service as any).templateRepo = { findOne: jest.fn().mockResolvedValue(template) };
+      (service as any).appsService = appsService;
+      (service as any).profilesService = profilesService;
+      (service as any).sessionsService = sessionsService;
+      (service as any).appRepo = { update: jest.fn().mockResolvedValue(undefined) };
+      (service as any).profileRepo = { update: jest.fn().mockResolvedValue(undefined) };
+      return { appsService, profilesService, sessionsService };
+    }
+
+    it('forwards an execute-enabled template onto the cloned app', async () => {
+      const { service } = buildService();
+      const { appsService } = wireAutoProvision(service, {
+        id: 'tpl-1', name: 'Expedia', profile_name_pattern: 'expedia',
+        login_config: {}, keepalive_config: {}, export_policy: {}, notification_config: {},
+        browser_policy: {}, execute_enabled: true,
+      });
+
+      await (service as any).autoProvisionFromTemplate(TEST_TENANT, 'expedia', 'user-a');
+
+      expect(appsService.create).toHaveBeenCalledWith(
+        expect.objectContaining({ execute_enabled: true }),
+        TEST_TENANT,
+        expect.any(String),
+      );
+    });
+
+    it('forwards an execute-disabled template as false', async () => {
+      const { service } = buildService();
+      const { appsService } = wireAutoProvision(service, {
+        id: 'tpl-2', name: 'Expedia', profile_name_pattern: 'expedia',
+        login_config: {}, keepalive_config: {}, export_policy: {}, notification_config: {},
+        browser_policy: {}, execute_enabled: false,
+      });
+
+      await (service as any).autoProvisionFromTemplate(TEST_TENANT, 'expedia', 'user-a');
+
+      expect(appsService.create).toHaveBeenCalledWith(
+        expect.objectContaining({ execute_enabled: false }),
+        TEST_TENANT,
+        expect.any(String),
+      );
+    });
+  });
+
   describe('findHealthySession — owner_user_id scoping', () => {
     it('includes owner_user_id in WHERE when provided', async () => {
       const { service, sessionRepo } = buildService();


### PR DESCRIPTION
## What & why
App Templates had no `execute_enabled` field and the create DTO rejected it (`whitelist`/`forbidNonWhitelisted`), so `POST /admin/app-templates` 400'd on the field NoUI emits. Deeper: **no API path persisted `execute_enabled` at all** — both `POST /apps` and template auto-provisioned apps defaulted to `false`. Since the controller only provisions the worker Service + NetworkPolicy ingress + `JWT_SIGNING_KEY` when an app's `execute_enabled` is true (`apps/controller/src/reconcile.service.ts`, `pod-manager.service.ts`), every tenant-wide auto-provisioned connection came up unable to run `/execute/fetch` | `/execute/browser`.

## Changes
- `app_templates`: add `execute_enabled` column (migration `1708300000024`, default false) + entity field
- `CreateAppTemplateDto`: accept `execute_enabled`
- `CreateAppDto`/`UpdateAppDto` + `AppsService.create/update`: persist `execute_enabled`
- `autoProvisionFromTemplate`: carry `template.execute_enabled` onto the cloned per-user app
- `AppTemplatesService`: propagate `execute_enabled` to linked apps on template update

## Risk / validation
Defaults to `false` to match `applications.execute_enabled` (security-sensitive opt-in). Rebased onto `dev`; `nx build api` + `nx lint api` clean; full api suite **557/557** green incl. new propagation + auto-provision tests. Validated on local Tabby end-to-end: template create now 201s + persists, and an auto-provisioned per-user app inherits `execute_enabled=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)