### PR TITLE
fix: short-link passes owner-minted token to viewer instead of forcing OAuth

### DIFF
--- a/apps/api/src/modules/streaming/streaming.controller.ts
+++ b/apps/api/src/modules/streaming/streaming.controller.ts
@@ -354,21 +354,18 @@ export class ShortLinkController {
         }
       }
 
-      // No valid cookie: redirect to OAuth login with post_login set to this short-link.
-      // No fallback to the bootstrap-admin tenant — each tenant must configure its own IdP.
-      if (session) {
-        const idp = await this.idpRepo.findOne({
-          where: { enabled: true, auth_url: Not(IsNull()) },
-        });
-        if (idp) {
-          const postLogin = `/s/${shortId}`;
-          res.redirect(302, `${PUBLIC_BASE_URL}/auth/oauth/${idp.id}/login?post_login=${encodeURIComponent(postLogin)}`);
-          return;
-        }
-      }
+      // No valid cookie: redirect to the stored viewer URL (which carries the
+      // #token fragment) rather than jumping straight to the IdP. The viewer's
+      // openStream → bridge page attempts verify-token first, so an owner-minted
+      // stream token (e.g. from the harness's own short-link call) auto-passes
+      // without an OAuth round-trip, and only non-owner-proving tokens fall
+      // through to the IdP. Previously this branch went directly to OAuth, which
+      // never exposed the fragment token to the client and so defeated the
+      // auto-pass — forcing OAuth (and its tenant resolution) even for the owner.
     }
 
-    // No session context or no OAuth configured: redirect directly
+    // No valid cookie, no session context, or no OAuth configured: redirect to
+    // the stored viewer URL and let the viewer page resolve auth.
     res.redirect(302, url);
   }
 }


### PR DESCRIPTION
## Summary

Completes the owner-minted-token auto-pass chain (#96, #98) for the agent-harness `call_web_api` login-HITL flow on cloud.

The `/s/{shortId}` short-link handler resolves the stored viewer URL (which carries the `#token` fragment), but when there's no `tabby_vnc` cookie it redirected **straight to the IdP** — so the fragment token never reached the client, and the viewer's `verify-token` auto-pass (#98) could never fire. An owner-minted link (the harness's own `short-link` call) was forced through a full OAuth round-trip and its tenant resolution, even though the token already proved ownership.

The no-cookie branch now redirects to the **stored viewer URL** and lets the viewer page resolve auth: `openStream` → bridge attempts `verify-token` first (owner-minted token auto-passes, no IdP), falling through to OAuth only for non-owner-proving tokens (e.g. `agent:{profile}` consumer tokens).

## Why this was invisible until cloud

Locally there's no IdP, so the viewer used the email-gate path and the short link redirected directly to the stored URL (final fallback). On dev/prod the IdP is configured, so the no-cookie branch took the OAuth detour — which is where the auto-pass was being short-circuited.

## Testing

- Build green
- Traced on dev: `/s/{id}` was returning `302 → /auth/oauth/.../login` with no cookie; after this change it returns `302 → /cdp/{id}#token=…` so the bridge can verify-token
- End-to-end cloud Spendflo login-HITL to be confirmed after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)