### PR TITLE
fix(helm): propagate imagePullSecrets to infra statefulsets

### DIFF
--- a/charts/browser-hitl/templates/minio-statefulset.yaml
+++ b/charts/browser-hitl/templates/minio-statefulset.yaml
@@ -22,6 +22,7 @@ spec:
         {{- include "browser-hitl.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: minio
     spec:
+      {{- include "browser-hitl.imagePullSecrets" . | nindent 6 }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/charts/browser-hitl/templates/nats-statefulset.yaml
+++ b/charts/browser-hitl/templates/nats-statefulset.yaml
@@ -22,6 +22,7 @@ spec:
         {{- include "browser-hitl.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: nats
     spec:
+      {{- include "browser-hitl.imagePullSecrets" . | nindent 6 }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/charts/browser-hitl/templates/postgres-statefulset.yaml
+++ b/charts/browser-hitl/templates/postgres-statefulset.yaml
@@ -22,6 +22,7 @@ spec:
         {{- include "browser-hitl.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: postgres
     spec:
+      {{- include "browser-hitl.imagePullSecrets" . | nindent 6 }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 999

--- a/charts/browser-hitl/templates/redis-deployment.yaml
+++ b/charts/browser-hitl/templates/redis-deployment.yaml
@@ -22,6 +22,7 @@ spec:
         {{- include "browser-hitl.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: redis
     spec:
+      {{- include "browser-hitl.imagePullSecrets" . | nindent 6 }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 999


### PR DESCRIPTION
## Summary

- `nats`, `postgres`, `redis`, and `minio` StatefulSets/Deployments were missing the `browser-hitl.imagePullSecrets` helper
- This caused `ImagePullBackOff` on these pods when `global.imagePullSecrets` is set for a private registry
- All 7 application deployments (api, controller, slack-bot, teams-bot, admin-ui, egress-proxy, backup-cronjob) already had the helper — this brings the infra workloads in line

## Test plan

- [ ] Set `global.imagePullSecrets` in your values and confirm pods start without `ImagePullBackOff`
- [ ] `helm lint charts/browser-hitl/` passes (already verified locally)
- [ ] If `global.imagePullSecrets` is empty, the helper emits nothing — no regression for deployments without a pull secret