### PR TITLE
feat: auto-resolve HITL confirm steps when login detected via URL pattern

### DIFF
--- a/apps/api/src/modules/streaming/stream-token.service.ts
+++ b/apps/api/src/modules/streaming/stream-token.service.ts
@@ -182,4 +182,9 @@ export class StreamTokenService implements OnModuleDestroy {
     const payload = JSON.stringify({ input_type: inputType, value });
     await this.redis.set(redisKey, payload, 'EX', REDIS_TTL.HUMAN_INPUT_SECONDS);
   }
+
+  async isHitlAutoResolved(sessionId: string): Promise<boolean> {
+    const val = await this.redis.get(REDIS_KEYS.hitlAutoResolved(sessionId));
+    return val !== null;
+  }
 }

--- a/apps/api/src/modules/streaming/streaming.controller.spec.ts
+++ b/apps/api/src/modules/streaming/streaming.controller.spec.ts
@@ -92,6 +92,7 @@ describe('StreamingController — panel-state', () => {
       }),
       generateToken: jest.fn().mockResolvedValue('new-token'),
       isStreamRevoked: jest.fn().mockResolvedValue(false),
+      isHitlAutoResolved: jest.fn().mockResolvedValue(false),
     };
 
     const module: TestingModule = await buildModule({ sessionRepo, interventionRepo, streamTokenService });

--- a/apps/api/src/modules/streaming/streaming.controller.ts
+++ b/apps/api/src/modules/streaming/streaming.controller.ts
@@ -1165,13 +1165,19 @@ export class StreamingController {
     // Redis key. Fall back to the latest intervention's input_request_metadata
     // so the resolve button can POST the correct step_index — same pattern
     // used by AgentService.getSessionStatus.
+    // Skip the fallback when the worker auto-resolved the HITL (login detected
+    // via URL pattern match) — the DSL is still running but human input is no
+    // longer needed.
     let pendingInput = session.pending_input_request as Record<string, unknown> | null;
     if (!pendingInput && (session.state === 'LOGIN_IN_PROGRESS' || session.state === 'LOGIN_NEEDED')) {
-      const latestIntervention = await this.interventionRepo.findOne({
-        where: { session_id: sessionId },
-        order: { started_at: 'DESC' },
-      });
-      pendingInput = latestIntervention?.input_request_metadata ?? null;
+      const autoResolved = await this.streamTokenService.isHitlAutoResolved(sessionId);
+      if (!autoResolved) {
+        const latestIntervention = await this.interventionRepo.findOne({
+          where: { session_id: sessionId },
+          order: { started_at: 'DESC' },
+        });
+        pendingInput = latestIntervention?.input_request_metadata ?? null;
+      }
     }
 
     return {
@@ -1394,11 +1400,14 @@ export class StreamingController {
 
     let pendingInput = session.pending_input_request as Record<string, unknown> | null;
     if (!pendingInput && (session.state === 'LOGIN_IN_PROGRESS' || session.state === 'LOGIN_NEEDED')) {
-      const latestIntervention = await this.interventionRepo.findOne({
-        where: { session_id: sessionId },
-        order: { started_at: 'DESC' },
-      });
-      pendingInput = latestIntervention?.input_request_metadata ?? null;
+      const autoResolved = await this.streamTokenService.isHitlAutoResolved(sessionId);
+      if (!autoResolved) {
+        const latestIntervention = await this.interventionRepo.findOne({
+          where: { session_id: sessionId },
+          order: { started_at: 'DESC' },
+        });
+        pendingInput = latestIntervention?.input_request_metadata ?? null;
+      }
     }
 
     return {

--- a/apps/worker/src/input-relay.ts
+++ b/apps/worker/src/input-relay.ts
@@ -1,5 +1,5 @@
 import Redis from 'ioredis';
-import { REDIS_KEYS, requireEnv } from '@browser-hitl/shared';
+import { REDIS_KEYS, REDIS_TTL, requireEnv } from '@browser-hitl/shared';
 
 /**
  * Generic Human Input Relay.
@@ -25,10 +25,13 @@ export class InputRelay {
   /**
    * Poll for human input value from Redis.
    * Returns the parsed input when available, null on timeout.
+   * When autoResolveCheck is provided, also evaluates it each cycle —
+   * if it returns true the wait is resolved as a synthetic confirm.
    */
   async waitForInput(
     stepIndex: number,
     timeoutMs: number = 120000,
+    autoResolveCheck?: () => boolean,
   ): Promise<{ input_type: string; value: string } | null> {
     const redis = this.getRedis();
     const key = REDIS_KEYS.humanInput(this.sessionId, stepIndex);
@@ -47,11 +50,32 @@ export class InputRelay {
         }
       }
 
+      if (autoResolveCheck) {
+        try {
+          if (autoResolveCheck()) {
+            console.log(`[InputRelay] Auto-resolved: login detected for step ${stepIndex}`);
+            return { input_type: 'confirm', value: 'auto-resolved' };
+          }
+        } catch {
+          // Page might not be ready — ignore and retry next cycle
+        }
+      }
+
       // Poll at 1-second interval
       await new Promise(resolve => setTimeout(resolve, 1000));
     }
 
     return null; // Timeout
+  }
+
+  async markAutoResolved(): Promise<void> {
+    const redis = this.getRedis();
+    await redis.set(
+      REDIS_KEYS.hitlAutoResolved(this.sessionId),
+      '1',
+      'EX',
+      REDIS_TTL.HUMAN_INPUT_SECONDS,
+    );
   }
 
   async disconnect(): Promise<void> {

--- a/apps/worker/src/login-dsl-runner.spec.ts
+++ b/apps/worker/src/login-dsl-runner.spec.ts
@@ -434,7 +434,7 @@ describe('LoginDslRunner', () => {
           step_index: 0,
         }),
       );
-      expect(inputRelay.waitForInput).toHaveBeenCalledWith(0, expect.any(Number));
+      expect(inputRelay.waitForInput).toHaveBeenCalledWith(0, expect.any(Number), undefined);
     });
 
     it('skips step on on_failure: skip and continues to next step', async () => {

--- a/apps/worker/src/login-dsl-runner.ts
+++ b/apps/worker/src/login-dsl-runner.ts
@@ -3,6 +3,20 @@ import { DslStep, RequestHumanInputStep, InputRequest } from '@browser-hitl/shar
 import { InputRelay } from './input-relay';
 
 /**
+ * Convert a URL glob (as used by wait_for_url) to a RegExp.
+ * Handles ** (any path segment), * (single segment), and ? (single char).
+ */
+function urlGlobToRegex(pattern: string): RegExp {
+  const re = pattern
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*\*/g, '\0')
+    .replace(/\*/g, '[^/]*')
+    .replace(/\0/g, '.*')
+    .replace(/\?/g, '[^/]');
+  return new RegExp(re);
+}
+
+/**
  * Login DSL Runner - executes all DSL actions per spec section 10.3.
  * Steps execute sequentially and are blocking.
  * Frame context persists across steps until explicitly changed.
@@ -12,6 +26,7 @@ export class LoginDslRunner {
   private readonly allowEvaluate: boolean;
   private readonly onInputRequested: ((request: InputRequest) => Promise<void> | void) | undefined;
   private readonly variables: Map<string, string> = new Map();
+  private allSteps: DslStep[] = [];
 
   constructor(
     private readonly page: Page,
@@ -41,6 +56,7 @@ export class LoginDslRunner {
     steps: DslStep[],
     credentials: { username: string; password: string },
   ): Promise<void> {
+    this.allSteps = steps;
     for (let i = 0; i < steps.length; i++) {
       const step = steps[i];
       const timeout = step.timeout_ms || 30000;
@@ -249,7 +265,14 @@ export class LoginDslRunner {
 
         // Poll for human response — on_failure has its own timeout, independent of the step's action timeout
         const timeoutMs = handler.timeout_ms || 600000;
-        const response = await this.inputRelay.waitForInput(stepIndex, timeoutMs);
+        const autoResolve = inputType === 'confirm'
+          ? this.buildAutoResolveCheck(stepIndex)
+          : undefined;
+        const response = await this.inputRelay.waitForInput(stepIndex, timeoutMs, autoResolve);
+
+        if (response?.value === 'auto-resolved') {
+          await this.inputRelay.markAutoResolved();
+        }
 
         if (!response) {
           console.warn(`Help request timeout for step ${stepIndex}`);
@@ -281,8 +304,29 @@ export class LoginDslRunner {
   }
 
   /**
+   * Build a synchronous auto-resolve checker for "confirm" HITL steps.
+   * Scans forward from fromStepIndex for the nearest wait_for_url step and
+   * returns a function that checks page.url() against its glob pattern.
+   * Stops scanning at goto / request_human_input steps (those change context).
+   */
+  private buildAutoResolveCheck(fromStepIndex: number): (() => boolean) | undefined {
+    for (let i = fromStepIndex + 1; i < this.allSteps.length; i++) {
+      const next = this.allSteps[i];
+      if (next.action === 'wait_for_url' && next.pattern) {
+        const regex = urlGlobToRegex(next.pattern);
+        console.log(`[DSL] Auto-resolve enabled for step ${fromStepIndex}: URL pattern "${next.pattern}"`);
+        return () => regex.test(this.page.url());
+      }
+      if (next.action === 'goto' || next.action === 'request_human_input') break;
+    }
+    return undefined;
+  }
+
+  /**
    * Handle a generic human input request step.
    * Signals controller, polls Redis for the response, then acts on it.
+   * For "confirm" type, also enables auto-resolve when the next wait_for_url
+   * pattern already matches (user finished login before clicking resolve).
    */
   private async handleHumanInputRequest(
     step: RequestHumanInputStep,
@@ -307,9 +351,16 @@ export class LoginDslRunner {
       }
     }
 
-    // Poll for human input
+    // Poll for human input (with auto-resolve for confirm steps)
     const timeoutMs = step.timeout_ms || 120000;
-    const response = await this.inputRelay.waitForInput(stepIndex, timeoutMs);
+    const autoResolve = step.input_type === 'confirm'
+      ? this.buildAutoResolveCheck(stepIndex)
+      : undefined;
+    const response = await this.inputRelay.waitForInput(stepIndex, timeoutMs, autoResolve);
+
+    if (response?.value === 'auto-resolved') {
+      await this.inputRelay.markAutoResolved();
+    }
 
     if (!response) {
       throw new Error(`Human input timeout - no value received for "${step.label}"`);
@@ -321,7 +372,7 @@ export class LoginDslRunner {
         await this.page.goto(response.value);
         break;
       case 'confirm':
-        // Human resolved via VNC, nothing to do
+        // Human resolved via VNC (or auto-resolved), nothing to do
         break;
       default:
         // Fill the value into the field
@@ -334,7 +385,7 @@ export class LoginDslRunner {
         break;
     }
 
-    console.log(`Human input received and processed: type=${response.input_type}`);
+    console.log(`Human input received and processed: type=${response.input_type}${response.value === 'auto-resolved' ? ' (auto-resolved)' : ''}`);
   }
 
   /**

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -76,6 +76,7 @@ export const REDIS_KEYS = {
   tokenRevoked: (jti: string) => `token:revoked:${jti}`,
   agentIdempotency: (tenantId: string, key: string) => `idempotency:agent:run-url:${tenantId}:${key}`,
   streamRevoked: (sessionId: string) => `stream_revoked:${sessionId}`,
+  hitlAutoResolved: (sessionId: string) => `hitl_auto_resolved:${sessionId}`,
 } as const;
 
 export const REDIS_TTL = {


### PR DESCRIPTION
## Summary

AA team requested that login sessions auto-resolve after the user completes login, without requiring them to click "Mark as Resolved". This was a pain point for every manual login flow (Salesforce, etc.).

**How it works:**
- During `request_human_input` confirm steps, the worker now checks `page.url()` against the next `wait_for_url` glob pattern every 1 second
- When the URL matches (user finished login and landed on the expected page), the HITL step auto-resolves
- A Redis flag (`hitl_auto_resolved:{sessionId}`, 300s TTL) tells the `panel-state` API endpoint to stop returning the intervention metadata as pending input
- The "Mark as Resolved" button disappears from the VNC viewer and adoptwebui tabby-viewer within the next poll cycle (3-5s)

**No migration needed. No template changes required.** Existing templates with `request_human_input` → `wait_for_url` patterns automatically benefit.

The `on_failure: request_help` with `input_type: confirm` also gets auto-resolve via the same look-ahead mechanism.

### Files changed

| File | Change |
|------|--------|
| `packages/shared/src/constants.ts` | New Redis key `hitlAutoResolved` |
| `apps/worker/src/input-relay.ts` | `autoResolveCheck` callback in poll loop + `markAutoResolved()` |
| `apps/worker/src/login-dsl-runner.ts` | URL glob matcher, look-ahead logic in `handleHumanInputRequest` and `handleOnFailure` |
| `apps/api/src/modules/streaming/stream-token.service.ts` | `isHitlAutoResolved()` Redis check |
| `apps/api/src/modules/streaming/streaming.controller.ts` | Both `hitl-state` and `panel-state` endpoints skip intervention fallback when auto-resolved |

### adoptwebui impact

**No changes needed.** The tabby-viewer component drives the button from `panelState.pending_input_request` which comes from the same `panel-state` endpoint. When auto-resolved, the endpoint returns `null` → button hides automatically.

## Test plan

- [x] Build passes (`pnpm run build`)
- [x] All 704 tests pass (`pnpm run test`)
- [x] Existing `login-dsl-runner.spec.ts` assertion updated for new `waitForInput` signature
- [x] `streaming.controller.spec.ts` mock updated with `isHitlAutoResolved`
- [ ] Manual: create session with Salesforce template → log in via VNC → confirm auto-resolve fires and button disappears
- [ ] Manual: verify manual "Mark as Resolved" still works when auto-resolve doesn't trigger