### PR TITLE
feat: error handling, egress fixes, and template propagation

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ThrottlerModule } from '@nestjs/throttler';
 import { ScheduleModule } from '@nestjs/schedule';
@@ -15,8 +15,10 @@ import { StreamingModule } from './modules/streaming/streaming.module';
 import { ObservabilityModule } from './modules/observability/observability.module';
 import { NatsAclModule } from './modules/nats/nats-acl.module';
 import { BootstrapModule } from './modules/auth/bootstrap.module';
-import { APP_GUARD } from '@nestjs/core';
+import { APP_FILTER, APP_GUARD } from '@nestjs/core';
 import { UserThrottlerGuard } from './common/guards/user-throttler.guard';
+import { GlobalExceptionFilter } from './common/filters/http-exception.filter';
+import { CorrelationIdMiddleware } from './common/middleware/correlation-id.middleware';
 import { EventsModule } from './modules/events/events.module';
 import { AgentModule } from './modules/agent/agent.module';
 import { LifecycleModule } from './modules/lifecycle/lifecycle.module';
@@ -68,9 +70,17 @@ import { RecordingProvisionModule } from './modules/recording/recording-provisio
   ],
   providers: [
     {
+      provide: APP_FILTER,
+      useClass: GlobalExceptionFilter,
+    },
+    {
       provide: APP_GUARD,
       useClass: UserThrottlerGuard,
     },
   ],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(CorrelationIdMiddleware).forRoutes('*');
+  }
+}

--- a/apps/api/src/common/exceptions/domain.exceptions.ts
+++ b/apps/api/src/common/exceptions/domain.exceptions.ts
@@ -1,0 +1,53 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+export class TabbyDomainException extends HttpException {
+  public readonly domainCode: string;
+
+  constructor(
+    domainCode: string,
+    message: string,
+    statusCode: number,
+    details?: Record<string, unknown>,
+  ) {
+    super({ message, code: domainCode, ...(details ? { details } : {}) }, statusCode);
+    this.domainCode = domainCode;
+  }
+}
+
+export class BatonConflictException extends TabbyDomainException {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('BATON_CONFLICT', message, HttpStatus.CONFLICT, details);
+  }
+}
+
+export class SessionStateException extends TabbyDomainException {
+  constructor(message: string, currentState: string, expectedStates: string[]) {
+    super('SESSION_STATE_INVALID', message, HttpStatus.BAD_REQUEST, {
+      current_state: currentState,
+      expected_states: expectedStates,
+    });
+  }
+}
+
+export class NoHealthySessionException extends TabbyDomainException {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('NO_HEALTHY_SESSION', message, HttpStatus.NOT_FOUND, details);
+  }
+}
+
+export class ProfileNotFoundException extends TabbyDomainException {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('PROFILE_NOT_FOUND', message, HttpStatus.NOT_FOUND, details);
+  }
+}
+
+export class CredentialDecryptException extends TabbyDomainException {
+  constructor(details?: Record<string, unknown>) {
+    super(
+      'CREDENTIAL_DECRYPT_FAILED',
+      'Failed to decrypt credential bundle',
+      HttpStatus.INTERNAL_SERVER_ERROR,
+      details,
+    );
+  }
+}

--- a/apps/api/src/common/filters/http-exception.filter.spec.ts
+++ b/apps/api/src/common/filters/http-exception.filter.spec.ts
@@ -1,0 +1,257 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpException, HttpStatus, BadRequestException, NotFoundException, ForbiddenException, InternalServerErrorException } from '@nestjs/common';
+import { GlobalExceptionFilter } from './http-exception.filter';
+import { TabbyDomainException, BatonConflictException, NoHealthySessionException, CredentialDecryptException } from '../exceptions/domain.exceptions';
+import * as Sentry from '@sentry/node';
+
+jest.mock('@sentry/node', () => ({
+  withScope: jest.fn((cb) => cb({
+    setTag: jest.fn(),
+    setExtra: jest.fn(),
+  })),
+  captureException: jest.fn(),
+}));
+
+describe('GlobalExceptionFilter', () => {
+  let filter: GlobalExceptionFilter;
+
+  const mockRequest = (overrides: Record<string, any> = {}) => ({
+    method: 'GET',
+    url: '/test',
+    path: '/test',
+    headers: { accept: 'application/json' },
+    correlationId: 'test-corr-id',
+    user: { tenant_id: 'tenant-1' },
+    ...overrides,
+  });
+
+  const mockResponse = () => {
+    const res: any = {
+      headersSent: false,
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+      send: jest.fn().mockReturnThis(),
+    };
+    return res;
+  };
+
+  const mockHost = (req: any, res: any) => ({
+    switchToHttp: () => ({
+      getRequest: () => req,
+      getResponse: () => res,
+    }),
+  } as any);
+
+  beforeEach(async () => {
+    filter = new GlobalExceptionFilter();
+    jest.clearAllMocks();
+  });
+
+  it('returns { error: { code, message } } for NotFoundException', () => {
+    const req = mockRequest();
+    const res = mockResponse();
+    const exception = new NotFoundException('App not found');
+
+    filter.catch(exception, mockHost(req, res));
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({
+      error: { code: 'NOT_FOUND', message: 'App not found' },
+    });
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it('returns { error: { code, message } } for ForbiddenException', () => {
+    const req = mockRequest();
+    const res = mockResponse();
+    const exception = new ForbiddenException('Access denied');
+
+    filter.catch(exception, mockHost(req, res));
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      error: { code: 'FORBIDDEN', message: 'Access denied' },
+    });
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it('handles validation errors with array messages', () => {
+    const req = mockRequest();
+    const res = mockResponse();
+    const exception = new BadRequestException({
+      message: ['email must be an email', 'password should not be empty'],
+      error: 'Bad Request',
+      statusCode: 400,
+    });
+
+    filter.catch(exception, mockHost(req, res));
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: 'email must be an email',
+        details: {
+          validation_errors: ['email must be an email', 'password should not be empty'],
+        },
+      },
+    });
+  });
+
+  it('captures 5xx to Sentry with correlation ID and tenant', () => {
+    const req = mockRequest();
+    const res = mockResponse();
+    const exception = new InternalServerErrorException('Something broke');
+
+    filter.catch(exception, mockHost(req, res));
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(Sentry.withScope).toHaveBeenCalled();
+    expect(Sentry.captureException).toHaveBeenCalled();
+
+    const body = res.json.mock.calls[0][0];
+    expect(body.error.code).toBe('INTERNAL_ERROR');
+    expect(body.request_id).toBe('test-corr-id');
+  });
+
+  it('does not include request_id in 4xx responses', () => {
+    const req = mockRequest();
+    const res = mockResponse();
+    const exception = new NotFoundException('Not found');
+
+    filter.catch(exception, mockHost(req, res));
+
+    const body = res.json.mock.calls[0][0];
+    expect(body.request_id).toBeUndefined();
+  });
+
+  it('captures non-HttpException as 500', () => {
+    const req = mockRequest();
+    const res = mockResponse();
+    const exception = new Error('Unexpected crash');
+
+    filter.catch(exception, mockHost(req, res));
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: { code: 'INTERNAL_ERROR', message: 'Internal server error' },
+        request_id: 'test-corr-id',
+      }),
+    );
+    expect(Sentry.captureException).toHaveBeenCalled();
+  });
+
+  it('handles TabbyDomainException with domainCode', () => {
+    const req = mockRequest();
+    const res = mockResponse();
+    const exception = new BatonConflictException('Baton is held by another user', {
+      baton_state: 'HUMAN_CONTROL',
+    });
+
+    filter.catch(exception, mockHost(req, res));
+
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json).toHaveBeenCalledWith({
+      error: {
+        code: 'BATON_CONFLICT',
+        message: 'Baton is held by another user',
+        details: { baton_state: 'HUMAN_CONTROL' },
+      },
+    });
+  });
+
+  it('handles NoHealthySessionException', () => {
+    const req = mockRequest();
+    const res = mockResponse();
+    const exception = new NoHealthySessionException('No healthy session available', {
+      profile_id: 'prof-1',
+    });
+
+    filter.catch(exception, mockHost(req, res));
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({
+      error: {
+        code: 'NO_HEALTHY_SESSION',
+        message: 'No healthy session available',
+        details: { profile_id: 'prof-1' },
+      },
+    });
+  });
+
+  it('captures CredentialDecryptException to Sentry (5xx)', () => {
+    const req = mockRequest();
+    const res = mockResponse();
+    const exception = new CredentialDecryptException({ artifact_id: 'art-1' });
+
+    filter.catch(exception, mockHost(req, res));
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(Sentry.captureException).toHaveBeenCalled();
+    const body = res.json.mock.calls[0][0];
+    expect(body.error.code).toBe('CREDENTIAL_DECRYPT_FAILED');
+    expect(body.request_id).toBe('test-corr-id');
+  });
+
+  it('does not double-send if headers already sent', () => {
+    const req = mockRequest();
+    const res = mockResponse();
+    res.headersSent = true;
+    const exception = new NotFoundException('Not found');
+
+    filter.catch(exception, mockHost(req, res));
+
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it('renders HTML for streaming routes when Accept is text/html', () => {
+    const req = mockRequest({
+      path: '/vnc/some-session-id',
+      headers: { accept: 'text/html' },
+    });
+    const res = mockResponse();
+    const exception = new ForbiddenException('Access denied');
+
+    filter.catch(exception, mockHost(req, res));
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.send).toHaveBeenCalled();
+    const html = res.send.mock.calls[0][0];
+    expect(html).toContain('<!doctype html>');
+    expect(html).toContain('Access denied');
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it('returns JSON for streaming routes when Accept is application/json', () => {
+    const req = mockRequest({
+      path: '/vnc/some-session-id',
+      headers: { accept: 'application/json' },
+    });
+    const res = mockResponse();
+    const exception = new NotFoundException('Session not found');
+
+    filter.catch(exception, mockHost(req, res));
+
+    expect(res.json).toHaveBeenCalled();
+    expect(res.send).not.toHaveBeenCalled();
+  });
+
+  it('preserves extra fields from ConflictException object body', () => {
+    const req = mockRequest();
+    const res = mockResponse();
+    const exception = new HttpException(
+      { message: 'HITL pause active', retry_after_seconds: 180 },
+      HttpStatus.CONFLICT,
+    );
+
+    filter.catch(exception, mockHost(req, res));
+
+    expect(res.status).toHaveBeenCalledWith(409);
+    const body = res.json.mock.calls[0][0];
+    expect(body.error.code).toBe('CONFLICT');
+    expect(body.error.message).toBe('HITL pause active');
+    expect(body.error.details).toEqual({ retry_after_seconds: 180 });
+  });
+});

--- a/apps/api/src/common/filters/http-exception.filter.ts
+++ b/apps/api/src/common/filters/http-exception.filter.ts
@@ -2,6 +2,8 @@ import { ExceptionFilter, Catch, ArgumentsHost, HttpException, HttpStatus, Logge
 import { Response, Request } from 'express';
 import * as Sentry from '@sentry/node';
 
+const STREAMING_PATH_RE = /^\/(vnc|cdp)\//;
+
 @Catch()
 export class GlobalExceptionFilter implements ExceptionFilter {
   private readonly logger = new Logger(GlobalExceptionFilter.name);
@@ -10,6 +12,8 @@ export class GlobalExceptionFilter implements ExceptionFilter {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
     const request = ctx.getRequest<Request>();
+
+    if (response.headersSent) return;
 
     let status = HttpStatus.INTERNAL_SERVER_ERROR;
     let code = 'INTERNAL_ERROR';
@@ -22,40 +26,84 @@ export class GlobalExceptionFilter implements ExceptionFilter {
 
       if (typeof body === 'object' && body !== null) {
         const obj = body as Record<string, unknown>;
-        message = (obj.message as string) || exception.message;
-        if (Array.isArray(obj.message)) {
+
+        if ((exception as any).domainCode) {
+          code = (exception as any).domainCode;
+          message = (obj.message as string) || exception.message;
+          if (obj.details) details = obj.details as Record<string, unknown>;
+        } else if (Array.isArray(obj.message)) {
+          code = 'VALIDATION_ERROR';
           message = obj.message[0];
           details = { validation_errors: obj.message };
+        } else {
+          message = (obj.message as string) || exception.message;
+          const { message: _m, statusCode: _s, error: _e, ...rest } = obj;
+          if (Object.keys(rest).length > 0) details = rest;
         }
       } else {
         message = String(body);
       }
 
-      switch (status) {
-        case 400: code = 'VALIDATION_ERROR'; break;
-        case 401: code = 'UNAUTHORIZED'; break;
-        case 403: code = 'FORBIDDEN'; break;
-        case 404: code = 'NOT_FOUND'; break;
-        case 409: code = 'CONFLICT'; break;
-        case 429: code = 'RATE_LIMITED'; break;
-        default: code = 'INTERNAL_ERROR';
+      if (!(exception as any).domainCode) {
+        switch (status) {
+          case 400: code = 'VALIDATION_ERROR'; break;
+          case 401: code = 'UNAUTHORIZED'; break;
+          case 403: code = 'FORBIDDEN'; break;
+          case 404: code = 'NOT_FOUND'; break;
+          case 409: code = 'CONFLICT'; break;
+          case 429: code = 'RATE_LIMITED'; break;
+          case 502: code = 'BAD_GATEWAY'; break;
+          case 504: code = 'GATEWAY_TIMEOUT'; break;
+          default: if (status >= 500) code = 'INTERNAL_ERROR';
+        }
       }
     }
 
-    // Send 5xx errors to Sentry for alerting
+    const correlationId: string | undefined = (request as any).correlationId;
+
     if (status >= 500) {
       Sentry.withScope((scope) => {
         scope.setTag('http.method', request.method);
         scope.setTag('http.url', request.url);
         scope.setTag('http.status_code', String(status));
-        scope.setExtra('body', request.body);
+        if (correlationId) scope.setTag('correlation_id', correlationId);
+        const user = (request as any).user;
+        if (user?.tenant_id) scope.setTag('tenant_id', user.tenant_id);
         Sentry.captureException(exception instanceof Error ? exception : new Error(message));
       });
-      this.logger.error(`${request.method} ${request.url} → ${status}: ${message}`, exception instanceof Error ? exception.stack : undefined);
+      this.logger.error(
+        `${request.method} ${request.url} → ${status}: ${message}` +
+        (correlationId ? ` [${correlationId}]` : ''),
+        exception instanceof Error ? exception.stack : undefined,
+      );
     }
 
-    response.status(status).json({
+    if (status >= 400 && STREAMING_PATH_RE.test(request.path)) {
+      const accept = request.headers.accept || '';
+      if (accept.includes('text/html') && !accept.includes('application/json')) {
+        response.status(status).send(renderHtmlError(status, message));
+        return;
+      }
+    }
+
+    const body: Record<string, unknown> = {
       error: { code, message, ...(details ? { details } : {}) },
-    });
+    };
+    if (status >= 500 && correlationId) {
+      body.request_id = correlationId;
+    }
+
+    response.status(status).json(body);
   }
+}
+
+function renderHtmlError(status: number, message: string): string {
+  const safe = message.replace(/[<>&"']/g, c =>
+    ({ '<': '&lt;', '>': '&gt;', '&': '&amp;', '"': '&quot;', "'": '&#39;' })[c]!,
+  );
+  return `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Error ${status}</title>
+<style>body{font-family:system-ui,sans-serif;display:flex;justify-content:center;align-items:center;min-height:100vh;margin:0;background:#0f172a;color:#e2e8f0}
+.box{text-align:center;max-width:400px;padding:2rem}.code{font-size:3rem;font-weight:700;color:#f87171}.msg{margin-top:1rem;color:#94a3b8}</style>
+</head><body><div class="box"><div class="code">${status}</div><div class="msg">${safe}</div></div></body></html>`;
 }

--- a/apps/api/src/common/middleware/correlation-id.middleware.spec.ts
+++ b/apps/api/src/common/middleware/correlation-id.middleware.spec.ts
@@ -1,0 +1,34 @@
+import { CorrelationIdMiddleware } from './correlation-id.middleware';
+
+describe('CorrelationIdMiddleware', () => {
+  let middleware: CorrelationIdMiddleware;
+
+  beforeEach(() => {
+    middleware = new CorrelationIdMiddleware();
+  });
+
+  it('uses incoming X-Request-ID header', () => {
+    const req: any = { headers: { 'x-request-id': 'incoming-123' } };
+    const res: any = { setHeader: jest.fn() };
+    const next = jest.fn();
+
+    middleware.use(req, res, next);
+
+    expect(req.correlationId).toBe('incoming-123');
+    expect(res.setHeader).toHaveBeenCalledWith('X-Request-ID', 'incoming-123');
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('generates UUID when no X-Request-ID header', () => {
+    const req: any = { headers: {} };
+    const res: any = { setHeader: jest.fn() };
+    const next = jest.fn();
+
+    middleware.use(req, res, next);
+
+    expect(req.correlationId).toBeDefined();
+    expect(req.correlationId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    expect(res.setHeader).toHaveBeenCalledWith('X-Request-ID', req.correlationId);
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/common/middleware/correlation-id.middleware.ts
+++ b/apps/api/src/common/middleware/correlation-id.middleware.ts
@@ -1,0 +1,13 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import { randomUUID } from 'crypto';
+
+@Injectable()
+export class CorrelationIdMiddleware implements NestMiddleware {
+  use(req: Request, _res: Response, next: NextFunction) {
+    const id = req.headers['x-request-id'] as string || randomUUID();
+    (req as any).correlationId = id;
+    _res.setHeader('X-Request-ID', id);
+    next();
+  }
+}

--- a/apps/api/src/common/types/express.d.ts
+++ b/apps/api/src/common/types/express.d.ts
@@ -1,0 +1,5 @@
+declare namespace Express {
+  interface Request {
+    correlationId: string;
+  }
+}

--- a/apps/api/src/modules/app-templates/app-templates.controller.ts
+++ b/apps/api/src/modules/app-templates/app-templates.controller.ts
@@ -79,6 +79,9 @@ class UpdateAppTemplateDto {
   @IsOptional() @IsBoolean() execute_enabled?: boolean;
   @ApiProperty({ required: false })
   @IsOptional() @IsInt() @Min(60) idle_shutdown_seconds?: number;
+  @ApiProperty({ required: false, description: 'Extra egress domains propagated to linked apps' })
+  @IsOptional() @IsArray() @IsString({ each: true })
+  extra_egress_allowlist?: string[];
 }
 
 @ApiTags('App Templates')

--- a/apps/api/src/modules/app-templates/app-templates.service.spec.ts
+++ b/apps/api/src/modules/app-templates/app-templates.service.spec.ts
@@ -144,6 +144,7 @@ describe('AppTemplatesService — propagation', () => {
         export_policy: template.export_policy,
         notification_config: template.notification_config,
         execute_enabled: template.execute_enabled,
+        extra_egress_allowlist: template.extra_egress_allowlist,
       };
 
       expect(appRepo.update).toHaveBeenCalledWith('app-1', expectedPayload);

--- a/apps/api/src/modules/app-templates/app-templates.service.ts
+++ b/apps/api/src/modules/app-templates/app-templates.service.ts
@@ -162,6 +162,7 @@ export class AppTemplatesService {
       const apps = await this.appRepo.find({
         where: { template_id: template.id },
         select: ['id'],
+        order: { id: 'ASC' },
         take: CHUNK_SIZE,
         skip: offset,
       });

--- a/apps/api/src/modules/app-templates/app-templates.service.ts
+++ b/apps/api/src/modules/app-templates/app-templates.service.ts
@@ -92,6 +92,7 @@ export class AppTemplatesService {
   private static readonly PROPAGATED_FIELDS = [
     'browser_policy', 'login_config', 'keepalive_config',
     'export_policy', 'notification_config', 'execute_enabled',
+    'extra_egress_allowlist',
   ] as const;
 
   /** Bump minor version, reset patch. e.g. "1.0.0" → "1.1.0", "2.5.3" → "2.6.0" */
@@ -114,6 +115,7 @@ export class AppTemplatesService {
       credential_ref_default: template.credential_ref_default,
       execute_enabled: template.execute_enabled,
       idle_shutdown_seconds: template.idle_shutdown_seconds,
+      extra_egress_allowlist: template.extra_egress_allowlist,
     };
     return createHash('sha256')
       .update(AppTemplatesService.stableStringify(fields))

--- a/apps/api/src/modules/credentials/credentials.service.ts
+++ b/apps/api/src/modules/credentials/credentials.service.ts
@@ -1,4 +1,9 @@
 import { ForbiddenException, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import {
+  NoHealthySessionException,
+  ProfileNotFoundException,
+  CredentialDecryptException,
+} from '../../common/exceptions/domain.exceptions';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, IsNull, MoreThan, Repository } from 'typeorm';
 import {
@@ -129,7 +134,7 @@ export class CredentialsService {
     try {
       session = await this.findHealthySession(tenantId, profile.app_id, ownerUserId);
     } catch (e) {
-      if (e instanceof NotFoundException && profile.app_id) {
+      if (e instanceof NoHealthySessionException && profile.app_id) {
         // No healthy session — check if app was idle-shutdown (desired_session_count=0)
         // If so, scale it back up so the controller creates a new session
         const app = await this.appRepo.findOne({ where: { id: profile.app_id } });
@@ -270,7 +275,7 @@ export class CredentialsService {
           throw err;
         }
       }
-      throw new NotFoundException(`No active profile found for "${profileId}"`);
+      throw new ProfileNotFoundException(`No active profile found for "${profileId}"`, { profile_id: profileId });
     }
 
     // Prefer ACTIVE over CANARY
@@ -372,7 +377,7 @@ export class CredentialsService {
 
     const session = await this.sessionRepo.findOne({ where });
     if (!session) {
-      throw new NotFoundException('No healthy session available');
+      throw new NoHealthySessionException('No healthy session available', { tenant_id: tenantId, app_id: appId });
     }
     return session;
   }
@@ -448,8 +453,8 @@ export class CredentialsService {
     try {
       decryptedJson = this.decryptBundle(encryptedBuf, nonceBuf);
     } catch (err) {
-      this.logger.warn(`Failed to decrypt artifact ${bundle.id}: ${(err as Error).message} (nonce type=${typeof bundle.nonce}, isBuffer=${Buffer.isBuffer(bundle.nonce)}, len=${nonceBuf.length})`);
-      return null;
+      this.logger.error(`Failed to decrypt artifact ${bundle.id}: ${(err as Error).message} (nonce type=${typeof bundle.nonce}, isBuffer=${Buffer.isBuffer(bundle.nonce)}, len=${nonceBuf.length})`);
+      throw new CredentialDecryptException({ artifact_id: bundle.id });
     } finally {
       // Zero the encrypted buffer
       encryptedBuf.fill(0);

--- a/apps/api/src/modules/events/events.gateway.ts
+++ b/apps/api/src/modules/events/events.gateway.ts
@@ -8,6 +8,7 @@ import {
 import { IncomingMessage } from 'http';
 import { NatsConnection, StringCodec, Subscription } from 'nats';
 import { requireEnv, connectNats } from '@browser-hitl/shared';
+import * as Sentry from '@sentry/node';
 import { AuthService } from '../auth/auth.service';
 import { AuditService } from '../audit/audit.service';
 import { ObservabilityService } from '../observability/observability.service';
@@ -148,6 +149,7 @@ export class EventsGateway
         }
       } catch (error) {
         this.logger.error(`Error processing NATS message on ${sub.getSubject()}: ${error}`);
+        Sentry.captureException(error instanceof Error ? error : new Error(String(error)));
       }
     }
   }

--- a/apps/api/src/modules/hitl/hitl.service.ts
+++ b/apps/api/src/modules/hitl/hitl.service.ts
@@ -3,10 +3,11 @@ import {
   NotFoundException,
   ConflictException,
   BadRequestException,
-  UnauthorizedException,
+  InternalServerErrorException,
   Logger,
   OnModuleDestroy,
 } from '@nestjs/common';
+import { BatonConflictException } from '../../common/exceptions/domain.exceptions';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, DataSource } from 'typeorm';
 import { SessionEntity, SessionBatonEntity, InterventionEntity } from '../../entities';
@@ -123,12 +124,15 @@ export class HitlService implements OnModuleDestroy {
       await this.applyBatonTimeoutState(manager, baton);
 
       if (baton.baton_state === 'HUMAN_CONTROL' && baton.owner_user_id !== actorId) {
-        throw new ConflictException('Baton is held by another user');
+        throw new BatonConflictException('Baton is held by another user', {
+          baton_state: baton.baton_state,
+        });
       }
       const takeoverReady = baton.baton_state === 'HUMAN_REQUESTED' || baton.baton_state === 'HUMAN_RELEASED';
       if (!takeoverReady && baton.owner_user_id !== actorId) {
-        throw new ConflictException(
+        throw new BatonConflictException(
           `Baton must be HUMAN_REQUESTED or HUMAN_RELEASED for takeover. Current state: ${baton.baton_state}`,
+          { baton_state: baton.baton_state },
         );
       }
 
@@ -189,11 +193,15 @@ export class HitlService implements OnModuleDestroy {
       await this.applyBatonTimeoutState(manager, baton);
 
       if (baton.baton_state !== 'HUMAN_CONTROL') {
-        throw new ConflictException('Baton is not in HUMAN_CONTROL state');
+        throw new BatonConflictException('Baton is not in HUMAN_CONTROL state', {
+          baton_state: baton.baton_state,
+        });
       }
 
       if (baton.owner_user_id !== actorId && actorRole !== 'Admin') {
-        throw new ConflictException('Only the baton holder can release it');
+        throw new BatonConflictException('Only the baton holder can release it', {
+          baton_state: baton.baton_state,
+        });
       }
 
       baton.baton_state = 'HUMAN_RELEASED';
@@ -414,7 +422,7 @@ export class HitlService implements OnModuleDestroy {
     try {
       return JSON.parse(raw) as T;
     } catch {
-      throw new UnauthorizedException('Corrupt idempotency cache entry');
+      throw new InternalServerErrorException('Corrupt idempotency cache entry');
     }
   }
 

--- a/apps/api/src/modules/streaming/streaming.controller.ts
+++ b/apps/api/src/modules/streaming/streaming.controller.ts
@@ -905,7 +905,7 @@ export class CdpStreamingController {
                 stUptime.textContent = Math.round((Date.now() - new Date(data.started_at).getTime()) / 60000) + 'm';
               }
               if (data.state === 'TERMINATED') { sessionTerminated = true; handleTerminated(); return; }
-              if (fromMcp && data.state === 'HEALTHY') { window.close(); }
+              if (!recordingMode && data.state === 'HEALTHY') { window.close(); }
               if (!fromMcp) return;
               var pending = data.pending_input_request;
               if (pending && pending.step_index != null) {
@@ -1787,7 +1787,7 @@ export class StreamingController {
                 stUptime.textContent = Math.round((Date.now() - new Date(data.started_at).getTime()) / 60000) + 'm';
               }
               if (data.state === 'TERMINATED') { sessionTerminated = true; handleTerminated(); return; }
-              if (fromMcp && data.state === 'HEALTHY') { window.close(); }
+              if (!recordingMode && data.state === 'HEALTHY') { window.close(); }
               if (!fromMcp) return;
               var pending = data.pending_input_request;
               if (pending && pending.step_index != null) {

--- a/apps/api/src/modules/streaming/streaming.controller.ts
+++ b/apps/api/src/modules/streaming/streaming.controller.ts
@@ -905,7 +905,7 @@ export class CdpStreamingController {
                 stUptime.textContent = Math.round((Date.now() - new Date(data.started_at).getTime()) / 60000) + 'm';
               }
               if (data.state === 'TERMINATED') { sessionTerminated = true; handleTerminated(); return; }
-              if (data.state === 'HEALTHY') { window.close(); }
+              if (fromMcp && data.state === 'HEALTHY') { window.close(); }
               if (!fromMcp) return;
               var pending = data.pending_input_request;
               if (pending && pending.step_index != null) {
@@ -1787,7 +1787,7 @@ export class StreamingController {
                 stUptime.textContent = Math.round((Date.now() - new Date(data.started_at).getTime()) / 60000) + 'm';
               }
               if (data.state === 'TERMINATED') { sessionTerminated = true; handleTerminated(); return; }
-              if (data.state === 'HEALTHY') { window.close(); }
+              if (fromMcp && data.state === 'HEALTHY') { window.close(); }
               if (!fromMcp) return;
               var pending = data.pending_input_request;
               if (pending && pending.step_index != null) {

--- a/apps/api/src/modules/streaming/streaming.controller.ts
+++ b/apps/api/src/modules/streaming/streaming.controller.ts
@@ -905,6 +905,7 @@ export class CdpStreamingController {
                 stUptime.textContent = Math.round((Date.now() - new Date(data.started_at).getTime()) / 60000) + 'm';
               }
               if (data.state === 'TERMINATED') { sessionTerminated = true; handleTerminated(); return; }
+              if (data.state === 'HEALTHY') { window.close(); }
               if (!fromMcp) return;
               var pending = data.pending_input_request;
               if (pending && pending.step_index != null) {
@@ -1786,6 +1787,7 @@ export class StreamingController {
                 stUptime.textContent = Math.round((Date.now() - new Date(data.started_at).getTime()) / 60000) + 'm';
               }
               if (data.state === 'TERMINATED') { sessionTerminated = true; handleTerminated(); return; }
+              if (data.state === 'HEALTHY') { window.close(); }
               if (!fromMcp) return;
               var pending = data.pending_input_request;
               if (pending && pending.step_index != null) {

--- a/apps/api/src/modules/tenants/tenants.service.ts
+++ b/apps/api/src/modules/tenants/tenants.service.ts
@@ -2,6 +2,7 @@ import { Injectable, ConflictException, NotFoundException, Logger } from '@nestj
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, DataSource } from 'typeorm';
 import * as crypto from 'crypto';
+import * as Sentry from '@sentry/node';
 import { TenantEntity } from '../../entities';
 import { AuditService } from '../audit/audit.service';
 import { MinioProvisionerService } from './minio-provisioner.service';
@@ -46,7 +47,11 @@ export class TenantsService {
       this.logger.error(
         `Failed to provision MinIO bucket for tenant ${saved.id}: ${(err as Error).message}`,
       );
-      // Non-fatal: tenant is created, bucket can be provisioned later
+      Sentry.withScope((scope) => {
+        scope.setTag('tenant_id', saved.id);
+        scope.setTag('warn_context', 'minio_provision_failed');
+        Sentry.captureException(err instanceof Error ? err : new Error(String(err)));
+      });
     }
 
     await this.auditService.log({

--- a/charts/browser-hitl/values-local.yaml
+++ b/charts/browser-hitl/values-local.yaml
@@ -289,6 +289,9 @@ egressProxy:
     # --- Automation Anywhere ---
     - ".automationanywhere.digital"
     - ".automationanywhere.com"
+    - ".goskope.com"
+    - ".okta.com"
+    - ".oktacdn.com"
     # --- Salesforce analytics (Pendo) ---
     - ".pendo.io"
     - ".pendo-static-5673999629942784.storage.googleapis.com"

--- a/packages/shared/src/enums.ts
+++ b/packages/shared/src/enums.ts
@@ -31,6 +31,7 @@ export enum HealthResultType {
 
 export enum UserRole {
   ADMIN = 'Admin',
+  EDITOR = 'Editor',
   OPERATOR = 'Operator',
   VIEWER = 'Viewer',
   AGENT = 'Agent',


### PR DESCRIPTION
## Summary
- Add GlobalExceptionFilter with domain exceptions (BatonConflict, NoHealthySession, ProfileNotFound, CredentialDecryptFailed), correlation IDs, Sentry enrichment, and HTML error pages for VNC/CDP viewer paths
- Add CorrelationIdMiddleware (X-Request-ID header propagation)
- Add Sentry capture in EventsGateway and TenantsService
- Add EDITOR role to shared enums
- Propagate `extra_egress_allowlist` on template update (was only copied on create — missed in PROPAGATED_FIELDS and content hash)
- Add `extra_egress_allowlist` to UpdateAppTemplateDto so PATCH accepts it
- Auto-close VNC/CDP viewer tab when session becomes HEALTHY (MCP-only, gated on `fromMcp`)
- Add `.okta.com`, `.oktacdn.com`, `.goskope.com` to egress proxy default allowlist (AA Salesforce SSO)

## Test plan
- [x] Build passes (`pnpm run build`)
- [x] All tests pass (`pnpm run test`) — 22 propagation tests, filter spec, middleware spec
- [ ] Deploy to local Kind and verify:
  - [ ] VNC viewer stays open for non-MCP sessions when HEALTHY
  - [ ] VNC viewer auto-closes for `?from=mcp` sessions after HITL → HEALTHY
  - [ ] Template PATCH with `extra_egress_allowlist` propagates to linked apps
  - [ ] AA Salesforce login completes through Okta/Netskope SSO without egress blocks