### PR TITLE
fix: stream viewer gate failures for agent sessions + punctuation key relay

### DIFF
--- a/apps/api/src/modules/streaming/streaming.controller.ts
+++ b/apps/api/src/modules/streaming/streaming.controller.ts
@@ -34,6 +34,101 @@ import { parseCookie } from '../../common/utils/cookie';
 /** Module-level constant — avoids repeating the env-read inline everywhere. */
 const PUBLIC_BASE_URL = (process.env.PUBLIC_BASE_URL || 'http://localhost:18080').replace(/\/+$/, '');
 
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Resolve the email the gate should match for a session owner.
+ *
+ * owner_user_id is a users.id uuid for password/OAuth users, but
+ * agent_assertion token-exchange stores the raw federated identity —
+ * typically an email — and never provisions a users row. Querying
+ * users.id (uuid column) with an email throws a Postgres cast error,
+ * so only uuid-shaped owners hit the table; email-shaped owners match
+ * directly.
+ */
+async function resolveOwnerEmail(
+  userRepo: Repository<UserEntity>,
+  ownerUserId: string,
+): Promise<string | null> {
+  if (UUID_RE.test(ownerUserId)) {
+    const ownerUser = await userRepo.findOne({ where: { id: ownerUserId } });
+    return ownerUser?.email?.toLowerCase() ?? null;
+  }
+  if (ownerUserId.includes('@')) {
+    return ownerUserId.toLowerCase();
+  }
+  return null;
+}
+
+/**
+ * Does a verified stream token prove the viewer IS the session owner?
+ *
+ * Stream tokens minted through the owner's own authenticated call (e.g.
+ * POST /sessions/:id/short-link with a user-scoped token-exchange JWT)
+ * carry that caller's identity as `user_id`, prefixed `federated:` for
+ * token-exchange users. When it matches the session owner, the OAuth /
+ * email gate adds nothing — the token already proves the same identity
+ * the gate would ask for — so the viewer cookie is minted directly.
+ * Tokens minted by other consumers (e.g. `agent:{profile}` from
+ * session-status) do NOT match and still go through the gate.
+ */
+function streamTokenProvesOwner(tokenUserId: string | undefined, ownerUserId: string): boolean {
+  if (!tokenUserId) return false;
+  const normalized = tokenUserId.replace(/^federated:/, '').toLowerCase();
+  return normalized === ownerUserId.toLowerCase();
+}
+
+/**
+ * Cookie-minting body shared by both viewers' POST :sessionId/verify-token.
+ *
+ * The stream token travels in the URL FRAGMENT (M-4: never sent to the
+ * server), so the page GET cannot auto-pass the gate — the gate page's
+ * script posts the fragment token here instead. When the token was minted
+ * by the session owner's own authenticated call, it proves the identity
+ * the email gate would ask for, so the viewer cookie is set without
+ * prompting. Any mismatch falls back to the manual gate (403).
+ */
+async function verifyStreamTokenForOwner(
+  streamTokenService: StreamTokenService,
+  sessionRepo: Repository<SessionEntity>,
+  jwtService: JwtService,
+  sessionId: string,
+  token: string | undefined,
+  res: Response,
+): Promise<{ status: string }> {
+  const denyMsg = 'Access denied';
+  if (!token) throw new BadRequestException('token is required');
+
+  const result = streamTokenService.verifyToken(token);
+  if (!result.valid || result.payload.session_id !== sessionId) {
+    throw new ForbiddenException(denyMsg);
+  }
+
+  const session = await sessionRepo.findOne({ where: { id: sessionId } });
+  if (!session || !session.owner_user_id) throw new ForbiddenException(denyMsg);
+  if (!streamTokenProvesOwner(result.payload.user_id, session.owner_user_id)) {
+    throw new ForbiddenException(denyMsg);
+  }
+
+  const vncToken = jwtService.sign({
+    sub: session.owner_user_id,
+    tenant_id: session.tenant_id,
+    type: 'vnc_access',
+    owner_user_id: session.owner_user_id,
+    jti: randomUUID(),
+  }, { expiresIn: 3600 });
+  const isHttps = PUBLIC_BASE_URL.startsWith('https://') || process.env.NODE_ENV === 'production';
+  res.cookie('tabby_vnc', vncToken, {
+    httpOnly: true,
+    secure: isHttps,
+    sameSite: 'lax',
+    maxAge: 3600 * 1000,
+    path: '/',
+  });
+
+  return { status: 'ok' };
+}
+
 /**
  * Redirect to OAuth login (or email gate fallback) when a valid tabby_vnc cookie is absent.
  * Shared by VNC and CDP viewers — pass `prefix` to control which path is used.
@@ -117,11 +212,38 @@ function renderEmailGatePage(sessionId: string, token: string | undefined, prefi
     </div>
     <script>
       var SESSION_ID = ${JSON.stringify(sessionId)};
+      var GATE_PREFIX = ${JSON.stringify(prefix)};
       var STREAM_TOKEN = ${JSON.stringify(token ?? '')};
       // Also check URL fragment for stream token (server never sees #fragment)
       if (!STREAM_TOKEN) {
         var h = window.location.hash.charAt(0) === '#' ? window.location.hash.slice(1) : window.location.hash;
         STREAM_TOKEN = new URLSearchParams(h).get('token') || '';
+      }
+
+      // A stream token minted by the session owner's own authenticated call
+      // proves the identity this gate would ask for — try it first and only
+      // show the email form when the server rejects it.
+      if (STREAM_TOKEN) {
+        document.getElementById('msg').style.color = '#94a3b8';
+        document.getElementById('msg').textContent = 'Verifying access…';
+        fetch('/' + GATE_PREFIX + '/' + SESSION_ID + '/verify-token', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ token: STREAM_TOKEN }),
+          credentials: 'same-origin',
+        })
+          .then(function(r) {
+            if (r.ok) {
+              window.location.reload();
+            } else {
+              document.getElementById('msg').style.color = '';
+              document.getElementById('msg').textContent = '';
+            }
+          })
+          .catch(function() {
+            document.getElementById('msg').style.color = '';
+            document.getElementById('msg').textContent = '';
+          });
       }
 
       document.getElementById('submitBtn').addEventListener('click', verify);
@@ -292,11 +414,14 @@ export class CdpStreamingController {
     if (!session) throw new ForbiddenException(denyMsg);
     if (!session.owner_user_id) throw new ForbiddenException(denyMsg);
 
-    const ownerUser = await this.userRepo.findOne({ where: { id: session.owner_user_id } });
-    if (!ownerUser || ownerUser.email?.toLowerCase() !== email) throw new ForbiddenException(denyMsg);
+    // agent_assertion sessions carry the federated identity (often an email)
+    // in owner_user_id; users.id is a uuid, so querying it with that value
+    // throws a Postgres cast error. Match email-form owners directly.
+    const ownerEmail = await resolveOwnerEmail(this.userRepo, session.owner_user_id);
+    if (!ownerEmail || ownerEmail !== email) throw new ForbiddenException(denyMsg);
 
     const vncToken = this.jwtService.sign({
-      sub: ownerUser.id,
+      sub: session.owner_user_id,
       tenant_id: session.tenant_id,
       type: 'vnc_access',
       owner_user_id: session.owner_user_id,
@@ -315,6 +440,19 @@ export class CdpStreamingController {
     return { status: 'ok' };
   }
 
+  @Post(':sessionId/verify-token')
+  @Throttle({ default: { limit: 10, ttl: 60000 } })
+  @HttpCode(200)
+  async verifyCdpToken(
+    @Param('sessionId', ParseUUIDPipe) sessionId: string,
+    @Body() body: { token?: string },
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<{ status: string }> {
+    return verifyStreamTokenForOwner(
+      this.streamTokenService, this.sessionRepo, this.jwtService, sessionId, body?.token, res,
+    );
+  }
+
   @Get(':sessionId')
   async openStream(
     @Param('sessionId', ParseUUIDPipe) sessionId: string,
@@ -322,10 +460,12 @@ export class CdpStreamingController {
     @Res() res: Response,
     @Query('token') token?: string,
   ): Promise<void> {
+    let tokenUserId: string | undefined;
     if (token) {
       const result = this.streamTokenService.verifyToken(token);
       if (!result.valid) throw new UnauthorizedException(result.reason);
       if (result.payload.session_id !== sessionId) throw new UnauthorizedException('Token is not valid for this session');
+      tokenUserId = result.payload.user_id;
     }
 
     const session = await this.sessionRepo.findOne({ where: { id: sessionId } });
@@ -333,7 +473,25 @@ export class CdpStreamingController {
     if (session.state === 'TERMINATED') throw new BadRequestException('Cannot open stream for TERMINATED session');
 
     // ── Auth gate (same pattern as VNC) ─────────────────────────────────────
-    if (session.owner_user_id) {
+    if (session.owner_user_id && streamTokenProvesOwner(tokenUserId, session.owner_user_id)) {
+      // Token already proves the owner's identity — mint the viewer cookie
+      // directly (the /cdp-ws upgrade requires it) and skip the gate.
+      const vncToken = this.jwtService.sign({
+        sub: session.owner_user_id,
+        tenant_id: session.tenant_id,
+        type: 'vnc_access',
+        owner_user_id: session.owner_user_id,
+        jti: randomUUID(),
+      }, { expiresIn: 3600 });
+      const isHttps = PUBLIC_BASE_URL.startsWith('https://') || process.env.NODE_ENV === 'production';
+      res.cookie('tabby_vnc', vncToken, {
+        httpOnly: true,
+        secure: isHttps,
+        sameSite: 'lax',
+        maxAge: 3600 * 1000,
+        path: '/',
+      });
+    } else if (session.owner_user_id) {
       const cookieToken = parseCookie(req.headers.cookie, 'tabby_vnc');
 
       if (!cookieToken) {
@@ -596,6 +754,24 @@ export class CdpStreamingController {
         'F6':117,'F7':118,'F8':119,'F9':120,'F10':121,'F11':122,'F12':123,
       };
 
+      // VK_OEM_* codes for punctuation. charCodeAt would collide with control
+      // VKs — '.'(46) is VK_DELETE, '-'(45) is VK_INSERT, ','(44) — so the
+      // remote browser executed Delete/Insert instead of typing the char.
+      var PUNCT_VK = {
+        ';':186,'=':187,',':188,'-':189,'.':190,'/':191,'\`':192,
+        '[':219,'\\\\':220,']':221,"'":222,
+        ':':186,'+':187,'<':188,'_':189,'>':190,'?':191,'~':192,
+        '{':219,'|':220,'}':221,'"':222,
+      };
+
+      function vkForKey(key) {
+        if (key.length !== 1) return KEY_VK[key] || 0;
+        var c = key.toUpperCase();
+        if ((c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')) return c.charCodeAt(0);
+        // Unknown printable char: vk 0 is safe — the text param still types it.
+        return PUNCT_VK[key] || 0;
+      }
+
       function sendKey(type, e) {
         if (!ws || ws.readyState !== 1) return;
         // Never send keys while an input inside the side panel is focused
@@ -620,7 +796,7 @@ export class CdpStreamingController {
         }
 
         if (onCanvas) e.preventDefault();
-        var vk = e.key.length === 1 ? e.key.toUpperCase().charCodeAt(0) : (KEY_VK[e.key] || 0);
+        var vk = vkForKey(e.key);
         ws.send(JSON.stringify({
           id: cmdId++,
           method: 'Input.dispatchKeyEvent',
@@ -1011,13 +1187,16 @@ export class StreamingController {
     if (!session) throw new ForbiddenException(denyMsg);
     if (!session.owner_user_id) throw new ForbiddenException(denyMsg);
 
-    const ownerUser = await this.userRepo.findOne({ where: { id: session.owner_user_id } });
-    if (!ownerUser || ownerUser.email?.toLowerCase() !== email) {
+    // agent_assertion sessions carry the federated identity (often an email)
+    // in owner_user_id; users.id is a uuid, so querying it with that value
+    // throws a Postgres cast error. Match email-form owners directly.
+    const ownerEmail = await resolveOwnerEmail(this.userRepo, session.owner_user_id);
+    if (!ownerEmail || ownerEmail !== email) {
       throw new ForbiddenException(denyMsg);
     }
 
     const vncPayload = {
-      sub: ownerUser.id,
+      sub: session.owner_user_id,
       tenant_id: session.tenant_id,
       type: 'vnc_access',
       owner_user_id: session.owner_user_id,
@@ -1193,6 +1372,19 @@ export class StreamingController {
     return { session_id: newSession.id, url };
   }
 
+  @Post(':sessionId/verify-token')
+  @Throttle({ default: { limit: 10, ttl: 60000 } })
+  @HttpCode(200)
+  async verifyVncToken(
+    @Param('sessionId', ParseUUIDPipe) sessionId: string,
+    @Body() body: { token?: string },
+    @Res({ passthrough: true }) res: Response,
+  ): Promise<{ status: string }> {
+    return verifyStreamTokenForOwner(
+      this.streamTokenService, this.sessionRepo, this.jwtService, sessionId, body?.token, res,
+    );
+  }
+
   @Get(':sessionId')
   async openStream(
     @Param('sessionId', ParseUUIDPipe) sessionId: string,
@@ -1200,6 +1392,7 @@ export class StreamingController {
     @Res() res: Response,
     @Query('token') token?: string,
   ): Promise<void> {
+    let tokenUserId: string | undefined;
     if (token) {
       const result = this.streamTokenService.verifyToken(token);
       if (!result.valid) {
@@ -1208,6 +1401,7 @@ export class StreamingController {
       if (result.payload.session_id !== sessionId) {
         throw new UnauthorizedException('Token is not valid for this session');
       }
+      tokenUserId = result.payload.user_id;
     }
 
     const session = await this.sessionRepo.findOne({ where: { id: sessionId } });
@@ -1219,7 +1413,25 @@ export class StreamingController {
     }
 
     // ── Auth gate ──────────────────────────────────────────────────────────
-    if (session.owner_user_id) {
+    if (session.owner_user_id && streamTokenProvesOwner(tokenUserId, session.owner_user_id)) {
+      // Token already proves the owner's identity — mint the viewer cookie
+      // directly (the /vnc-ws upgrade requires it) and skip the gate.
+      const vncToken = this.jwtService.sign({
+        sub: session.owner_user_id,
+        tenant_id: session.tenant_id,
+        type: 'vnc_access',
+        owner_user_id: session.owner_user_id,
+        jti: randomUUID(),
+      }, { expiresIn: 3600 });
+      const isHttps = PUBLIC_BASE_URL.startsWith('https://') || process.env.NODE_ENV === 'production';
+      res.cookie('tabby_vnc', vncToken, {
+        httpOnly: true,
+        secure: isHttps,
+        sameSite: 'lax',
+        maxAge: 3600 * 1000,
+        path: '/',
+      });
+    } else if (session.owner_user_id) {
       const cookieToken = parseCookie(req.headers.cookie, 'tabby_vnc');
 
       if (!cookieToken) {


### PR DESCRIPTION
## Summary

Three viewer fixes found while integrating the Adopt agent-harness `call_web_api` flow (agent_assertion token-exchange sessions):

1. **Email gate 500** — agent_assertion sessions store the federated identity (an email) in `owner_user_id`, but both viewers' `verify-email` handlers queried `users.id` (uuid column) with it → Postgres cast error (`invalid input syntax for type uuid`). Owners now resolve via uuid-or-email shape (`resolveOwnerEmail`); the agent_assertion path never provisions a `users` row, so email-form owners match directly.

2. **Gate auto-pass for owner-minted links** — a stream token minted through the session owner's own authenticated call (`POST /sessions/:id/short-link`) already proves the identity the email gate asks the owner to re-type. New `POST /{vnc,cdp}/:sessionId/verify-token` mints the viewer cookie when the token's `user_id` matches the session owner (`federated:` prefix normalized), and the gate page auto-submits the fragment token on load — falling back to the manual email form when rejected. Tokens minted by other consumers (`agent:{profile}` from session-status) still hit the manual gate. `openStream` honors owner-proving tokens when they arrive via query param (server-to-server path).

3. **CDP viewer dropped punctuation** — the key relay derived `windowsVirtualKeyCode` from `charCodeAt`, so `.` (46) became VK_DELETE and `-` (45) VK_INSERT: the remote browser deleted text instead of typing. Punctuation now maps through `VK_OEM_*` codes (`PUNCT_VK`); unknown printable chars send vk 0 with the `text` param.

## Testing

- Build + unit tests green (pre-commit hook)
- Live e2e: agent-harness login HITL against GitHub and Spendflo test env through the CDP viewer — gate auto-passes from the short-link, `.`/`-`/`,` type correctly, email-gate fallback verified with a non-matching token

🤖 Generated with [Claude Code](https://claude.com/claude-code)