### PR TITLE
fix(infra): persist egress-proxy allowlist entries for Frontegg-hosted logins

### DIFF
--- a/infra/tfy/deploy.yaml
+++ b/infra/tfy/deploy.yaml
@@ -326,8 +326,6 @@ values:
       - ".workday.com"
       - ".workdaycdn.com"
       # --- Adopt platform assets + Frontegg-hosted logins (Spendflo etc.) ---
-      # These were applied via kubectl set env during the 2026-06 blank-screen
-      # incident but never persisted; every chart deploy reverted them.
       - ".adopt.ai"
       - ".frontegg.com"
       - ".spendflo.com"

--- a/infra/tfy/deploy.yaml
+++ b/infra/tfy/deploy.yaml
@@ -325,6 +325,15 @@ values:
       # --- Workday ---
       - ".workday.com"
       - ".workdaycdn.com"
+      # --- Adopt platform assets + Frontegg-hosted logins (Spendflo etc.) ---
+      # These were applied via kubectl set env during the 2026-06 blank-screen
+      # incident but never persisted; every chart deploy reverted them.
+      - ".adopt.ai"
+      - ".frontegg.com"
+      - ".spendflo.com"
+      - ".googleusercontent.com"
+      # --- BeyondRisk / Adopt Bank demo VM (exact host, kept narrow) ---
+      - ".nearby-nifty.eastus2.cloudapp.azure.com"
 
   ingress:
     enabled: false


### PR DESCRIPTION
## Problem

The Spendflo CDP viewer is blank-white again on dev: the HTML shell loads but the Frontegg-hosted login SPA never paints, because the egress proxy blocks `spendflo.frontegg.com` / `cdn.adopt.ai`.

This was fixed during the 2026-06 blank-screen incident via `kubectl set env deploy/tabby-dev-browser-hitl-egress-proxy EGRESS_PROXY_DEFAULT_ALLOWLIST=...` — but that env edit was never persisted to `infra/tfy/deploy.yaml`, so the chart deploys since (1.9.3 → 1.10.0) reverted it.

## Fix

Persist the missing entries in `egressProxy.defaultAllowlist`:
- `.adopt.ai`, `.frontegg.com`, `.spendflo.com`, `.googleusercontent.com` (Frontegg-hosted login flow; the Google asset + MSFT domains were already present)
- `.nearby-nifty.eastus2.cloudapp.azure.com` — the BeyondRisk/Adopt Bank demo VM used by the agent-harness `call_web_api` e2e, kept as an exact host rather than `.cloudapp.azure.com`

## Notes

- Separate known issue (not addressed here): per-session `target_urls` → proxy allowlist sync is partial, which is why these need to be in the default list at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)