### PR TITLE
feat: base64-encode binary responses in /execute/fetch

### DIFF
--- a/apps/worker/src/execute-handler.ts
+++ b/apps/worker/src/execute-handler.ts
@@ -79,15 +79,52 @@ export function registerExecuteHandler(app: Express, page: Page): void {
           const respHeaders: Record<string, string> = {};
           resp.headers.forEach((v, k) => { respHeaders[k] = v; });
 
-          const text = await resp.text();
-          const truncated = text.length > maxBytes
-            ? text.slice(0, maxBytes)
-            : text;
+          // Decide text vs binary from the response Content-Type. Textual
+          // bodies (json/text/xml/form/svg) go through resp.text() as before;
+          // anything else is read as raw bytes and base64-encoded so binary
+          // payloads (e.g. application/pdf) survive transit intact instead of
+          // being mangled by a UTF-8 text decode.
+          const contentType = (respHeaders['content-type'] || '').toLowerCase();
+          const isTextual =
+            contentType === '' ||
+            contentType.startsWith('text/') ||
+            contentType.includes('json') ||
+            contentType.includes('xml') ||
+            contentType.includes('javascript') ||
+            contentType.includes('x-www-form-urlencoded') ||
+            contentType.includes('svg');
 
+          if (isTextual) {
+            const text = await resp.text();
+            const wasTruncated = text.length > maxBytes;
+            return {
+              status: resp.status,
+              headers: respHeaders,
+              body: wasTruncated ? text.slice(0, maxBytes) : text,
+              encoding: 'utf-8' as const,
+              truncated: wasTruncated,
+            };
+          }
+
+          const buf = new Uint8Array(await resp.arrayBuffer());
+          const wasTruncated = buf.length > maxBytes;
+          const bytes = wasTruncated ? buf.subarray(0, maxBytes) : buf;
+          // Chunked base64 encode — String.fromCharCode.apply over the whole
+          // array can blow the call stack for multi-MB payloads.
+          let binary = '';
+          const CHUNK = 0x8000;
+          for (let i = 0; i < bytes.length; i += CHUNK) {
+            binary += String.fromCharCode.apply(
+              null,
+              Array.from(bytes.subarray(i, i + CHUNK)),
+            );
+          }
           return {
             status: resp.status,
             headers: respHeaders,
-            body: truncated,
+            body: btoa(binary),
+            encoding: 'base64' as const,
+            truncated: wasTruncated,
           };
         },
         {

--- a/apps/worker/src/execute-integration.spec.ts
+++ b/apps/worker/src/execute-integration.spec.ts
@@ -206,6 +206,23 @@ describe('execute handlers (integration)', () => {
       expect(res.status).toBe(502);
       expect(res.body.error).toMatch(/Browser fetch failed/);
     });
+
+    it('passes through base64 encoding + truncated flags for binary responses', async () => {
+      page.evaluate.mockResolvedValueOnce({
+        status: 200,
+        headers: { 'content-type': 'application/pdf' },
+        body: 'JVBERi0xLjM=', // base64("%PDF-1.3")
+        encoding: 'base64',
+        truncated: false,
+      });
+      const res = await request(server, 'POST', '/execute/fetch', {
+        url: 'https://api.example.com/statement.pdf',
+      }, auth());
+      expect(res.status).toBe(200);
+      expect(res.body.encoding).toBe('base64');
+      expect(res.body.truncated).toBe(false);
+      expect(res.body.body).toBe('JVBERi0xLjM=');
+    });
   });
 
   // ─── Execute browser handler ─────────────────────────────────────

--- a/packages/shared/src/execute-types.ts
+++ b/packages/shared/src/execute-types.ts
@@ -10,6 +10,13 @@ export interface ExecuteFetchResponse {
   status: number;
   headers: Record<string, string>;
   body: string;
+  // How `body` is encoded. 'utf-8' (default) for textual responses; 'base64'
+  // when the response is binary (e.g. application/pdf) and reading it as text
+  // would corrupt the bytes. Optional for backward compatibility.
+  encoding?: 'utf-8' | 'base64';
+  // True when the response exceeded MAX_RESPONSE_BODY_BYTES and was cut off.
+  // For binary bodies a truncated payload is unusable, so consumers should error.
+  truncated?: boolean;
 }
 
 export const EXECUTE_LIMITS = {


### PR DESCRIPTION
## What

`/execute/fetch` read **every** response body with `resp.text()` and byte-truncated it. For binary payloads (e.g. `application/pdf`) that decodes the bytes as UTF-8 and **corrupts the file**, so callers cannot retrieve binary resources through the authenticated browser session at all.

This branches on the response `Content-Type`:
- **Textual** (`json`/`text`/`xml`/`form`/`svg`/empty) → `resp.text()`, unchanged behavior.
- **Binary** → `resp.arrayBuffer()` + chunked base64 (`btoa` over `String.fromCharCode` in 0x8000 slices, to avoid a call-stack overflow on multi-MB payloads).

`ExecuteFetchResponse` gains two optional fields:
- `encoding`: `'utf-8' | 'base64'` — so consumers know how to decode `body`.
- `truncated`: `boolean` — a size-capped binary body is unusable, so consumers should error rather than write a corrupt file.

Backward compatible: existing textual callers are unaffected (default `utf-8`, fields optional).

## Why

A NoUI-generated skill needed to download bank-statement PDFs through the Tabby session. The list (JSON) worked; the PDF download came back corrupt because of the text decode. With this change the downloaded PDF is **byte-identical** (SHA256-matched) to a direct authenticated fetch.

## Risk

Low. Behavior for textual responses is identical to before; only non-textual content-types take the new path. New response fields are optional.

## Validation

- `pnpm nx build worker` — clean (types compile).
- `pnpm nx test worker` — **104 passed** (added an integration test asserting `encoding`/`truncated` passthrough for `application/pdf`).
- `pnpm nx lint worker` — clean.
- End-to-end via local Tabby: bank-statement PDFs downloaded through `/execute/fetch` are SHA256-identical to direct authenticated downloads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)