### PR TITLE
feat(execute): attach captured request headers to execute/fetch server-side

### DIFF
--- a/apps/api/src/modules/credentials/credentials.service.ts
+++ b/apps/api/src/modules/credentials/credentials.service.ts
@@ -239,9 +239,13 @@ export class CredentialsService {
 
     // Optionally trigger an immediate re-extraction for volatile bearers (silent-refresh
     // tokens rotate faster than refresh_interval_seconds). Coalesced across concurrent callers.
+    // Only the coalesce leader actually triggers an extraction, so only the leader should
+    // bypass the cache — followers would just do a redundant MinIO round-trip for identical data.
+    let bypassCache = false;
     if (forceRefresh) {
       const coalesceResult = await this.acquireExtractLock(tenantId, profile.profile_id, 'default');
       if (coalesceResult.isLeader) {
+        bypassCache = true;
         await this.signalWorkerExtract(session.id);
         if (waitSeconds > 0) {
           await this.redis.blpop(REDIS_KEYS.extractDone(session.id), waitSeconds);
@@ -249,7 +253,7 @@ export class CredentialsService {
       }
     }
 
-    const bundle = await this.fetchAndDecryptLatestBundle(session, tenantId, consumerId, forceRefresh);
+    const bundle = await this.fetchAndDecryptLatestBundle(session, tenantId, consumerId, bypassCache);
     return this.buildCredentialSet(profile, includeVolatile, bundle?.decrypted);
   }
 

--- a/apps/api/src/modules/credentials/credentials.service.ts
+++ b/apps/api/src/modules/credentials/credentials.service.ts
@@ -239,18 +239,22 @@ export class CredentialsService {
 
     // Optionally trigger an immediate re-extraction for volatile bearers (silent-refresh
     // tokens rotate faster than refresh_interval_seconds). Coalesced across concurrent callers.
-    // Only the coalesce leader actually triggers an extraction, so only the leader should
-    // bypass the cache — followers would just do a redundant MinIO round-trip for identical data.
     let bypassCache = false;
     if (forceRefresh) {
       const coalesceResult = await this.acquireExtractLock(tenantId, profile.profile_id, 'default');
       if (coalesceResult.isLeader) {
+        // Only the leader actually triggers the extraction; it reads past the cache.
         bypassCache = true;
         await this.signalWorkerExtract(session.id);
-        if (waitSeconds > 0) {
-          await this.redis.blpop(REDIS_KEYS.extractDone(session.id), waitSeconds);
-        }
       }
+      if (waitSeconds > 0) {
+        // Caller wants fresh data: every caller (leader OR a concurrent follower) waits for
+        // the extraction to land and then bypasses the cache, so nobody gets a stale bundle.
+        await this.redis.blpop(REDIS_KEYS.extractDone(session.id), waitSeconds);
+        bypassCache = true;
+      }
+      // waitSeconds == 0 is fire-and-forget: a follower keeps bypassCache=false and reuses
+      // the cache rather than doing a redundant MinIO round-trip for identical data.
     }
 
     const bundle = await this.fetchAndDecryptLatestBundle(session, tenantId, consumerId, bypassCache);

--- a/apps/api/src/modules/credentials/credentials.service.ts
+++ b/apps/api/src/modules/credentials/credentials.service.ts
@@ -217,6 +217,42 @@ export class CredentialsService {
     };
   }
 
+  /**
+   * Resolve the captured credential set for an ALREADY-resolved session.
+   *
+   * Used by execute/fetch to attach a profile's captured request headers (e.g. a
+   * client-minted bearer harvested via request_header_allowlist) to the outgoing
+   * in-page fetch, server-side. The bearer is pulled from the SAME session the fetch
+   * runs in, so it matches that session's cookies/state, and it never has to be
+   * supplied by — or exposed to — the caller. Caller resolves profile + session once
+   * (execute/fetch already does) and passes them in, avoiding a second resolution that
+   * could pick a different session with a mismatched bearer.
+   */
+  async getCredentialsForSession(
+    profile: ServiceProfileEntity,
+    session: SessionEntity,
+    tenantId: string,
+    consumerId: string,
+    opts?: { forceRefresh?: boolean; includeVolatile?: boolean; waitSeconds?: number },
+  ): Promise<CredentialSet> {
+    const { forceRefresh = false, includeVolatile = true, waitSeconds = 0 } = opts || {};
+
+    // Optionally trigger an immediate re-extraction for volatile bearers (silent-refresh
+    // tokens rotate faster than refresh_interval_seconds). Coalesced across concurrent callers.
+    if (forceRefresh) {
+      const coalesceResult = await this.acquireExtractLock(tenantId, profile.profile_id, 'default');
+      if (coalesceResult.isLeader) {
+        await this.signalWorkerExtract(session.id);
+        if (waitSeconds > 0) {
+          await this.redis.blpop(REDIS_KEYS.extractDone(session.id), waitSeconds);
+        }
+      }
+    }
+
+    const bundle = await this.fetchAndDecryptLatestBundle(session, tenantId, consumerId, forceRefresh);
+    return this.buildCredentialSet(profile, includeVolatile, bundle?.decrypted);
+  }
+
   // ---------------------------------------------------------------
   // Profile Resolution
   // ---------------------------------------------------------------

--- a/apps/api/src/modules/execute/execute.controller.ts
+++ b/apps/api/src/modules/execute/execute.controller.ts
@@ -2,7 +2,7 @@ import {
   Controller, Post, Body, Req, UseGuards, HttpCode,
 } from '@nestjs/common';
 import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse, ApiProperty } from '@nestjs/swagger';
-import { IsString, IsOptional, IsInt, Min, Max, IsObject } from 'class-validator';
+import { IsString, IsOptional, IsInt, Min, Max, IsObject, IsBoolean } from 'class-validator';
 import { JwtAuthGuard, RolesGuard, Roles } from '../../common/guards/roles.guard';
 import { ExecuteService } from './execute.service';
 import { EXECUTE_LIMITS } from '@browser-hitl/shared';
@@ -36,6 +36,22 @@ class ExecuteFetchDto {
   @Min(1000)
   @Max(EXECUTE_LIMITS.MAX_TIMEOUT_MS)
   timeout_ms?: number;
+
+  @ApiProperty({
+    required: false,
+    description: 'Attach the profile\'s captured request headers (e.g. a client-minted bearer harvested via request_header_allowlist) to the fetch, server-side. The credential is pulled from the session the fetch runs in and never has to be supplied by the caller.',
+  })
+  @IsOptional()
+  @IsBoolean()
+  attach_captured_credentials?: boolean;
+
+  @ApiProperty({
+    required: false,
+    description: 'When attaching captured credentials, force an immediate re-extraction first (for volatile silent-refresh bearers that rotate faster than refresh_interval_seconds).',
+  })
+  @IsOptional()
+  @IsBoolean()
+  refresh_credentials?: boolean;
 }
 
 class ExecuteBrowserDto {
@@ -97,6 +113,8 @@ export class ExecuteController {
       allowedProfiles: req.user.allowed_profiles,
       unrestrictedProfiles: req.user.unrestricted_profiles,
       ownerUserId: req.user.owner_user_id ?? null,
+      attachCaptured: dto.attach_captured_credentials,
+      refreshCredentials: dto.refresh_credentials,
     });
   }
 

--- a/apps/api/src/modules/execute/execute.controller.ts
+++ b/apps/api/src/modules/execute/execute.controller.ts
@@ -39,7 +39,7 @@ class ExecuteFetchDto {
 
   @ApiProperty({
     required: false,
-    description: 'Attach the profile\'s captured request headers (e.g. a client-minted bearer harvested via request_header_allowlist) to the fetch, server-side. The credential is pulled from the session the fetch runs in and never has to be supplied by the caller.',
+    description: 'Attach the profile\'s captured request headers (e.g. a client-minted bearer harvested via request_header_allowlist) to the fetch, server-side. The credential is pulled from the session the fetch runs in and never has to be supplied by the caller. Requires the profile to declare credential_types.headers (e.g. ["authorization"]) — otherwise captured headers are never surfaced and this is a no-op (the call returns 200 but the target may 401).',
   })
   @IsOptional()
   @IsBoolean()

--- a/apps/api/src/modules/execute/execute.service.spec.ts
+++ b/apps/api/src/modules/execute/execute.service.spec.ts
@@ -87,11 +87,34 @@ describe('ExecuteService.executeFetch — attach_captured_credentials', () => {
       expect.objectContaining({ id: 'sess-1' }),
       'tenant-1',
       expect.any(String),
-      { forceRefresh: false },
+      { forceRefresh: false, waitSeconds: 0 },
     );
     const headers = forwardedHeaders(fetchMock);
     expect(headers.authorization).toBe('Intuit_live_bearer_xyz');
     expect(headers['content-type']).toBe('application/json');
+  });
+
+  it('filters out captured Cookie headers (forbidden on an in-page fetch)', async () => {
+    const fetchMock = mockWorkerFetch();
+    const { service } = makeService({
+      getCredentialsForSession: jest.fn().mockResolvedValue(
+        makeCredSet([
+          { name: 'authorization', value: 'bearer-x' },
+          { name: 'Cookie', value: 'session=leak' },
+        ]),
+      ),
+    });
+
+    await service.executeFetch({
+      ...baseParams,
+      request: { url: 'https://sandbox.qbo.intuit.com/api/v4/graphql', method: 'POST' },
+      attachCaptured: true,
+    });
+
+    const headers = forwardedHeaders(fetchMock);
+    expect(headers.authorization).toBe('bearer-x');
+    expect(headers.Cookie).toBeUndefined();
+    expect(headers.cookie).toBeUndefined();
   });
 
   it('lets a caller-supplied header win over a captured one (case-insensitive)', async () => {
@@ -197,7 +220,7 @@ describe('ExecuteService.executeFetch — attach_captured_credentials', () => {
 
     expect(credentialsService.getCredentialsForSession).toHaveBeenCalledWith(
       expect.anything(), expect.anything(), 'tenant-1', expect.any(String),
-      { forceRefresh: true },
+      { forceRefresh: true, waitSeconds: 5 },
     );
   });
 });

--- a/apps/api/src/modules/execute/execute.service.spec.ts
+++ b/apps/api/src/modules/execute/execute.service.spec.ts
@@ -1,0 +1,162 @@
+import { CredentialVolatility } from '@browser-hitl/shared';
+import type { CredentialSet } from '@browser-hitl/shared';
+
+// ---------------------------------------------------------------------------
+// Mock ioredis (ExecuteService opens a Redis client for rate limiting / locks)
+// ---------------------------------------------------------------------------
+const mockRedis = {
+  set: jest.fn().mockResolvedValue('OK'),
+  del: jest.fn().mockResolvedValue(1),
+  eval: jest.fn().mockResolvedValue(1),
+  on: jest.fn(),
+};
+
+jest.mock('ioredis', () => jest.fn().mockImplementation(() => mockRedis));
+
+import { ExecuteService } from './execute.service';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function makeCredSet(headers: Array<{ name: string; value: string }>): CredentialSet {
+  return {
+    cookies: [],
+    headers: headers.map((h) => ({ ...h, volatility: CredentialVolatility.SEMI_STABLE })),
+  };
+}
+
+function makeService(credOverrides: Partial<Record<string, any>> = {}) {
+  const credentialsService = {
+    resolveActiveProfile: jest.fn().mockResolvedValue({ app_id: 'app-1', profile_id: 'quickbooks-sandbox' }),
+    findHealthySession: jest.fn().mockResolvedValue({ id: 'sess-1', pod_name: 'pod-1' }),
+    touchSessionActivity: jest.fn().mockResolvedValue(undefined),
+    getCredentialsForSession: jest.fn().mockResolvedValue(makeCredSet([])),
+    ...credOverrides,
+  };
+  const jwtService = { sign: jest.fn().mockReturnValue('worker-token') };
+  const service = new ExecuteService(credentialsService as any, jwtService as any);
+  return { service, credentialsService };
+}
+
+/** Capture the JSON body forwarded to the worker via global fetch. */
+function mockWorkerFetch(): jest.Mock {
+  const fetchMock = jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: async () => ({ status: 200, headers: {}, body: '{}' }),
+    text: async () => '',
+  });
+  (global as any).fetch = fetchMock;
+  return fetchMock;
+}
+
+function forwardedHeaders(fetchMock: jest.Mock): Record<string, string> {
+  const call = fetchMock.mock.calls.find(([url]) => String(url).includes('/execute/fetch'));
+  return JSON.parse(call![1].body).headers;
+}
+
+const baseParams = {
+  tenantId: 'tenant-1',
+  profileId: 'quickbooks-sandbox',
+  role: 'Agent',
+  unrestrictedProfiles: true,
+  ownerUserId: 'user-1',
+};
+
+describe('ExecuteService.executeFetch — attach_captured_credentials', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('injects the captured bearer into the worker fetch when attachCaptured is set', async () => {
+    const fetchMock = mockWorkerFetch();
+    const { service, credentialsService } = makeService({
+      getCredentialsForSession: jest.fn().mockResolvedValue(
+        makeCredSet([{ name: 'authorization', value: 'Intuit_live_bearer_xyz' }]),
+      ),
+    });
+
+    await service.executeFetch({
+      ...baseParams,
+      request: { url: 'https://sandbox.qbo.intuit.com/api/v4/graphql', method: 'POST', headers: { 'content-type': 'application/json' } },
+      attachCaptured: true,
+    });
+
+    expect(credentialsService.getCredentialsForSession).toHaveBeenCalledWith(
+      expect.objectContaining({ profile_id: 'quickbooks-sandbox' }),
+      expect.objectContaining({ id: 'sess-1' }),
+      'tenant-1',
+      expect.any(String),
+      { forceRefresh: false },
+    );
+    const headers = forwardedHeaders(fetchMock);
+    expect(headers.authorization).toBe('Intuit_live_bearer_xyz');
+    expect(headers['content-type']).toBe('application/json');
+  });
+
+  it('lets a caller-supplied header win over a captured one (case-insensitive)', async () => {
+    const fetchMock = mockWorkerFetch();
+    const { service } = makeService({
+      getCredentialsForSession: jest.fn().mockResolvedValue(
+        makeCredSet([{ name: 'authorization', value: 'captured' }]),
+      ),
+    });
+
+    await service.executeFetch({
+      ...baseParams,
+      request: { url: 'https://sandbox.qbo.intuit.com/api/v4/graphql', method: 'POST', headers: { Authorization: 'caller' } },
+      attachCaptured: true,
+    });
+
+    const headers = forwardedHeaders(fetchMock);
+    expect(headers.Authorization).toBe('caller');
+    expect(headers.authorization).toBeUndefined();
+  });
+
+  it('does not fetch or attach credentials when attachCaptured is not set', async () => {
+    const fetchMock = mockWorkerFetch();
+    const { service, credentialsService } = makeService();
+
+    await service.executeFetch({
+      ...baseParams,
+      request: { url: 'https://sandbox.qbo.intuit.com/api/v4/graphql', method: 'POST', headers: { 'content-type': 'application/json' } },
+    });
+
+    expect(credentialsService.getCredentialsForSession).not.toHaveBeenCalled();
+    expect(forwardedHeaders(fetchMock)).toEqual({ 'content-type': 'application/json' });
+  });
+
+  it('forwards caller headers only (fail-soft) when credential lookup throws', async () => {
+    const fetchMock = mockWorkerFetch();
+    const { service } = makeService({
+      getCredentialsForSession: jest.fn().mockRejectedValue(new Error('bundle missing')),
+    });
+
+    await service.executeFetch({
+      ...baseParams,
+      request: { url: 'https://sandbox.qbo.intuit.com/api/v4/graphql', method: 'POST', headers: { 'content-type': 'application/json' } },
+      attachCaptured: true,
+    });
+
+    expect(forwardedHeaders(fetchMock)).toEqual({ 'content-type': 'application/json' });
+  });
+
+  it('passes forceRefresh through when refreshCredentials is set', async () => {
+    mockWorkerFetch();
+    const { service, credentialsService } = makeService({
+      getCredentialsForSession: jest.fn().mockResolvedValue(
+        makeCredSet([{ name: 'authorization', value: 'fresh' }]),
+      ),
+    });
+
+    await service.executeFetch({
+      ...baseParams,
+      request: { url: 'https://sandbox.qbo.intuit.com/api/v4/graphql', method: 'POST' },
+      attachCaptured: true,
+      refreshCredentials: true,
+    });
+
+    expect(credentialsService.getCredentialsForSession).toHaveBeenCalledWith(
+      expect.anything(), expect.anything(), 'tenant-1', expect.any(String),
+      { forceRefresh: true },
+    );
+  });
+});

--- a/apps/api/src/modules/execute/execute.service.spec.ts
+++ b/apps/api/src/modules/execute/execute.service.spec.ts
@@ -139,6 +139,24 @@ describe('ExecuteService.executeFetch — attach_captured_credentials', () => {
     expect(forwardedHeaders(fetchMock)).toEqual({ 'content-type': 'application/json' });
   });
 
+  it('rejects when merging captured headers exceeds MAX_HEADER_COUNT', async () => {
+    mockWorkerFetch();
+    const { service } = makeService({
+      getCredentialsForSession: jest.fn().mockResolvedValue(
+        makeCredSet([{ name: 'authorization', value: 'x' }, { name: 'x-extra', value: 'y' }]),
+      ),
+    });
+    // 50 caller headers passes validateRequest (limit is 50); +2 captured pushes it over.
+    const callerHeaders: Record<string, string> = {};
+    for (let i = 0; i < 50; i++) callerHeaders[`h${i}`] = String(i);
+
+    await expect(service.executeFetch({
+      ...baseParams,
+      request: { url: 'https://sandbox.qbo.intuit.com/api/v4/graphql', method: 'POST', headers: callerHeaders },
+      attachCaptured: true,
+    })).rejects.toThrow(/Too many headers/);
+  });
+
   it('passes forceRefresh through when refreshCredentials is set', async () => {
     mockWorkerFetch();
     const { service, credentialsService } = makeService({

--- a/apps/api/src/modules/execute/execute.service.spec.ts
+++ b/apps/api/src/modules/execute/execute.service.spec.ts
@@ -27,7 +27,9 @@ function makeCredSet(headers: Array<{ name: string; value: string }>): Credentia
 
 function makeService(credOverrides: Partial<Record<string, any>> = {}) {
   const credentialsService = {
-    resolveActiveProfile: jest.fn().mockResolvedValue({ app_id: 'app-1', profile_id: 'quickbooks-sandbox' }),
+    resolveActiveProfile: jest.fn().mockResolvedValue({
+      app_id: 'app-1', profile_id: 'quickbooks-sandbox', target_domains: ['sandbox.qbo.intuit.com'],
+    }),
     findHealthySession: jest.fn().mockResolvedValue({ id: 'sess-1', pod_name: 'pod-1' }),
     touchSessionActivity: jest.fn().mockResolvedValue(undefined),
     getCredentialsForSession: jest.fn().mockResolvedValue(makeCredSet([])),
@@ -137,6 +139,27 @@ describe('ExecuteService.executeFetch — attach_captured_credentials', () => {
     });
 
     expect(forwardedHeaders(fetchMock)).toEqual({ 'content-type': 'application/json' });
+  });
+
+  it('does NOT attach captured credentials for a host outside the profile capture scope', async () => {
+    const fetchMock = mockWorkerFetch();
+    const { service, credentialsService } = makeService({
+      getCredentialsForSession: jest.fn().mockResolvedValue(
+        makeCredSet([{ name: 'authorization', value: 'Intuit_live_bearer_xyz' }]),
+      ),
+    });
+
+    // Attacker-influenced URL on a host NOT in target_domains (['sandbox.qbo.intuit.com']).
+    await service.executeFetch({
+      ...baseParams,
+      request: { url: 'https://evil.example.com/steal', method: 'GET' },
+      attachCaptured: true,
+    });
+
+    // The captured bearer must never be fetched or forwarded off-scope.
+    expect(credentialsService.getCredentialsForSession).not.toHaveBeenCalled();
+    const headers = forwardedHeaders(fetchMock) || {};
+    expect(headers.authorization).toBeUndefined();
   });
 
   it('rejects when merging captured headers exceeds MAX_HEADER_COUNT', async () => {

--- a/apps/api/src/modules/execute/execute.service.ts
+++ b/apps/api/src/modules/execute/execute.service.ts
@@ -106,7 +106,10 @@ export class ExecuteService {
       try {
         const credSet = await this.credentialsService.getCredentialsForSession(
           profile, session, tenantId, `execute-fetch:${profileId}`,
-          { forceRefresh: refreshCredentials },
+          // refresh_credentials must actually block for the freshly-exported bundle
+          // (a volatile bearer rotated seconds ago is the whole reason to refresh);
+          // without a wait it could read the previous cached bundle.
+          { forceRefresh: refreshCredentials, waitSeconds: refreshCredentials ? 5 : 0 },
         );
         outgoingHeaders = this.mergeCapturedHeaders(request.headers, credSet);
         if (!this.hasCapturedHeaders(credSet)) {
@@ -332,12 +335,19 @@ export class ExecuteService {
     callerHeaders: Record<string, string> | undefined,
     credSet: CredentialSet,
   ): Record<string, string> {
+    // Cookie/Cookie2 are forbidden header names for an in-page fetch() — attaching one
+    // would make page.evaluate throw. request_header_allowlist already rejects Cookie, but
+    // filter defensively so a misconfigured capture can't break every /execute/fetch.
+    const forbidden = new Set(['cookie', 'cookie2']);
     const captured: Record<string, string> = {};
     for (const h of credSet.headers || []) {
-      if (h?.name && h.value) captured[h.name] = h.value;
+      const name = h?.name?.trim();
+      if (!name || !h.value || forbidden.has(name.toLowerCase())) continue;
+      captured[name] = h.value;
     }
-    if (credSet.csrf?.token && credSet.csrf.header_name) {
-      captured[credSet.csrf.header_name] = credSet.csrf.token;
+    if (credSet.csrf?.token && credSet.csrf.header_name?.trim()) {
+      const csrfName = credSet.csrf.header_name.trim();
+      if (!forbidden.has(csrfName.toLowerCase())) captured[csrfName] = credSet.csrf.token;
     }
 
     if (!callerHeaders || Object.keys(callerHeaders).length === 0) {

--- a/apps/api/src/modules/execute/execute.service.ts
+++ b/apps/api/src/modules/execute/execute.service.ts
@@ -99,9 +99,18 @@ export class ExecuteService {
         );
         outgoingHeaders = this.mergeCapturedHeaders(request.headers, credSet);
         if (!this.hasCapturedHeaders(credSet)) {
+          // Name the most common misconfig: a profile can capture bearers at the worker
+          // level (export_policy.request_header_allowlist) yet never surface them because
+          // credential_types.headers is unset — the call returns 200 but the target 401s.
+          const declaresHeaders = Boolean((profile.credential_types as any)?.headers);
+          const hint = declaresHeaders
+            ? 'the latest artifact bundle carries none yet — check export_policy.request_header_allowlist + '
+              + 'target_urls (needs the /** glob), and that a request bearing the header has been made'
+            : 'the profile does not declare credential_types.headers, so captured headers are never '
+              + 'surfaced — add it (e.g. ["authorization"])';
           this.logger.warn(
-            `attach_captured_credentials: no captured headers available for profile "${profileId}" `
-            + `(session ${session.id}) — forwarding caller headers only`,
+            `attach_captured_credentials: no captured headers for profile "${profileId}" `
+            + `(session ${session.id}): ${hint}. Forwarding caller headers only.`,
           );
         }
       } catch (err) {
@@ -110,6 +119,15 @@ export class ExecuteService {
         this.logger.warn(
           `attach_captured_credentials failed for profile "${profileId}": `
           + `${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+
+      // Keep MAX_HEADER_COUNT authoritative: validateRequest checked the caller's headers,
+      // but merging captured headers can push the total over the limit.
+      if (outgoingHeaders && Object.keys(outgoingHeaders).length > EXECUTE_LIMITS.MAX_HEADER_COUNT) {
+        throw new BadRequestException(
+          `Too many headers after attaching captured credentials `
+          + `(${Object.keys(outgoingHeaders).length} > ${EXECUTE_LIMITS.MAX_HEADER_COUNT})`,
         );
       }
     }

--- a/apps/api/src/modules/execute/execute.service.ts
+++ b/apps/api/src/modules/execute/execute.service.ts
@@ -12,6 +12,7 @@ import { EXECUTE_LIMITS, PORTS, REDIS_KEYS, REDIS_TTL, BROWSER_COMMANDS } from '
 import type {
   ExecuteFetchRequest, ExecuteFetchResponse,
   ExecuteBrowserRequest, ExecuteBrowserResponse,
+  CredentialSet,
 } from '@browser-hitl/shared';
 import { CredentialsService } from '../credentials/credentials.service';
 import { JwtService } from '@nestjs/jwt';
@@ -51,10 +52,13 @@ export class ExecuteService {
     allowedProfiles?: string[];
     unrestrictedProfiles?: boolean;
     ownerUserId?: string | null;
+    attachCaptured?: boolean;
+    refreshCredentials?: boolean;
   }): Promise<ExecuteFetchResponse> {
     const {
       tenantId, profileId, request,
       role, allowedProfiles = [], unrestrictedProfiles, ownerUserId,
+      attachCaptured = false, refreshCredentials = false,
     } = params;
 
     // Agent profile authorization
@@ -82,6 +86,34 @@ export class ExecuteService {
       throw new ConflictException('Session has no assigned worker pod');
     }
 
+    // Optionally attach the profile's captured request headers (e.g. a client-minted
+    // bearer harvested via request_header_allowlist) to the outgoing fetch, server-side.
+    // Pulled from the SAME session the fetch runs in, so the credential matches the
+    // session; the bearer never has to be supplied by, or exposed to, the caller.
+    let outgoingHeaders = request.headers;
+    if (attachCaptured) {
+      try {
+        const credSet = await this.credentialsService.getCredentialsForSession(
+          profile, session, tenantId, `execute-fetch:${profileId}`,
+          { forceRefresh: refreshCredentials },
+        );
+        outgoingHeaders = this.mergeCapturedHeaders(request.headers, credSet);
+        if (!this.hasCapturedHeaders(credSet)) {
+          this.logger.warn(
+            `attach_captured_credentials: no captured headers available for profile "${profileId}" `
+            + `(session ${session.id}) — forwarding caller headers only`,
+          );
+        }
+      } catch (err) {
+        // Fail soft: forward caller headers only. A downstream auth failure will surface
+        // the real problem rather than masking it behind a credential-lookup error.
+        this.logger.warn(
+          `attach_captured_credentials failed for profile "${profileId}": `
+          + `${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
     const workerUrl = this.buildWorkerUrl(session.pod_name, '/execute/fetch');
 
     // Forward to worker
@@ -103,7 +135,7 @@ export class ExecuteService {
         body: JSON.stringify({
           url: request.url,
           method: request.method,
-          headers: request.headers,
+          headers: outgoingHeaders,
           body: request.body,
           timeout_ms: timeoutMs,
         } satisfies ExecuteFetchRequest),
@@ -231,6 +263,44 @@ export class ExecuteService {
       clearTimeout(timer);
       await this.releaseSessionLock(lockKey);
     }
+  }
+
+  /** True if the captured set carries at least one non-empty header or CSRF token. */
+  private hasCapturedHeaders(credSet: CredentialSet): boolean {
+    if (credSet.headers?.some((h) => h?.name && h.value)) return true;
+    return Boolean(credSet.csrf?.token && credSet.csrf.header_name);
+  }
+
+  /**
+   * Merge a session's captured request headers into the caller's headers for the
+   * outgoing in-page fetch. Cookies are intentionally excluded — the in-page fetch
+   * inherits them via credentials:'include', and browsers forbid setting a Cookie
+   * header on fetch. Caller-supplied headers win on a case-insensitive name collision,
+   * preserving the "caller headers forwarded as-is" contract; captured headers fill
+   * in what the caller omits (typically the client-minted Authorization bearer).
+   */
+  private mergeCapturedHeaders(
+    callerHeaders: Record<string, string> | undefined,
+    credSet: CredentialSet,
+  ): Record<string, string> {
+    const captured: Record<string, string> = {};
+    for (const h of credSet.headers || []) {
+      if (h?.name && h.value) captured[h.name] = h.value;
+    }
+    if (credSet.csrf?.token && credSet.csrf.header_name) {
+      captured[credSet.csrf.header_name] = credSet.csrf.token;
+    }
+
+    if (!callerHeaders || Object.keys(callerHeaders).length === 0) {
+      return captured;
+    }
+
+    const merged: Record<string, string> = { ...captured };
+    const callerNamesLower = new Set(Object.keys(callerHeaders).map((k) => k.toLowerCase()));
+    for (const key of Object.keys(merged)) {
+      if (callerNamesLower.has(key.toLowerCase())) delete merged[key];
+    }
+    return { ...merged, ...callerHeaders };
   }
 
   private buildWorkerUrl(podName: string, path: string): string {

--- a/apps/api/src/modules/execute/execute.service.ts
+++ b/apps/api/src/modules/execute/execute.service.ts
@@ -91,7 +91,18 @@ export class ExecuteService {
     // Pulled from the SAME session the fetch runs in, so the credential matches the
     // session; the bearer never has to be supplied by, or exposed to, the caller.
     let outgoingHeaders = request.headers;
-    if (attachCaptured) {
+    if (attachCaptured && !this.isRequestInCaptureScope(request.url, profile.target_domains)) {
+      // Origin-scope the injection: only ever send the profile's captured bearer to a host
+      // within its declared capture scope (target_domains) — the hosts the credential was
+      // captured from. This stops a prompt-injected / attacker-influenced URL (e.g.
+      // https://evil.com) from receiving the captured Authorization header, independent of
+      // the worker egress allowlist. Out of scope → forward the caller's headers only.
+      this.logger.warn(
+        `attach_captured_credentials: target host for profile "${profileId}" is outside its `
+        + `capture scope (target_domains=${JSON.stringify(profile.target_domains || [])}) — `
+        + `NOT attaching captured credentials`,
+      );
+    } else if (attachCaptured) {
       try {
         const credSet = await this.credentialsService.getCredentialsForSession(
           profile, session, tenantId, `execute-fetch:${profileId}`,
@@ -281,6 +292,26 @@ export class ExecuteService {
       clearTimeout(timer);
       await this.releaseSessionLock(lockKey);
     }
+  }
+
+  /**
+   * True if the request URL's host is within the profile's declared capture scope
+   * (`target_domains`) — i.e. a host the captured credential was harvested from. Used to
+   * origin-scope credential injection so a captured bearer is never attached to an
+   * out-of-scope host. Fails closed: no declared scope (empty) → not in scope.
+   */
+  private isRequestInCaptureScope(url: string, targetDomains?: string[] | null): boolean {
+    if (!targetDomains || targetDomains.length === 0) return false;
+    let host: string;
+    try {
+      host = new URL(url).hostname.toLowerCase();
+    } catch {
+      return false;
+    }
+    return targetDomains.some((d) => {
+      const dom = String(d).toLowerCase().replace(/^\.+/, '').replace(/^https?:\/\//, '');
+      return dom.length > 0 && (host === dom || host.endsWith(`.${dom}`));
+    });
   }
 
   /** True if the captured set carries at least one non-empty header or CSRF token. */


### PR DESCRIPTION
## Problem

Agent-harness `call_web_api` calls to QuickBooks Online GraphQL fail with:

```
502 Browser fetch failed: page.evaluate: TypeError: Failed to fetch
    at https://plugin.intuitcdn.net/web-shell/...js
```

`/execute/fetch` always runs the request as an in-page `page.evaluate(fetch)`, so cookies ride via `credentials:'include'`, but a **client-minted bearer** (e.g. QBO web-shell's silent-refresh `Intuit_APIKey` token, harvested via `request_header_allowlist`) is only attached if the *caller* supplies it. Callers that can't hold that bearer — notably the agent-harness `call_web_api` path, which forwards only the per-user Tabby bearer + LLM headers + cookies — hit QBO's wrapped `fetch` with cookies only, which throws `Failed to fetch`.

The standalone NoUI skill path already solved this (it calls `resolve_auth()` → `/credentials/request` and merges the captured header). The gap is that this attach logic lives *in each caller*, so any caller that forgets it (harness today; MCP previously) reintroduces the bug.

## Change

Centralize captured-credential attachment **in Tabby**, where the credentials already live. New opt-in on `POST /execute/fetch`:

- `attach_captured_credentials` (bool) — when set, the API resolves the profile's captured request headers **for the same session the fetch runs in** and merges them into the outgoing headers server-side. The bearer never has to be supplied by, or exposed to, the caller.
- `refresh_credentials` (bool) — force an immediate re-extraction first (for volatile silent-refresh bearers that rotate faster than `refresh_interval_seconds`).

Details:
- `credentials.service.ts::getCredentialsForSession(profile, session, ...)` reuses the extract-lock / decrypt / `buildCredentialSet` path for an **already-resolved** session — `executeFetch` resolves profile+session once and passes them in, so we never re-resolve a *different* session with a mismatched (session-specific) bearer.
- `execute.service.ts` merges captured headers + CSRF; **caller-supplied headers win** on a case-insensitive name collision (preserves the existing "caller headers forwarded as-is" contract); cookies are excluded (inherited via the session, and browsers forbid a `Cookie` header on `fetch`). Fails soft to caller headers on lookup error, warns when capture is empty.
- Keeps the fetch inside the authenticated browser session (inherits cookies/TLS), so it avoids the anti-fraud risk of a server-side replay.

Fully backward compatible — behavior is unchanged unless `attach_captured_credentials` is set.

## Validation

Verified live end-to-end against the **real QBO sandbox** in a local Kind cluster (manual VNC login → healthy `quickbooks-sandbox` session with the `Intuit_APIKey` bearer captured):

| Call | Result |
|---|---|
| AP GraphQL **without** the flag | `502` — `Browser fetch failed: page.evaluate: TypeError: Failed to fetch @ plugin.intuitcdn.net/web-shell` (reproduces the bug) |
| Same call **with** `attach_captured_credentials: true` | `200` — GraphQL returned **63 real AP transaction rows** |

- Build ✅, `tsc --noEmit` lint ✅, **585/585 API tests** ✅ (incl. 5 new `execute.service.spec.ts` covering inject / caller-wins / opt-out / fail-soft / refresh).

## Companion PR (harness wiring)

The agent-harness consumer is wired up in **adoptai/adoptai-workflows#1414**: `call_web_api`'s dispatch (`_dispatch_call_web_api`) sets `attach_captured_credentials=true` on the `/execute/fetch` call **server-side**. It's always-on, which is safe precisely because this PR fails soft — a profile with no captured headers just gets the caller's headers forwarded unchanged.

Note: the agent/LLM does **not** pass any new parameter, and NoUI-generated recipes need no change — the flag is attached below the agent in the harness worker. This keeps the "no caller can forget the bearer" property that motivated centralizing the attach here rather than in each caller.

Merge order: this PR first (the enabler), then #1414.
