### PR TITLE
feat: admin UI redesign, error handling, and RBAC fixes

### DIFF
--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -332,6 +332,10 @@ jobs:
       EGRESS_MEM_REQUEST: ${{ secrets.EGRESS_MEM_REQUEST || '128Mi' }}
       EGRESS_MEM_LIMIT: ${{ secrets.EGRESS_MEM_LIMIT || '512Mi' }}
       RECONCILE_BATCH_SIZE: ${{ secrets.RECONCILE_BATCH_SIZE || '50' }}
+      # New Relic APM
+      NEWRELIC_ENABLED: ${{ secrets.NEWRELIC_ENABLED || 'false' }}
+      NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY || '' }}
+      NEW_RELIC_ENVIRONMENT: ${{ secrets.NEW_RELIC_ENVIRONMENT || 'production' }}
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:

--- a/.github/workflows/sync-branches.yaml
+++ b/.github/workflows/sync-branches.yaml
@@ -1,0 +1,101 @@
+name: Sync branches after production deploy
+
+on:
+  workflow_run:
+    workflows: ["Deploy to Production"]
+    types: [completed]
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: sync-branches
+  cancel-in-progress: false
+
+jobs:
+  sync-main-to-dev:
+    name: Sync main → dev
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          token: ${{ secrets.GH_PAT }}
+          ref: dev
+          fetch-depth: 0
+
+      - name: Merge main into dev
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin main
+          if git merge origin/main --no-edit; then
+            echo "Merge clean"
+          else
+            # Only Chart.yaml should conflict (version bump). Keep dev's version.
+            git checkout HEAD -- charts/browser-hitl/Chart.yaml
+            git add charts/browser-hitl/Chart.yaml
+            git commit --no-edit
+            echo "Resolved Chart.yaml conflict (kept dev version)"
+          fi
+          git push origin dev
+
+  sync-main-to-noui:
+    name: Sync main → tabby-noui
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          token: ${{ secrets.GH_PAT }}
+          ref: tabby-noui
+          fetch-depth: 0
+
+      - name: Merge main into tabby-noui
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git fetch origin main
+          if git merge origin/main --no-edit; then
+            echo "Merge clean"
+          else
+            # Chart.yaml version conflict: keep the higher version
+            if git diff --name-only --diff-filter=U | grep -q 'Chart.yaml'; then
+              HEAD_VER=$(git show HEAD:charts/browser-hitl/Chart.yaml | grep '^version:' | awk '{print $2}')
+              MAIN_VER=$(git show origin/main:charts/browser-hitl/Chart.yaml | grep '^version:' | awk '{print $2}')
+              if [ "$(printf '%s\n%s' "$HEAD_VER" "$MAIN_VER" | sort -V | tail -1)" = "$HEAD_VER" ]; then
+                git checkout HEAD -- charts/browser-hitl/Chart.yaml
+              else
+                git checkout origin/main -- charts/browser-hitl/Chart.yaml
+              fi
+              git add charts/browser-hitl/Chart.yaml
+            fi
+            # If other conflicts remain, abort
+            if git diff --name-only --diff-filter=U | grep -q .; then
+              echo "::error::Unresolvable conflicts in tabby-noui sync — resolve manually"
+              git merge --abort
+              exit 1
+            fi
+            git commit --no-edit
+            echo "Resolved Chart.yaml conflict (kept higher version)"
+          fi
+          git push origin tabby-noui
+
+  notify:
+    name: Sync Summary
+    runs-on: ubuntu-latest
+    needs: [sync-main-to-dev, sync-main-to-noui]
+    if: always()
+    steps:
+      - name: Summary
+        run: |
+          echo "## Branch sync after production deploy" >> $GITHUB_STEP_SUMMARY
+          if [ "${{ needs.sync-main-to-dev.result }}" = "success" ]; then
+            echo "- main → dev: ✓" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- main → dev: **FAILED** (run manually)" >> $GITHUB_STEP_SUMMARY
+          fi
+          if [ "${{ needs.sync-main-to-noui.result }}" = "success" ]; then
+            echo "- main → tabby-noui: ✓" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "- main → tabby-noui: **FAILED** (run manually)" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -150,4 +150,3 @@ docs/tabby-admin-ui-design-brief.md
 docs/admin-ui-testing-guide.md
 apps/admin-ui/public/env.js
 screenshots/
-adminui-bonito/

--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,11 @@ docs/zero-to-hero-test-workflow.md
 docs/zero-to-hero-tabby-platform-setup.md
 docs/adopt-org-templates-backup.json
 docs/tabby-platform-setup-consolidation.md
+.omc/
+docs/residential-proxy-plan.md
+docs/customer/
+docs/tabby-admin-ui-design-brief.md
+docs/admin-ui-testing-guide.md
+apps/admin-ui/public/env.js
+screenshots/
+adminui-bonito/

--- a/apps/admin-ui/index.html
+++ b/apps/admin-ui/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Tabby Admin</title>
+    <script src="/env.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/admin-ui/package.json
+++ b/apps/admin-ui/package.json
@@ -2,22 +2,53 @@
   "name": "@browser-hitl/admin-ui",
   "version": "0.1.0",
   "private": true,
+  "type": "module",
   "scripts": {
-    "build": "echo 'Building admin-ui'",
-    "start": "node server.js",
-    "test": "echo 'Testing admin-ui'",
-    "lint": "echo 'Linting admin-ui'"
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "tsc --noEmit"
   },
   "dependencies": {
     "@browser-hitl/shared": "workspace:*",
-    "@sentry/node": "^10.51.0",
-    "next": "^15.5.16",
+    "@hookform/resolvers": "^3.9.0",
+    "@novnc/novnc": "^1.5.0",
+    "@radix-ui/react-dialog": "^1.1.0",
+    "@radix-ui/react-dropdown-menu": "^2.1.0",
+    "@radix-ui/react-select": "^2.1.0",
+    "@radix-ui/react-separator": "^1.1.0",
+    "@radix-ui/react-slot": "^1.1.0",
+    "@radix-ui/react-tabs": "^1.1.0",
+    "@radix-ui/react-toast": "^1.2.0",
+    "@radix-ui/react-tooltip": "^1.1.0",
+    "@tanstack/react-query": "^5.60.0",
+    "@tanstack/react-table": "^8.20.0",
+    "axios": "^1.7.0",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.0",
+    "date-fns": "^4.1.0",
+    "lucide-react": "^0.460.0",
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-hook-form": "^7.54.0",
+    "react-router": "^7.0.0",
+    "tailwind-merge": "^2.6.0",
+    "tailwindcss": "^4.0.0",
+    "@tailwindcss/vite": "^4.0.0",
+    "zod": "^3.23.0",
+    "zustand": "^5.0.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.0",
+    "@testing-library/react": "^16.1.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
-    "typescript": "^5.7.3"
+    "@vitejs/plugin-react": "^4.3.0",
+    "jsdom": "^25.0.0",
+    "typescript": "^5.7.3",
+    "vite": "^6.0.0",
+    "vitest": "^2.1.0"
   }
 }

--- a/apps/admin-ui/public/env.js
+++ b/apps/admin-ui/public/env.js
@@ -1,3 +1,0 @@
-window.__env = {
-  API_URL: "http://localhost:8000",
-};

--- a/apps/admin-ui/public/env.js
+++ b/apps/admin-ui/public/env.js
@@ -1,0 +1,3 @@
+window.__env = {
+  API_URL: "http://localhost:8000",
+};

--- a/apps/admin-ui/public/favicon.svg
+++ b/apps/admin-ui/public/favicon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y=".9em" font-size="90">🤖</text></svg>

--- a/apps/admin-ui/src/api/agent-clients.ts
+++ b/apps/admin-ui/src/api/agent-clients.ts
@@ -1,0 +1,42 @@
+import { api } from './client';
+
+export interface AgentClient {
+  id: string;
+  client_id: string;
+  name: string;
+  tenant_id: string;
+  allowed_profiles: string[] | null;
+  unrestricted_profiles: boolean;
+  token_ttl_seconds: number | null;
+  rate_limit_per_minute: number | null;
+  revoked_at: string | null;
+  last_used_at: string | null;
+  created_at: string;
+}
+
+export interface RegisterAgentClientResponse {
+  client_id: string;
+  client_secret: string;
+  id: string;
+}
+
+export const agentClientsApi = {
+  list: (tenantId: string) =>
+    api.get<AgentClient[]>(`/admin/agent-clients/${tenantId}`).then((r) => r.data),
+
+  register: (data: {
+    name: string;
+    tenant_id: string;
+    allowed_profiles?: string[];
+    unrestricted_profiles?: boolean;
+    token_ttl_seconds?: number;
+    rate_limit_per_minute?: number;
+  }) =>
+    api.post<RegisterAgentClientResponse>('/admin/agent-clients', data).then((r) => r.data),
+
+  revoke: (id: string) =>
+    api.delete(`/admin/agent-clients/${id}`).then((r) => r.data),
+
+  rotateSecret: (id: string) =>
+    api.post<{ client_secret: string }>(`/admin/agent-clients/${id}/rotate-secret`).then((r) => r.data),
+};

--- a/apps/admin-ui/src/api/apps.ts
+++ b/apps/admin-ui/src/api/apps.ts
@@ -1,0 +1,42 @@
+import { api } from './client';
+import type { PaginatedResponse } from './sessions';
+
+export interface Application {
+  id: string;
+  tenant_id: string;
+  name: string;
+  target_urls: string[];
+  desired_session_count: number;
+  execute_enabled: boolean;
+  template_id: string | null;
+  owner_user_id: string | null;
+  login_config: unknown;
+  keepalive_config: unknown;
+  export_policy: unknown;
+  browser_policy: unknown;
+  notification_config: unknown;
+  extra_egress_allowlist: string[] | null;
+  credential_ref: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export const appsApi = {
+  list: (params?: { limit?: number; offset?: number; tenant_id?: string }) =>
+    api.get<PaginatedResponse<Application>>('/apps', { params }).then((r) => r.data),
+
+  get: (id: string) =>
+    api.get<Application>(`/apps/${id}`).then((r) => r.data),
+
+  create: (data: Partial<Application>) =>
+    api.post<Application>('/apps', data).then((r) => r.data),
+
+  update: (id: string, data: Partial<Application>) =>
+    api.put<Application>(`/apps/${id}`, data).then((r) => r.data),
+
+  deactivate: (id: string) =>
+    api.delete(`/apps/${id}`).then((r) => r.data),
+
+  destroy: (id: string) =>
+    api.delete(`/apps/${id}/destroy`).then((r) => r.data),
+};

--- a/apps/admin-ui/src/api/auth.ts
+++ b/apps/admin-ui/src/api/auth.ts
@@ -1,0 +1,26 @@
+import { api } from './client';
+
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export interface LoginResponse {
+  token: string;
+}
+
+export interface OAuthProvider {
+  id: string;
+  name: string;
+}
+
+export const authApi = {
+  login: (data: LoginRequest) =>
+    api.post<LoginResponse>('/login', data).then((r) => r.data),
+
+  listOAuthProviders: () =>
+    api.get<OAuthProvider[]>('/auth/oauth/providers').then((r) => r.data),
+
+  logout: () =>
+    api.post('/auth/logout').then((r) => r.data),
+};

--- a/apps/admin-ui/src/api/client.ts
+++ b/apps/admin-ui/src/api/client.ts
@@ -1,0 +1,30 @@
+import axios from 'axios';
+import { env } from '@/env';
+import { useAuthStore } from '@/stores/auth';
+
+export const api = axios.create({
+  headers: { 'Content-Type': 'application/json' },
+});
+
+api.interceptors.request.use((config) => {
+  config.baseURL = env.apiUrl();
+  const token = useAuthStore.getState().token;
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+api.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    if (axios.isAxiosError(error) && error.response?.status === 401) {
+      const path = window.location.pathname;
+      if (path !== '/login' && path !== '/auth/callback') {
+        useAuthStore.getState().logout();
+        window.location.href = '/login';
+      }
+    }
+    return Promise.reject(error);
+  },
+);

--- a/apps/admin-ui/src/api/hitl.ts
+++ b/apps/admin-ui/src/api/hitl.ts
@@ -1,0 +1,29 @@
+import { api } from './client';
+
+export interface InputRequest {
+  input_type: string;
+  value: string;
+  step_index: number;
+}
+
+export const hitlApi = {
+  takeover: (sessionId: string, idempotencyKey?: string) =>
+    api.post(`/sessions/${sessionId}/takeover`, {}, {
+      headers: idempotencyKey ? { 'idempotency-key': idempotencyKey } : {},
+    }).then((r) => r.data),
+
+  release: (sessionId: string, idempotencyKey?: string) =>
+    api.post(`/sessions/${sessionId}/release`, {}, {
+      headers: idempotencyKey ? { 'idempotency-key': idempotencyKey } : {},
+    }).then((r) => r.data),
+
+  submitInput: (sessionId: string, input: InputRequest, idempotencyKey?: string) =>
+    api.post(`/sessions/${sessionId}/input`, input, {
+      headers: idempotencyKey ? { 'idempotency-key': idempotencyKey } : {},
+    }).then((r) => r.data),
+
+  acknowledge: (sessionId: string, note?: string, idempotencyKey?: string) =>
+    api.post(`/sessions/${sessionId}/acknowledge`, note ? { note } : {}, {
+      headers: idempotencyKey ? { 'idempotency-key': idempotencyKey } : {},
+    }).then((r) => r.data),
+};

--- a/apps/admin-ui/src/api/identity-providers.ts
+++ b/apps/admin-ui/src/api/identity-providers.ts
@@ -1,0 +1,49 @@
+import { api } from './client';
+
+export interface IdentityProviderConfig {
+  id: string;
+  name: string;
+  provider_type: 'oidc' | 'saml';
+  issuer_url: string | null;
+  jwks_uri: string | null;
+  auth_url: string | null;
+  token_url: string | null;
+  userinfo_url: string | null;
+  sign_out_url: string | null;
+  scopes: string | null;
+  audience: string | null;
+  user_id_claim: string;
+  email_claim: string;
+  name_claim: string | null;
+  tenant_id_claim: string | null;
+  enabled: boolean;
+  allow_auto_provision: boolean;
+  allow_shared_session_fallback: boolean;
+  admin_domains: string[];
+  default_role: string;
+  role_claim: string | null;
+  admin_role_values: string[];
+  editor_role_values: string[];
+  created_at: string;
+  updated_at: string;
+}
+
+export const idpApi = {
+  list: () =>
+    api.get<IdentityProviderConfig[]>('/admin/identity-providers').then((r) => r.data),
+
+  get: (id: string) =>
+    api.get<IdentityProviderConfig>(`/admin/identity-providers/${id}`).then((r) => r.data),
+
+  create: (data: Partial<IdentityProviderConfig>) =>
+    api.post<IdentityProviderConfig>('/admin/identity-providers', data).then((r) => r.data),
+
+  update: (id: string, data: Partial<IdentityProviderConfig>) =>
+    api.put<IdentityProviderConfig>(`/admin/identity-providers/${id}`, data).then((r) => r.data),
+
+  remove: (id: string) =>
+    api.delete(`/admin/identity-providers/${id}`).then((r) => r.data),
+
+  test: (id: string) =>
+    api.get<{ key_count: number; latency_ms: number }>(`/admin/identity-providers/${id}/test`).then((r) => r.data),
+};

--- a/apps/admin-ui/src/api/profiles.ts
+++ b/apps/admin-ui/src/api/profiles.ts
@@ -1,0 +1,39 @@
+import { api } from './client';
+
+export interface ServiceProfile {
+  id: string;
+  tenant_id: string;
+  app_id: string;
+  profile_id: string;
+  version: number;
+  version_state: string;
+  login_config: unknown;
+  credential_types: unknown;
+  target_domains: string[];
+  canary_request_count: number;
+  canary_error_count: number;
+  parent_version_id: string | null;
+  owner_user_id: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export const profilesApi = {
+  list: (params?: { limit?: number; offset?: number }) =>
+    api.get<ServiceProfile[]>('/admin/profiles', { params }).then((r) => r.data),
+
+  get: (id: string) =>
+    api.get<ServiceProfile>(`/admin/profiles/${id}`).then((r) => r.data),
+
+  create: (data: Partial<ServiceProfile>) =>
+    api.post<ServiceProfile>('/admin/profiles', data).then((r) => r.data),
+
+  promote: (id: string) =>
+    api.post(`/admin/profiles/${id}/promote`).then((r) => r.data),
+
+  rollback: (id: string) =>
+    api.post(`/admin/profiles/${id}/rollback`).then((r) => r.data),
+
+  remove: (id: string) =>
+    api.delete(`/admin/profiles/${id}`).then((r) => r.data),
+};

--- a/apps/admin-ui/src/api/sessions.ts
+++ b/apps/admin-ui/src/api/sessions.ts
@@ -1,0 +1,64 @@
+import { api } from './client';
+
+export interface Session {
+  id: string;
+  app_id: string;
+  tenant_id: string;
+  state: string;
+  health_result_type: string | null;
+  pod_name: string | null;
+  retry_count: number;
+  hitl_attempt_count: number;
+  pending_input_request: unknown | null;
+  owner_user_id: string | null;
+  created_at: string;
+  updated_at: string;
+  application?: {
+    id: string;
+    name: string;
+  };
+}
+
+export interface Intervention {
+  id: string;
+  session_id: string;
+  type: string;
+  outcome: string | null;
+  input_request_metadata: unknown | null;
+  human_note: string | null;
+  created_at: string;
+  completed_at: string | null;
+}
+
+export interface PaginatedResponse<T> {
+  data: T[];
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface StreamResponse {
+  url: string;
+  stream_token?: string;
+  mode?: string;
+}
+
+export const sessionsApi = {
+  list: (params: { limit?: number; offset?: number }) =>
+    api.get<PaginatedResponse<Session>>('/sessions', { params }).then((r) => r.data),
+
+  get: (id: string) =>
+    api.get<Session>(`/sessions/${id}`).then((r) => r.data),
+
+  interventions: (id: string, params?: { limit?: number; offset?: number }) =>
+    api.get<PaginatedResponse<Intervention>>(`/sessions/${id}/interventions`, { params }).then((r) => r.data),
+
+  scale: (appId: string, desiredSessions: number) =>
+    api.post(`/apps/${appId}/sessions/scale`, { desired_sessions: desiredSessions }).then((r) => r.data),
+
+  stream: (id: string) =>
+    api.post<StreamResponse>(`/sessions/${id}/stream`).then((r) => r.data),
+
+  shortLink: (id: string, mode?: string) =>
+    api.post<{ short_url: string }>(`/sessions/${id}/short-link`, mode ? { mode } : {}).then((r) => r.data),
+};

--- a/apps/admin-ui/src/api/templates.ts
+++ b/apps/admin-ui/src/api/templates.ts
@@ -1,0 +1,39 @@
+import { api } from './client';
+
+export interface AppTemplate {
+  id: string;
+  tenant_id: string;
+  name: string;
+  profile_name_pattern: string | null;
+  credential_ref_default: string | null;
+  idle_shutdown_seconds: number | null;
+  execute_enabled: boolean;
+  extra_egress_allowlist: string[] | null;
+  login_config: unknown;
+  keepalive_config: unknown;
+  export_policy: unknown;
+  browser_policy: unknown;
+  notification_config: unknown;
+  created_at: string;
+  updated_at: string;
+}
+
+export const templatesApi = {
+  list: (params?: { tenant_id?: string }) =>
+    api.get<AppTemplate[]>('/admin/app-templates', { params }).then((r) => r.data),
+
+  get: (id: string) =>
+    api.get<AppTemplate>(`/admin/app-templates/${id}`).then((r) => r.data),
+
+  create: (data: Partial<AppTemplate>) =>
+    api.post<AppTemplate>('/admin/app-templates', data).then((r) => r.data),
+
+  update: (id: string, data: Partial<AppTemplate>) =>
+    api.put<AppTemplate>(`/admin/app-templates/${id}`, data).then((r) => r.data),
+
+  patch: (id: string, data: Partial<AppTemplate>) =>
+    api.patch<AppTemplate>(`/admin/app-templates/${id}`, data).then((r) => r.data),
+
+  remove: (id: string) =>
+    api.delete(`/admin/app-templates/${id}`).then((r) => r.data),
+};

--- a/apps/admin-ui/src/api/tenants.ts
+++ b/apps/admin-ui/src/api/tenants.ts
@@ -1,0 +1,27 @@
+import { api } from './client';
+import type { PaginatedResponse } from './sessions';
+
+export interface Tenant {
+  id: string;
+  name: string;
+  max_sessions: number;
+  created_at: string;
+  updated_at: string;
+}
+
+export const tenantsApi = {
+  list: (params?: { limit?: number; offset?: number }) =>
+    api.get<PaginatedResponse<Tenant>>('/tenants', { params }).then((r) => r.data),
+
+  get: (id: string) =>
+    api.get<Tenant>(`/tenants/${id}`).then((r) => r.data),
+
+  create: (data: { name: string; id?: string; max_sessions?: number }) =>
+    api.post<Tenant>('/tenants', data).then((r) => r.data),
+
+  update: (id: string, data: { max_sessions?: number }) =>
+    api.patch<Tenant>(`/tenants/${id}`, data).then((r) => r.data),
+
+  remove: (id: string) =>
+    api.delete(`/tenants/${id}`).then((r) => r.data),
+};

--- a/apps/admin-ui/src/api/users.ts
+++ b/apps/admin-ui/src/api/users.ts
@@ -1,0 +1,22 @@
+import { api } from './client';
+import type { PaginatedResponse } from './sessions';
+
+export interface User {
+  id: string;
+  email: string;
+  role: string;
+  tenant_id: string;
+  status: string;
+  created_at: string;
+}
+
+export const usersApi = {
+  list: (params?: { limit?: number; offset?: number }) =>
+    api.get<PaginatedResponse<User>>('/users', { params }).then((r) => r.data),
+
+  create: (data: { email: string; password: string; role: string; tenant_id: string }) =>
+    api.post<User>('/users', data).then((r) => r.data),
+
+  remove: (id: string) =>
+    api.delete(`/users/${id}`).then((r) => r.data),
+};

--- a/apps/admin-ui/src/components/layout/sidebar.tsx
+++ b/apps/admin-ui/src/components/layout/sidebar.tsx
@@ -1,0 +1,262 @@
+import { useState } from 'react';
+import { NavLink } from 'react-router';
+import { useAuthStore } from '@/stores/auth';
+import { useUiStore } from '@/stores/ui';
+import { useQuery } from '@tanstack/react-query';
+import { sessionsApi } from '@/api/sessions';
+import {
+  LayoutDashboard,
+  Monitor,
+  AppWindow,
+  FileCode2,
+  Layers,
+  Building2,
+  Users,
+  Shield,
+  KeyRound,
+} from 'lucide-react';
+
+interface NavItem {
+  label: string;
+  to: string;
+  icon: React.ElementType;
+  roles?: string[];
+  showBadge?: boolean;
+}
+
+const NAV_ITEMS: NavItem[] = [
+  { label: 'Dashboard', to: '/dashboard', icon: LayoutDashboard },
+  { label: 'Sessions', to: '/sessions', icon: Monitor, showBadge: true },
+  { label: 'Applications', to: '/apps', icon: AppWindow, roles: ['Admin', 'Editor', 'Operator'] },
+  { label: 'App Templates', to: '/templates', icon: FileCode2, roles: ['Admin', 'Editor', 'Operator'] },
+  { label: 'Profiles', to: '/profiles', icon: Layers },
+  { label: 'Tenants', to: '/tenants', icon: Building2, roles: ['Admin'] },
+  { label: 'Users', to: '/users', icon: Users, roles: ['Admin'] },
+  { label: 'Identity Providers', to: '/identity-providers', icon: Shield, roles: ['Admin'] },
+  { label: 'Agent Clients', to: '/agent-clients', icon: KeyRound, roles: ['Admin'] },
+];
+
+interface NavItemProps {
+  item: NavItem;
+  collapsed: boolean;
+  sessionCount: number;
+}
+
+function SidebarNavItem({ item, collapsed, sessionCount }: NavItemProps) {
+  const [hovered, setHovered] = useState(false);
+
+  return (
+    <NavLink
+      to={item.to}
+      style={({ isActive }) => ({
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        height: 34,
+        padding: collapsed ? '0 8px' : '0 10px',
+        borderRadius: 8,
+        textDecoration: 'none',
+        fontSize: 13,
+        fontWeight: isActive ? 600 : 400,
+        justifyContent: collapsed ? 'center' : 'flex-start',
+        transition: 'background 120ms ease, color 120ms ease',
+        background: isActive
+          ? 'color-mix(in srgb, var(--primary) 18%, transparent)'
+          : hovered
+          ? 'var(--card-2)'
+          : 'transparent',
+        color: isActive ? 'var(--primary)' : hovered ? 'var(--fg)' : 'var(--muted-fg)',
+      })}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+    >
+      <item.icon size={18} style={{ flexShrink: 0 }} />
+      {!collapsed && (
+        <>
+          <span
+            style={{
+              flex: 1,
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            {item.label}
+          </span>
+          {item.showBadge && sessionCount > 0 && (
+            <span
+              style={{
+                background: 'var(--primary)',
+                color: 'var(--primary-fg)',
+                fontSize: 10,
+                fontWeight: 700,
+                lineHeight: 1,
+                padding: '2px 6px',
+                borderRadius: 20,
+                minWidth: 18,
+                textAlign: 'center',
+              }}
+            >
+              {sessionCount > 999 ? '999+' : sessionCount}
+            </span>
+          )}
+        </>
+      )}
+    </NavLink>
+  );
+}
+
+export function Sidebar() {
+  const collapsed = useUiStore((s) => s.sidebarCollapsed);
+  const toggle = useUiStore((s) => s.toggleSidebar);
+  const role = useAuthStore((s) => s.user?.role);
+
+  const { data: sessionsData } = useQuery({
+    queryKey: ['sessions-count'],
+    queryFn: () => sessionsApi.list({ limit: 1 }),
+    refetchInterval: 30_000,
+  });
+
+  const sessionCount = sessionsData?.total ?? 0;
+
+  const visible = NAV_ITEMS.filter(
+    (item) => !item.roles || (role && item.roles.includes(role)),
+  );
+
+  return (
+    <aside
+      style={{
+        width: collapsed ? 64 : 240,
+        transition: 'width 200ms ease',
+        position: 'fixed',
+        top: 0,
+        left: 0,
+        bottom: 0,
+        zIndex: 30,
+        display: 'flex',
+        flexDirection: 'column',
+        borderRight: '1px solid var(--border)',
+        background: 'var(--card)',
+      }}
+    >
+      {/* Header */}
+      <div
+        style={{
+          height: 56,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          padding: '0 10px',
+          borderBottom: '1px solid var(--border)',
+          flexShrink: 0,
+          gap: 8,
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 9, minWidth: 0 }}>
+          <div
+            style={{
+              width: 26,
+              height: 26,
+              background: 'var(--primary)',
+              borderRadius: 7,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              color: '#fff',
+              fontSize: 13,
+              fontWeight: 800,
+              flexShrink: 0,
+            }}
+          >
+            T
+          </div>
+          {!collapsed && (
+            <span
+              style={{
+                fontSize: 15,
+                fontWeight: 800,
+                letterSpacing: '-0.02em',
+                color: 'var(--fg)',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              Tabby
+            </span>
+          )}
+        </div>
+
+        <button
+          onClick={toggle}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 22,
+            height: 22,
+            borderRadius: 6,
+            border: '1px solid var(--border)',
+            background: 'transparent',
+            color: 'var(--muted-fg)',
+            cursor: 'pointer',
+            fontSize: 11,
+            fontWeight: 700,
+            flexShrink: 0,
+            lineHeight: 1,
+          }}
+        >
+          {collapsed ? '»' : '«'}
+        </button>
+      </div>
+
+      {/* Nav */}
+      <nav
+        style={{
+          flex: 1,
+          overflowY: 'auto',
+          padding: 8,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 2,
+        }}
+      >
+        {visible.map((item) => (
+          <SidebarNavItem
+            key={item.to}
+            item={item}
+            collapsed={collapsed}
+            sessionCount={sessionCount}
+          />
+        ))}
+      </nav>
+
+      {/* Environment indicator */}
+      <div
+        style={{
+          padding: collapsed ? '12px 0' : '11px 14px',
+          borderTop: '1px solid var(--border)',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: collapsed ? 'center' : 'flex-start',
+          gap: 8,
+          flexShrink: 0,
+        }}
+      >
+        <div
+          style={{
+            width: 7,
+            height: 7,
+            borderRadius: '50%',
+            background: 'var(--success)',
+            flexShrink: 0,
+            boxShadow: '0 0 6px var(--success)',
+          }}
+        />
+        {!collapsed && (
+          <span style={{ fontSize: 11, color: 'var(--muted-fg)', letterSpacing: '0.01em' }}>
+            api · us-east-1
+          </span>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/apps/admin-ui/src/components/layout/topbar.tsx
+++ b/apps/admin-ui/src/components/layout/topbar.tsx
@@ -1,0 +1,227 @@
+import { useState } from 'react';
+import { useLocation } from 'react-router';
+import { useAuthStore } from '@/stores/auth';
+import { useUiStore } from '@/stores/ui';
+import { Sun, Moon, Power } from 'lucide-react';
+
+const ROUTE_LABELS: Array<{ pattern: RegExp; label: string }> = [
+  { pattern: /^\/dashboard$/, label: 'Dashboard' },
+  { pattern: /^\/sessions\/[^/]+\/viewer/, label: 'Session Viewer' },
+  { pattern: /^\/sessions\/[^/]+/, label: 'Session Detail' },
+  { pattern: /^\/sessions/, label: 'Sessions' },
+  { pattern: /^\/apps\/new/, label: 'New Application' },
+  { pattern: /^\/apps\/[^/]+/, label: 'Application' },
+  { pattern: /^\/apps/, label: 'Applications' },
+  { pattern: /^\/templates\/new/, label: 'New Template' },
+  { pattern: /^\/templates\/[^/]+\/edit/, label: 'Edit Template' },
+  { pattern: /^\/templates\/[^/]+/, label: 'Template' },
+  { pattern: /^\/templates/, label: 'App Templates' },
+  { pattern: /^\/profiles\/[^/]+/, label: 'Profile' },
+  { pattern: /^\/profiles/, label: 'Profiles' },
+  { pattern: /^\/tenants/, label: 'Tenants' },
+  { pattern: /^\/users/, label: 'Users' },
+  { pattern: /^\/identity-providers/, label: 'Identity Providers' },
+  { pattern: /^\/agent-clients/, label: 'Agent Clients' },
+];
+
+function getPageLabel(pathname: string): string {
+  for (const { pattern, label } of ROUTE_LABELS) {
+    if (pattern.test(pathname)) return label;
+  }
+  return '';
+}
+
+const ROLE_BADGE_COLORS: Record<string, string> = {
+  Admin: 'var(--primary)',
+  Editor: 'var(--violet)',
+  Operator: 'var(--info)',
+  Viewer: 'var(--neutral)',
+};
+
+function RoleBadge({ role }: { role: string }) {
+  const color = ROLE_BADGE_COLORS[role] ?? 'var(--neutral)';
+  return (
+    <span
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 6,
+        padding: '3px 8px',
+        borderRadius: 20,
+        border: '1px solid var(--border-2)',
+        background: 'var(--card-2)',
+        fontSize: 12,
+        color: 'var(--muted-fg)',
+        cursor: 'default',
+        userSelect: 'none',
+      }}
+    >
+      <span style={{ fontSize: 11, color: 'var(--faint-fg)' }}>Role</span>
+      <span
+        style={{
+          fontSize: 10.5,
+          fontWeight: 700,
+          letterSpacing: '0.02em',
+          color,
+          textTransform: 'uppercase',
+        }}
+      >
+        {role}
+      </span>
+    </span>
+  );
+}
+
+export function Topbar() {
+  const { user, logout } = useAuthStore();
+  const { theme, toggleTheme } = useUiStore();
+  const location = useLocation();
+  const [logoutHovered, setLogoutHovered] = useState(false);
+
+  const pageLabel = getPageLabel(location.pathname);
+
+  const displayName = user
+    ? (user.sub ?? '').replace(/^(federated:|svc:)/, '')
+    : '';
+
+  const avatarLetter = displayName.charAt(0).toUpperCase() || '?';
+
+  return (
+    <header
+      style={{
+        height: 56,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        padding: '0 24px',
+        borderBottom: '1px solid var(--border)',
+        background: 'color-mix(in srgb, var(--bg) 80%, transparent)',
+        backdropFilter: 'blur(8px)',
+        flexShrink: 0,
+        position: 'sticky',
+        top: 0,
+        zIndex: 20,
+      }}
+    >
+      {/* Left: breadcrumb */}
+      <span
+        style={{
+          fontSize: 13,
+          color: 'var(--muted-fg)',
+          fontWeight: 500,
+        }}
+      >
+        {pageLabel}
+      </span>
+
+      {/* Right: controls */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        {/* Role badge */}
+        {user?.role && <RoleBadge role={user.role} />}
+
+        {/* Theme toggle */}
+        <button
+          onClick={toggleTheme}
+          title={theme === 'dark' ? 'Switch to light mode' : 'Switch to dark mode'}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 32,
+            height: 32,
+            borderRadius: 7,
+            border: '1px solid var(--border)',
+            background: 'transparent',
+            color: 'var(--muted-fg)',
+            cursor: 'pointer',
+          }}
+        >
+          {theme === 'dark' ? <Sun size={14} /> : <Moon size={14} />}
+        </button>
+
+        {/* Separator */}
+        <div
+          style={{
+            width: 1,
+            height: 24,
+            background: 'var(--border)',
+            flexShrink: 0,
+          }}
+        />
+
+        {/* User info + avatar */}
+        {user && (
+          <>
+            <div style={{ textAlign: 'right', lineHeight: 1.3 }}>
+              <div
+                style={{
+                  fontSize: 12,
+                  fontWeight: 600,
+                  color: 'var(--fg)',
+                  maxWidth: 200,
+                  overflow: 'hidden',
+                  textOverflow: 'ellipsis',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {displayName}
+              </div>
+              <div
+                style={{
+                  fontSize: 10.5,
+                  color: 'var(--faint-fg)',
+                  marginTop: 1,
+                }}
+              >
+                {user.role}
+              </div>
+            </div>
+
+            <div
+              style={{
+                width: 30,
+                height: 30,
+                borderRadius: '50%',
+                background: 'color-mix(in srgb, var(--primary) 25%, var(--card-2))',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                fontSize: 12,
+                fontWeight: 700,
+                color: 'var(--primary)',
+                flexShrink: 0,
+                userSelect: 'none',
+              }}
+            >
+              {avatarLetter}
+            </div>
+          </>
+        )}
+
+        {/* Logout */}
+        <button
+          onClick={logout}
+          title="Sign out"
+          onMouseEnter={() => setLogoutHovered(true)}
+          onMouseLeave={() => setLogoutHovered(false)}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            width: 32,
+            height: 32,
+            borderRadius: 7,
+            border: '1px solid var(--border)',
+            background: 'transparent',
+            color: logoutHovered ? 'var(--error)' : 'var(--muted-fg)',
+            cursor: 'pointer',
+            transition: 'color 120ms ease, border-color 120ms ease',
+            borderColor: logoutHovered ? 'var(--error)' : 'var(--border)',
+          }}
+        >
+          <Power size={14} />
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/apps/admin-ui/src/components/shared/confirm-dialog.tsx
+++ b/apps/admin-ui/src/components/shared/confirm-dialog.tsx
@@ -1,0 +1,159 @@
+import { useState } from 'react';
+
+interface Props {
+  open: boolean;
+  title: string;
+  description: string;
+  confirmLabel?: string;
+  destructive?: boolean;
+  requireInput?: string;
+  onConfirm: () => void | Promise<void>;
+  onCancel: () => void;
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel = 'Confirm',
+  destructive,
+  requireInput,
+  onConfirm,
+  onCancel,
+}: Props) {
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const canConfirm = !requireInput || input === requireInput;
+
+  if (!open) return null;
+
+  const handleConfirm = async () => {
+    setLoading(true);
+    try {
+      await onConfirm();
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      style={{ background: 'rgba(0, 0, 0, 0.6)' }}
+      onClick={onCancel}
+    >
+      <div
+        onClick={(e) => e.stopPropagation()}
+        style={{
+          background: 'var(--elev)',
+          border: '1px solid var(--border-2)',
+          borderRadius: '12px',
+          padding: '24px',
+          width: '420px',
+          boxShadow: '0 12px 30px rgba(0, 0, 0, 0.35)',
+        }}
+      >
+        <h3
+          style={{
+            fontSize: '18px',
+            fontWeight: 700,
+            color: 'var(--fg)',
+            marginBottom: '8px',
+          }}
+        >
+          {title}
+        </h3>
+        <p
+          style={{
+            fontSize: '13px',
+            color: 'var(--muted-fg)',
+            lineHeight: 1.5,
+          }}
+        >
+          {description}
+        </p>
+
+        {requireInput && (
+          <div style={{ marginTop: '20px' }}>
+            <label
+              style={{
+                display: 'block',
+                fontSize: '12.5px',
+                color: 'var(--muted-fg)',
+                marginBottom: '6px',
+              }}
+            >
+              Type{' '}
+              <code
+                style={{
+                  background: 'var(--card-2)',
+                  padding: '1px 5px',
+                  borderRadius: '4px',
+                  fontSize: '12px',
+                  fontFamily: 'monospace',
+                  color: 'var(--fg)',
+                }}
+              >
+                {requireInput}
+              </code>{' '}
+              to confirm
+            </label>
+            <input
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              style={{
+                width: '100%',
+                padding: '8px 12px',
+                background: 'var(--bg)',
+                border: '1px solid var(--border)',
+                borderRadius: '8px',
+                fontSize: '13px',
+                color: 'var(--fg)',
+                outline: 'none',
+                boxSizing: 'border-box',
+              }}
+            />
+          </div>
+        )}
+
+        <div
+          className="flex justify-end gap-3"
+          style={{ marginTop: '24px' }}
+        >
+          <button
+            onClick={onCancel}
+            style={{
+              padding: '8px 16px',
+              background: 'var(--card)',
+              border: '1px solid var(--border)',
+              borderRadius: '8px',
+              fontSize: '13px',
+              color: 'var(--fg)',
+              cursor: 'pointer',
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleConfirm}
+            disabled={!canConfirm || loading}
+            style={{
+              padding: '8px 16px',
+              background: destructive ? 'var(--error)' : 'var(--primary)',
+              border: 'none',
+              borderRadius: '8px',
+              fontSize: '13px',
+              fontWeight: 600,
+              color: destructive ? '#fff' : 'var(--primary-fg)',
+              cursor: !canConfirm || loading ? 'default' : 'pointer',
+              opacity: !canConfirm || loading ? 0.5 : 1,
+              transition: 'opacity 0.15s',
+            }}
+          >
+            {loading ? 'Processing…' : confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin-ui/src/components/shared/empty-state.tsx
+++ b/apps/admin-ui/src/components/shared/empty-state.tsx
@@ -1,0 +1,43 @@
+export function EmptyState({
+  title,
+  description,
+  action,
+}: {
+  title: string;
+  description?: string;
+  action?: React.ReactNode;
+}) {
+  return (
+    <div
+      style={{
+        border: '1px dashed var(--border-2)',
+        borderRadius: '12px',
+        padding: '60px 20px',
+        textAlign: 'center',
+        background: 'var(--card)',
+      }}
+    >
+      <p
+        style={{
+          fontSize: '15px',
+          fontWeight: 600,
+          color: 'var(--fg)',
+        }}
+      >
+        {title}
+      </p>
+      {description && (
+        <p
+          style={{
+            fontSize: '12.5px',
+            color: 'var(--muted-fg)',
+            marginTop: '5px',
+          }}
+        >
+          {description}
+        </p>
+      )}
+      {action && <div style={{ marginTop: '16px' }}>{action}</div>}
+    </div>
+  );
+}

--- a/apps/admin-ui/src/components/shared/error-boundary.tsx
+++ b/apps/admin-ui/src/components/shared/error-boundary.tsx
@@ -1,0 +1,37 @@
+import { Component, type ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface State {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  render() {
+    if (this.state.error) {
+      if (this.props.fallback) return this.props.fallback;
+      return (
+        <div className="flex flex-col items-center justify-center p-8 text-center">
+          <h2 className="text-lg font-semibold text-destructive">Something went wrong</h2>
+          <p className="mt-2 text-sm text-muted-foreground max-w-md">{this.state.error.message}</p>
+          <button
+            onClick={() => this.setState({ error: null })}
+            className="mt-4 rounded-lg bg-primary px-4 py-2 text-sm text-primary-foreground hover:opacity-90"
+          >
+            Try again
+          </button>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/apps/admin-ui/src/components/shared/loading-skeleton.tsx
+++ b/apps/admin-ui/src/components/shared/loading-skeleton.tsx
@@ -1,0 +1,55 @@
+import { cn } from '@/lib/utils';
+
+export function Skeleton({ className }: { className?: string }) {
+  return (
+    <div
+      className={cn('animate-pulse', className)}
+      style={{ background: 'var(--card-2)', borderRadius: '6px' }}
+    />
+  );
+}
+
+export function TableSkeleton({ rows = 5, cols = 4 }: { rows?: number; cols?: number }) {
+  return (
+    <div className="overflow-x-auto rounded-xl" style={{ border: '1px solid var(--border)' }}>
+      <table className="w-full">
+        <thead>
+          <tr style={{ borderBottom: '1px solid var(--border)', background: 'color-mix(in srgb, var(--card-2) 60%, transparent)' }}>
+            {Array.from({ length: cols }).map((_, i) => (
+              <th key={i} className="px-4 py-3">
+                <Skeleton className="h-4 w-20" />
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {Array.from({ length: rows }).map((_, r) => (
+            <tr key={r} style={{ borderBottom: r < rows - 1 ? '1px solid var(--border)' : 'none' }}>
+              {Array.from({ length: cols }).map((_, c) => (
+                <td key={c} className="px-4 py-3">
+                  <Skeleton className="h-4 w-24" />
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function CardSkeleton() {
+  return (
+    <div
+      className="p-4 space-y-3"
+      style={{
+        borderRadius: '12px',
+        border: '1px solid var(--border)',
+        background: 'var(--card)',
+      }}
+    >
+      <Skeleton className="h-4 w-16" />
+      <Skeleton className="h-8 w-12" />
+    </div>
+  );
+}

--- a/apps/admin-ui/src/components/shared/status-badge.spec.tsx
+++ b/apps/admin-ui/src/components/shared/status-badge.spec.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { StatusBadge } from './status-badge';
+
+describe('StatusBadge', () => {
+  it('renders the value', () => {
+    render(<StatusBadge value="HEALTHY" />);
+    expect(screen.getByText('HEALTHY')).toBeInTheDocument();
+  });
+
+  it('renders N/A for null', () => {
+    render(<StatusBadge value={null} />);
+    expect(screen.getByText('N/A')).toBeInTheDocument();
+  });
+
+  it('renders N/A for undefined', () => {
+    render(<StatusBadge value={undefined} />);
+    expect(screen.getByText('N/A')).toBeInTheDocument();
+  });
+
+  it('applies success color for HEALTHY', () => {
+    render(<StatusBadge value="HEALTHY" />);
+    const el = screen.getByText('HEALTHY');
+    expect(el.style.color).toBe('var(--success)');
+  });
+
+  it('applies success color for PASS', () => {
+    render(<StatusBadge value="PASS" />);
+    const el = screen.getByText('PASS');
+    expect(el.style.color).toBe('var(--success)');
+  });
+
+  it('applies error color for FAILED', () => {
+    render(<StatusBadge value="FAILED" />);
+    const el = screen.getByText('FAILED');
+    expect(el.style.color).toBe('var(--error)');
+  });
+
+  it('applies error color for AUTH_FAIL', () => {
+    render(<StatusBadge value="AUTH_FAIL" />);
+    const el = screen.getByText('AUTH_FAIL');
+    expect(el.style.color).toBe('var(--error)');
+  });
+
+  it('applies warning color for LOGIN_NEEDED', () => {
+    render(<StatusBadge value="LOGIN_NEEDED" />);
+    const el = screen.getByText('LOGIN_NEEDED');
+    expect(el.style.color).toBe('var(--warning)');
+  });
+
+  it('applies violet color for LOGIN_IN_PROGRESS', () => {
+    render(<StatusBadge value="LOGIN_IN_PROGRESS" />);
+    const el = screen.getByText('LOGIN_IN_PROGRESS');
+    expect(el.style.color).toBe('var(--violet)');
+  });
+
+  it('applies neutral color for TERMINATED', () => {
+    render(<StatusBadge value="TERMINATED" />);
+    const el = screen.getByText('TERMINATED');
+    expect(el.style.color).toBe('var(--neutral)');
+  });
+
+  it('applies neutral fallback color for unknown status', () => {
+    render(<StatusBadge value="SOME_UNKNOWN_STATE" />);
+    const el = screen.getByText('SOME_UNKNOWN_STATE');
+    expect(el.style.color).toBe('var(--neutral)');
+  });
+
+  it('forwards className to the element', () => {
+    render(<StatusBadge value="HEALTHY" className="my-custom-class" />);
+    const el = screen.getByText('HEALTHY');
+    expect(el.className).toContain('my-custom-class');
+  });
+});

--- a/apps/admin-ui/src/components/shared/status-badge.tsx
+++ b/apps/admin-ui/src/components/shared/status-badge.tsx
@@ -1,0 +1,54 @@
+import { cn } from '@/lib/utils';
+
+const STATUS_STYLES: Record<string, { bg: string; color: string }> = {
+  HEALTHY: { bg: 'color-mix(in srgb, var(--success) 15%, transparent)', color: 'var(--success)' },
+  PASS: { bg: 'color-mix(in srgb, var(--success) 15%, transparent)', color: 'var(--success)' },
+  ACTIVE: { bg: 'color-mix(in srgb, var(--success) 15%, transparent)', color: 'var(--success)' },
+  ENABLED: { bg: 'color-mix(in srgb, var(--success) 15%, transparent)', color: 'var(--success)' },
+  STARTING: { bg: 'color-mix(in srgb, var(--info) 15%, transparent)', color: 'var(--info)' },
+  STAGING: { bg: 'color-mix(in srgb, var(--info) 15%, transparent)', color: 'var(--info)' },
+  UNHEALTHY: { bg: 'color-mix(in srgb, var(--warning) 15%, transparent)', color: 'var(--warning)' },
+  LOGIN_NEEDED: { bg: 'color-mix(in srgb, var(--warning) 15%, transparent)', color: 'var(--warning)' },
+  CANARY: { bg: 'color-mix(in srgb, var(--warning) 15%, transparent)', color: 'var(--warning)' },
+  TRANSIENT_FAIL: { bg: 'color-mix(in srgb, var(--warning) 15%, transparent)', color: 'var(--warning)' },
+  LOGIN_IN_PROGRESS: { bg: 'color-mix(in srgb, var(--violet) 15%, transparent)', color: 'var(--violet)' },
+  FAILED: { bg: 'color-mix(in srgb, var(--error) 15%, transparent)', color: 'var(--error)' },
+  AUTH_FAIL: { bg: 'color-mix(in srgb, var(--error) 15%, transparent)', color: 'var(--error)' },
+  TERMINATED: { bg: 'color-mix(in srgb, var(--neutral) 15%, transparent)', color: 'var(--neutral)' },
+  RETIRED: { bg: 'color-mix(in srgb, var(--neutral) 15%, transparent)', color: 'var(--neutral)' },
+  DISABLED: { bg: 'color-mix(in srgb, var(--neutral) 15%, transparent)', color: 'var(--neutral)' },
+};
+
+const FALLBACK_STYLE: { bg: string; color: string } = {
+  bg: 'color-mix(in srgb, var(--neutral) 15%, transparent)',
+  color: 'var(--neutral)',
+};
+
+export function StatusBadge({
+  value,
+  className,
+}: {
+  value: string | null | undefined;
+  className?: string;
+}) {
+  const display = value ?? 'N/A';
+  const { bg, color } = STATUS_STYLES[display] ?? FALLBACK_STYLE;
+
+  return (
+    <span
+      className={cn('inline-flex items-center', className)}
+      style={{
+        backgroundColor: bg,
+        color,
+        fontSize: '11px',
+        fontWeight: 600,
+        textTransform: 'uppercase',
+        letterSpacing: '0.04em',
+        padding: '3px 8px',
+        borderRadius: '6px',
+      }}
+    >
+      {display}
+    </span>
+  );
+}

--- a/apps/admin-ui/src/components/templates/common-options.tsx
+++ b/apps/admin-ui/src/components/templates/common-options.tsx
@@ -1,0 +1,87 @@
+interface Props {
+  step: Record<string, unknown>;
+  onChange: (key: string, value: unknown) => void;
+}
+
+const inputClass =
+  'w-full rounded-lg border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring';
+const labelClass = 'block text-xs font-medium text-muted-foreground mb-1';
+
+export function CommonOptions({ step, onChange }: Props) {
+  return (
+    <div className="grid grid-cols-2 gap-3">
+      <div>
+        <label className={labelClass}>Timeout (ms)</label>
+        <input
+          type="number"
+          min={0}
+          value={(step.timeout_ms as number) ?? ''}
+          onChange={(e) => onChange('timeout_ms', e.target.value === '' ? undefined : Number(e.target.value))}
+          placeholder="30000"
+          className={inputClass}
+        />
+      </div>
+
+      <div>
+        <label className={labelClass}>Retry Count</label>
+        <input
+          type="number"
+          min={0}
+          value={(step.retry_count as number) ?? ''}
+          onChange={(e) => onChange('retry_count', e.target.value === '' ? undefined : Number(e.target.value))}
+          placeholder="1"
+          className={inputClass}
+        />
+      </div>
+
+      <div>
+        <label className={labelClass}>Retry Backoff</label>
+        <select
+          value={(step.retry_backoff as string) ?? ''}
+          onChange={(e) => onChange('retry_backoff', e.target.value || undefined)}
+          className={inputClass}
+        >
+          <option value="">default (fixed)</option>
+          <option value="fixed">fixed</option>
+          <option value="exponential">exponential</option>
+        </select>
+      </div>
+
+      <div>
+        <label className={labelClass}>Retry Delay (ms)</label>
+        <input
+          type="number"
+          min={0}
+          value={(step.retry_delay_ms as number) ?? ''}
+          onChange={(e) => onChange('retry_delay_ms', e.target.value === '' ? undefined : Number(e.target.value))}
+          placeholder="1000"
+          className={inputClass}
+        />
+      </div>
+
+      <div>
+        <label className={labelClass}>Retry Max Delay (ms)</label>
+        <input
+          type="number"
+          min={0}
+          value={(step.retry_max_delay_ms as number) ?? ''}
+          onChange={(e) => onChange('retry_max_delay_ms', e.target.value === '' ? undefined : Number(e.target.value))}
+          placeholder="30000"
+          className={inputClass}
+        />
+      </div>
+
+      <div className="flex items-end pb-2">
+        <label className="flex items-center gap-2 text-sm cursor-pointer">
+          <input
+            type="checkbox"
+            checked={(step.sensitive as boolean) ?? false}
+            onChange={(e) => onChange('sensitive', e.target.checked || undefined)}
+            className="h-4 w-4 rounded border-border"
+          />
+          Sensitive
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin-ui/src/components/templates/dsl-step-builder.tsx
+++ b/apps/admin-ui/src/components/templates/dsl-step-builder.tsx
@@ -1,0 +1,205 @@
+import { useState, useCallback } from 'react';
+import { DSL_ACTIONS, type DslAction, type StepData, INTERNAL_KEYS } from './step-types';
+import { StepCard } from './step-card';
+import { JsonEditorPanel } from './json-editor-panel';
+
+interface Props {
+  value: unknown[];
+  onChange: (steps: unknown[]) => void;
+}
+
+type Mode = 'visual' | 'json';
+
+/** Parse raw unknown[] into StepData[], preserving unknown fields in _rest. */
+function parseSteps(raw: unknown[]): StepData[] {
+  return raw.map((item) => {
+    if (typeof item !== 'object' || item === null) {
+      return { action: 'goto' as DslAction, _rest: {} };
+    }
+    const obj = item as Record<string, unknown>;
+    const action = (obj.action as DslAction) ?? ('goto' as DslAction);
+    const rest: Record<string, unknown> = {};
+    const known: Record<string, unknown> = { action };
+
+    for (const [k, v] of Object.entries(obj)) {
+      if (k === 'action') continue;
+      known[k] = v;
+    }
+
+    return { ...known, action, _rest: rest } as StepData;
+  });
+}
+
+/** Serialize StepData[] back to plain objects, stripping internal tracking keys. */
+function serializeSteps(steps: StepData[]): unknown[] {
+  return steps.map(({ _rest, ...rest }) => {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(rest)) {
+      if (INTERNAL_KEYS.has(k)) continue;
+      if (v === undefined || v === '') continue;
+      out[k] = v;
+    }
+    // _rest fields come last so known fields win on conflict
+    for (const [k, v] of Object.entries(_rest ?? {})) {
+      if (!(k in out)) out[k] = v;
+    }
+    return out;
+  });
+}
+
+function defaultStep(action: DslAction): StepData {
+  return { action, _rest: {} };
+}
+
+export function DslStepBuilder({ value, onChange }: Props) {
+  const [mode, setMode] = useState<Mode>('visual');
+  const [steps, setSteps] = useState<StepData[]>(() => parseSteps(value));
+  const [addDropdownOpen, setAddDropdownOpen] = useState(false);
+
+  function commit(next: StepData[]) {
+    setSteps(next);
+    onChange(serializeSteps(next));
+  }
+
+  const handleStepChange = useCallback((index: number, updated: StepData) => {
+    setSteps((prev) => {
+      const next = [...prev];
+      next[index] = updated;
+      onChange(serializeSteps(next));
+      return next;
+    });
+  }, [onChange]);
+
+  function handleDelete(index: number) {
+    commit(steps.filter((_, i) => i !== index));
+  }
+
+  function handleMoveUp(index: number) {
+    if (index === 0) return;
+    const next = [...steps];
+    const a = next[index - 1]!;
+    const b = next[index]!;
+    next[index - 1] = b;
+    next[index] = a;
+    commit(next);
+  }
+
+  function handleMoveDown(index: number) {
+    if (index === steps.length - 1) return;
+    const next = [...steps];
+    const a = next[index]!;
+    const b = next[index + 1]!;
+    next[index] = b;
+    next[index + 1] = a;
+    commit(next);
+  }
+
+  function handleAddStep(action: DslAction) {
+    commit([...steps, defaultStep(action)]);
+    setAddDropdownOpen(false);
+  }
+
+  function handleJsonApply(parsed: StepData[]) {
+    commit(parsed);
+  }
+
+  function toggleMode() {
+    setMode((m) => (m === 'visual' ? 'json' : 'visual'));
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Toolbar */}
+      <div className="flex items-center gap-3">
+        {/* Add Step dropdown */}
+        <div className="relative">
+          <button
+            type="button"
+            onClick={() => setAddDropdownOpen((o) => !o)}
+            className="rounded-lg border border-border bg-background px-3 py-2 text-sm hover:bg-muted flex items-center gap-1.5"
+          >
+            + Add Step
+            <span className="text-muted-foreground text-xs">▾</span>
+          </button>
+
+          {addDropdownOpen && (
+            <>
+              {/* Backdrop */}
+              <div
+                className="fixed inset-0 z-10"
+                onClick={() => setAddDropdownOpen(false)}
+              />
+              <div className="absolute left-0 top-full z-20 mt-1 w-52 rounded-xl border border-border bg-card shadow-lg overflow-hidden">
+                <div className="grid grid-cols-2 gap-px bg-border p-px">
+                  {DSL_ACTIONS.map((action) => (
+                    <button
+                      key={action}
+                      type="button"
+                      onClick={() => handleAddStep(action)}
+                      className="bg-card px-3 py-2 text-left text-xs font-mono hover:bg-muted"
+                    >
+                      {action}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            </>
+          )}
+        </div>
+
+        <div className="ml-auto flex items-center gap-1 rounded-lg border border-border bg-background p-1">
+          <button
+            type="button"
+            onClick={() => setMode('visual')}
+            className={`rounded px-3 py-1 text-xs font-medium transition-colors ${
+              mode === 'visual' ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'
+            }`}
+          >
+            Visual
+          </button>
+          <button
+            type="button"
+            onClick={toggleMode}
+            className={`rounded px-3 py-1 text-xs font-medium transition-colors ${
+              mode === 'json' ? 'bg-primary text-primary-foreground' : 'hover:bg-muted'
+            }`}
+          >
+            JSON
+          </button>
+        </div>
+      </div>
+
+      {/* Content */}
+      {mode === 'visual' ? (
+        <div className="space-y-3">
+          {steps.length === 0 && (
+            <div className="rounded-xl border border-dashed border-border py-10 text-center">
+              <p className="text-sm text-muted-foreground">No steps yet. Use "Add Step" to begin.</p>
+            </div>
+          )}
+          {steps.map((step, i) => (
+            <StepCard
+              key={i}
+              index={i}
+              step={step}
+              onChange={handleStepChange}
+              onDelete={handleDelete}
+              onMoveUp={handleMoveUp}
+              onMoveDown={handleMoveDown}
+              isFirst={i === 0}
+              isLast={i === steps.length - 1}
+            />
+          ))}
+        </div>
+      ) : (
+        <JsonEditorPanel steps={steps} onApply={handleJsonApply} />
+      )}
+
+      {mode === 'visual' && steps.length > 0 && (
+        <p className="text-xs text-muted-foreground">
+          {steps.length} step{steps.length !== 1 ? 's' : ''}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/admin-ui/src/components/templates/json-editor-panel.tsx
+++ b/apps/admin-ui/src/components/templates/json-editor-panel.tsx
@@ -1,0 +1,86 @@
+import { useState, useEffect } from 'react';
+import type { StepData } from './step-types';
+
+interface Props {
+  steps: StepData[];
+  onApply: (steps: StepData[]) => void;
+}
+
+function stepsToJson(steps: StepData[]): string {
+  const serialized = steps.map(({ _rest, ...rest }) => {
+    const { ...fields } = rest;
+    // Strip undefined values and merge _rest back in
+    const clean: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(fields)) {
+      if (v !== undefined) clean[k] = v;
+    }
+    return { ...clean, ...(_rest ?? {}) };
+  });
+  return JSON.stringify(serialized, null, 2);
+}
+
+export function JsonEditorPanel({ steps, onApply }: Props) {
+  const [text, setText] = useState(() => stepsToJson(steps));
+  const [error, setError] = useState<string | null>(null);
+
+  // Sync when steps change externally (e.g. add/delete from visual mode)
+  useEffect(() => {
+    setText(stepsToJson(steps));
+    setError(null);
+  }, [steps]);
+
+  function handleApply() {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(text);
+    } catch (e) {
+      setError(`JSON parse error: ${(e as Error).message}`);
+      return;
+    }
+
+    if (!Array.isArray(parsed)) {
+      setError('Root value must be an array of steps.');
+      return;
+    }
+
+    for (let i = 0; i < parsed.length; i++) {
+      const item = parsed[i];
+      if (typeof item !== 'object' || item === null || !('action' in item)) {
+        setError(`Step ${i + 1} is missing required "action" field.`);
+        return;
+      }
+    }
+
+    setError(null);
+    onApply(parsed as StepData[]);
+  }
+
+  return (
+    <div className="space-y-3">
+      <textarea
+        value={text}
+        onChange={(e) => {
+          setText(e.target.value);
+          setError(null);
+        }}
+        rows={20}
+        spellCheck={false}
+        className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm font-mono focus:outline-none focus:ring-2 focus:ring-ring resize-y"
+      />
+
+      {error && (
+        <p className="rounded-lg border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+          {error}
+        </p>
+      )}
+
+      <button
+        type="button"
+        onClick={handleApply}
+        className="rounded-lg bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90"
+      >
+        Apply
+      </button>
+    </div>
+  );
+}

--- a/apps/admin-ui/src/components/templates/on-failure-section.tsx
+++ b/apps/admin-ui/src/components/templates/on-failure-section.tsx
@@ -1,0 +1,95 @@
+import { HUMAN_INPUT_TYPES } from './step-types';
+
+interface OnFailureValue {
+  action: 'skip' | 'abort' | 'request_help';
+  message?: string;
+  input_type?: string;
+  screenshot?: boolean;
+}
+
+interface Props {
+  step: Record<string, unknown>;
+  onChange: (key: string, value: unknown) => void;
+}
+
+const inputClass =
+  'w-full rounded-lg border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring';
+const labelClass = 'block text-xs font-medium text-muted-foreground mb-1';
+
+export function OnFailureSection({ step, onChange }: Props) {
+  const raw = step.on_failure as OnFailureValue | undefined;
+  const action = raw?.action ?? '';
+
+  function setField(field: keyof OnFailureValue, value: unknown) {
+    const current = (step.on_failure as OnFailureValue | undefined) ?? { action: 'skip' };
+    onChange('on_failure', { ...current, [field]: value });
+  }
+
+  function handleActionChange(next: string) {
+    if (!next) {
+      onChange('on_failure', undefined);
+      return;
+    }
+    const base: OnFailureValue = { action: next as OnFailureValue['action'] };
+    onChange('on_failure', base);
+  }
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <label className={labelClass}>Action</label>
+        <select
+          value={action}
+          onChange={(e) => handleActionChange(e.target.value)}
+          className={inputClass}
+        >
+          <option value="">— none —</option>
+          <option value="skip">skip</option>
+          <option value="abort">abort</option>
+          <option value="request_help">request_help</option>
+        </select>
+      </div>
+
+      {action === 'request_help' && (
+        <>
+          <div>
+            <label className={labelClass}>Message</label>
+            <input
+              type="text"
+              value={raw?.message ?? ''}
+              onChange={(e) => setField('message', e.target.value || undefined)}
+              placeholder="Please help with this step"
+              className={inputClass}
+            />
+          </div>
+
+          <div>
+            <label className={labelClass}>Input Type (optional)</label>
+            <select
+              value={raw?.input_type ?? ''}
+              onChange={(e) => setField('input_type', e.target.value || undefined)}
+              className={inputClass}
+            >
+              <option value="">— none —</option>
+              {HUMAN_INPUT_TYPES.map((t) => (
+                <option key={t} value={t}>
+                  {t}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <label className="flex items-center gap-2 text-sm cursor-pointer">
+            <input
+              type="checkbox"
+              checked={raw?.screenshot ?? false}
+              onChange={(e) => setField('screenshot', e.target.checked || undefined)}
+              className="h-4 w-4 rounded border-border"
+            />
+            Capture screenshot
+          </label>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/admin-ui/src/components/templates/step-card.tsx
+++ b/apps/admin-ui/src/components/templates/step-card.tsx
@@ -1,0 +1,167 @@
+import { type StepData, type DslAction, SELECTOR_VALUE_ACTIONS, ZERO_FIELD_ACTIONS, ON_FAILURE_ACTIONS } from './step-types';
+import {
+  GotoFields,
+  SelectorValueFields,
+  SelectorFields,
+  PatternField,
+  KeyboardField,
+  EvaluateFields,
+  SleepField,
+  HumanInputFields,
+  ZeroFields,
+} from './step-fields';
+import { CommonOptions } from './common-options';
+import { OnFailureSection } from './on-failure-section';
+
+interface Props {
+  index: number;
+  step: StepData;
+  onChange: (index: number, step: StepData) => void;
+  onDelete: (index: number) => void;
+  onMoveUp: (index: number) => void;
+  onMoveDown: (index: number) => void;
+  isFirst: boolean;
+  isLast: boolean;
+}
+
+const ACTION_BADGE_COLORS: Record<DslAction, string> = {
+  goto: 'bg-blue-100 text-blue-800 dark:bg-blue-900/40 dark:text-blue-300',
+  fill: 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300',
+  type: 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300',
+  click: 'bg-orange-100 text-orange-800 dark:bg-orange-900/40 dark:text-orange-300',
+  select: 'bg-green-100 text-green-800 dark:bg-green-900/40 dark:text-green-300',
+  wait_for: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-300',
+  wait_for_url: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/40 dark:text-yellow-300',
+  frame: 'bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300',
+  main_frame: 'bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300',
+  popup: 'bg-purple-100 text-purple-800 dark:bg-purple-900/40 dark:text-purple-300',
+  keyboard: 'bg-slate-100 text-slate-800 dark:bg-slate-900/40 dark:text-slate-300',
+  evaluate: 'bg-pink-100 text-pink-800 dark:bg-pink-900/40 dark:text-pink-300',
+  sleep: 'bg-slate-100 text-slate-800 dark:bg-slate-900/40 dark:text-slate-300',
+  screenshot: 'bg-indigo-100 text-indigo-800 dark:bg-indigo-900/40 dark:text-indigo-300',
+  reload: 'bg-slate-100 text-slate-800 dark:bg-slate-900/40 dark:text-slate-300',
+  request_human_input: 'bg-rose-100 text-rose-800 dark:bg-rose-900/40 dark:text-rose-300',
+};
+
+function stepSummary(step: StepData): string {
+  const s = step as Record<string, unknown>;
+  if (s.url) return String(s.url);
+  if (s.selector) return String(s.selector);
+  if (s.pattern) return String(s.pattern);
+  if (s.key) return String(s.key);
+  if (s.label) return String(s.label);
+  if (s.ms != null) return `${s.ms}ms`;
+  return '';
+}
+
+export function StepCard({ index, step, onChange, onDelete, onMoveUp, onMoveDown, isFirst, isLast }: Props) {
+  const action = step.action;
+  const badgeColor = ACTION_BADGE_COLORS[action] ?? 'bg-muted text-foreground';
+  const summary = stepSummary(step);
+
+  function handleFieldChange(key: string, value: unknown) {
+    onChange(index, { ...step, [key]: value });
+  }
+
+  function renderFields() {
+    if (action === 'goto') return <GotoFields step={step as Record<string, unknown>} onChange={handleFieldChange} />;
+    if (SELECTOR_VALUE_ACTIONS.includes(action as typeof SELECTOR_VALUE_ACTIONS[number])) {
+      return <SelectorValueFields step={step as Record<string, unknown>} onChange={handleFieldChange} />;
+    }
+    if (action === 'frame') {
+      return <SelectorFields step={step as Record<string, unknown>} onChange={handleFieldChange} showFirst={false} />;
+    }
+    if (action === 'click' || action === 'wait_for') {
+      return <SelectorFields step={step as Record<string, unknown>} onChange={handleFieldChange} showFirst />;
+    }
+    if (action === 'wait_for_url') return <PatternField step={step as Record<string, unknown>} onChange={handleFieldChange} />;
+    if (action === 'keyboard') return <KeyboardField step={step as Record<string, unknown>} onChange={handleFieldChange} />;
+    if (action === 'evaluate') return <EvaluateFields step={step as Record<string, unknown>} onChange={handleFieldChange} />;
+    if (action === 'sleep') return <SleepField step={step as Record<string, unknown>} onChange={handleFieldChange} />;
+    if (action === 'request_human_input') return <HumanInputFields step={step as Record<string, unknown>} onChange={handleFieldChange} />;
+    if (ZERO_FIELD_ACTIONS.includes(action as typeof ZERO_FIELD_ACTIONS[number])) return <ZeroFields />;
+    return <ZeroFields />;
+  }
+
+  const showOnFailure = ON_FAILURE_ACTIONS.includes(action as typeof ON_FAILURE_ACTIONS[number]);
+
+  return (
+    <div className="rounded-xl border border-border bg-card">
+      {/* Header */}
+      <div className="flex items-center gap-3 px-4 py-3">
+        <span className="text-xs font-mono text-muted-foreground w-6 shrink-0">{index + 1}</span>
+
+        <span className={`shrink-0 rounded-md px-2 py-0.5 text-xs font-mono font-medium ${badgeColor}`}>
+          {action}
+        </span>
+
+        {summary && (
+          <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground font-mono">
+            {summary}
+          </span>
+        )}
+
+        <div className="ml-auto flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => onMoveUp(index)}
+            disabled={isFirst}
+            className="rounded px-1.5 py-1 text-xs text-muted-foreground hover:bg-muted disabled:opacity-30"
+            title="Move up"
+          >
+            ↑
+          </button>
+          <button
+            type="button"
+            onClick={() => onMoveDown(index)}
+            disabled={isLast}
+            className="rounded px-1.5 py-1 text-xs text-muted-foreground hover:bg-muted disabled:opacity-30"
+            title="Move down"
+          >
+            ↓
+          </button>
+          <button
+            type="button"
+            onClick={() => onDelete(index)}
+            className="rounded px-1.5 py-1 text-xs text-muted-foreground hover:bg-destructive/10 hover:text-destructive"
+            title="Delete step"
+          >
+            ✕
+          </button>
+        </div>
+      </div>
+
+      {/* Body */}
+      <div className="border-t border-border px-4 py-3">
+        {renderFields()}
+      </div>
+
+      {/* Advanced */}
+      <details className="border-t border-border">
+        <summary className="cursor-pointer px-4 py-2 text-xs font-medium text-muted-foreground hover:bg-muted select-none">
+          Advanced options
+        </summary>
+        <div className="px-4 pb-3 pt-2">
+          <CommonOptions step={step as Record<string, unknown>} onChange={handleFieldChange} />
+        </div>
+      </details>
+
+      {/* On Failure */}
+      {showOnFailure && (
+        <details className="border-t border-border">
+          <summary className="cursor-pointer px-4 py-2 text-xs font-medium text-muted-foreground hover:bg-muted select-none">
+            On failure
+            {step.on_failure != null && (
+              <span className="ml-2 rounded bg-amber-100 px-1.5 text-amber-800 dark:bg-amber-900/40 dark:text-amber-300">
+                {(step.on_failure as { action: string }).action}
+              </span>
+            )}
+          </summary>
+          <div className="px-4 pb-3 pt-2">
+            <OnFailureSection step={step as Record<string, unknown>} onChange={handleFieldChange} />
+          </div>
+        </details>
+      )}
+    </div>
+  );
+}

--- a/apps/admin-ui/src/components/templates/step-fields.tsx
+++ b/apps/admin-ui/src/components/templates/step-fields.tsx
@@ -1,0 +1,208 @@
+import { HUMAN_INPUT_TYPES } from './step-types';
+
+interface FieldProps {
+  step: Record<string, unknown>;
+  onChange: (key: string, value: unknown) => void;
+}
+
+const inputClass =
+  'w-full rounded-lg border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring';
+const labelClass = 'block text-xs font-medium text-muted-foreground mb-1';
+const checkboxLabelClass = 'flex items-center gap-2 text-sm';
+
+function TextField({
+  label,
+  fieldKey,
+  step,
+  onChange,
+  placeholder,
+  mono,
+}: {
+  label: string;
+  fieldKey: string;
+  step: Record<string, unknown>;
+  onChange: (key: string, value: unknown) => void;
+  placeholder?: string;
+  mono?: boolean;
+}) {
+  return (
+    <div>
+      <label className={labelClass}>{label}</label>
+      <input
+        type="text"
+        value={(step[fieldKey] as string) ?? ''}
+        onChange={(e) => onChange(fieldKey, e.target.value)}
+        placeholder={placeholder}
+        className={inputClass + (mono ? ' font-mono' : '')}
+      />
+    </div>
+  );
+}
+
+function CheckboxField({
+  label,
+  fieldKey,
+  step,
+  onChange,
+}: {
+  label: string;
+  fieldKey: string;
+  step: Record<string, unknown>;
+  onChange: (key: string, value: unknown) => void;
+}) {
+  return (
+    <label className={checkboxLabelClass}>
+      <input
+        type="checkbox"
+        checked={(step[fieldKey] as boolean) ?? false}
+        onChange={(e) => onChange(fieldKey, e.target.checked)}
+        className="h-4 w-4 rounded border-border"
+      />
+      {label}
+    </label>
+  );
+}
+
+export function GotoFields({ step, onChange }: FieldProps) {
+  return (
+    <div className="space-y-3">
+      <TextField label="URL" fieldKey="url" step={step} onChange={onChange} placeholder="https://example.com" mono />
+      {step.url_expression != null && (
+        <TextField
+          label="URL Expression (JS)"
+          fieldKey="url_expression"
+          step={step}
+          onChange={onChange}
+          placeholder="'https://example.com/' + tenantId"
+          mono
+        />
+      )}
+      {step.url_expression == null && (
+        <button
+          type="button"
+          onClick={() => onChange('url_expression', '')}
+          className="text-xs text-primary hover:underline"
+        >
+          + Add url_expression
+        </button>
+      )}
+    </div>
+  );
+}
+
+export function SelectorValueFields({ step, onChange }: FieldProps) {
+  return (
+    <div className="space-y-3">
+      <TextField label="Selector" fieldKey="selector" step={step} onChange={onChange} placeholder="input#username" mono />
+      <TextField label="Value" fieldKey="value" step={step} onChange={onChange} placeholder="${USERNAME}" mono />
+    </div>
+  );
+}
+
+export function SelectorFields({ step, onChange, showFirst }: FieldProps & { showFirst?: boolean }) {
+  return (
+    <div className="space-y-3">
+      <TextField label="Selector" fieldKey="selector" step={step} onChange={onChange} placeholder="button.submit" mono />
+      {showFirst && (
+        <CheckboxField label="First match only" fieldKey="first" step={step} onChange={onChange} />
+      )}
+    </div>
+  );
+}
+
+export function PatternField({ step, onChange }: FieldProps) {
+  return (
+    <TextField
+      label="URL Pattern (regex or glob)"
+      fieldKey="pattern"
+      step={step}
+      onChange={onChange}
+      placeholder="**/dashboard**"
+      mono
+    />
+  );
+}
+
+export function KeyboardField({ step, onChange }: FieldProps) {
+  return (
+    <TextField
+      label="Key"
+      fieldKey="key"
+      step={step}
+      onChange={onChange}
+      placeholder="Enter"
+      mono
+    />
+  );
+}
+
+export function EvaluateFields({ step, onChange }: FieldProps) {
+  return (
+    <div className="space-y-3">
+      <div>
+        <label className={labelClass}>Expression (JS)</label>
+        <textarea
+          value={(step.expression as string) ?? ''}
+          onChange={(e) => onChange('expression', e.target.value)}
+          rows={3}
+          placeholder="document.querySelector('#token')?.value"
+          className={inputClass + ' font-mono resize-y'}
+        />
+      </div>
+      <TextField
+        label="Store as (variable name)"
+        fieldKey="store_as"
+        step={step}
+        onChange={onChange}
+        placeholder="myVar"
+        mono
+      />
+    </div>
+  );
+}
+
+export function SleepField({ step, onChange }: FieldProps) {
+  return (
+    <div>
+      <label className={labelClass}>Duration (ms)</label>
+      <input
+        type="number"
+        min={0}
+        value={(step.ms as number) ?? ''}
+        onChange={(e) => onChange('ms', e.target.value === '' ? '' : Number(e.target.value))}
+        placeholder="1000"
+        className={inputClass}
+      />
+    </div>
+  );
+}
+
+export function HumanInputFields({ step, onChange }: FieldProps) {
+  return (
+    <div className="space-y-3">
+      <div>
+        <label className={labelClass}>Input Type</label>
+        <select
+          value={(step.input_type as string) ?? ''}
+          onChange={(e) => onChange('input_type', e.target.value)}
+          className={inputClass}
+        >
+          <option value="">— select —</option>
+          {HUMAN_INPUT_TYPES.map((t) => (
+            <option key={t} value={t}>
+              {t}
+            </option>
+          ))}
+        </select>
+      </div>
+      <TextField label="Label" fieldKey="label" step={step} onChange={onChange} placeholder="Enter your OTP" />
+      <TextField label="Field Selector (optional)" fieldKey="field_selector" step={step} onChange={onChange} placeholder="input#otp" mono />
+      <TextField label="Submit Selector (optional)" fieldKey="submit_selector" step={step} onChange={onChange} placeholder="button[type=submit]" mono />
+      <TextField label="Placeholder (optional)" fieldKey="placeholder" step={step} onChange={onChange} placeholder="6-digit code" />
+    </div>
+  );
+}
+
+export function ZeroFields() {
+  return <p className="text-xs text-muted-foreground italic">No fields for this step type.</p>;
+}

--- a/apps/admin-ui/src/components/templates/step-types.spec.ts
+++ b/apps/admin-ui/src/components/templates/step-types.spec.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { DSL_ACTIONS, ZERO_FIELD_ACTIONS, ON_FAILURE_ACTIONS, SELECTOR_VALUE_ACTIONS } from './step-types';
+
+describe('step-types', () => {
+  it('has 16 action types', () => {
+    expect(DSL_ACTIONS).toHaveLength(16);
+  });
+
+  it('zero-field actions are subset of all actions', () => {
+    for (const a of ZERO_FIELD_ACTIONS) {
+      expect(DSL_ACTIONS).toContain(a);
+    }
+  });
+
+  it('on-failure actions are subset of all actions', () => {
+    for (const a of ON_FAILURE_ACTIONS) {
+      expect(DSL_ACTIONS).toContain(a);
+    }
+  });
+
+  it('selector-value actions are fill, type, select', () => {
+    expect(SELECTOR_VALUE_ACTIONS).toEqual(['fill', 'type', 'select']);
+  });
+});

--- a/apps/admin-ui/src/components/templates/step-types.ts
+++ b/apps/admin-ui/src/components/templates/step-types.ts
@@ -54,4 +54,4 @@ export const COMMON_OPTION_KEYS = [
 export const ON_FAILURE_KEY = 'on_failure';
 
 /** Keys that are serialized from StepData directly (not unknown extra keys). */
-export const INTERNAL_KEYS = new Set(['action', '_rest']);
+export const INTERNAL_KEYS = new Set(['_rest']);

--- a/apps/admin-ui/src/components/templates/step-types.ts
+++ b/apps/admin-ui/src/components/templates/step-types.ts
@@ -1,0 +1,57 @@
+export const DSL_ACTIONS = [
+  'goto',
+  'fill',
+  'type',
+  'click',
+  'select',
+  'wait_for',
+  'wait_for_url',
+  'frame',
+  'main_frame',
+  'popup',
+  'keyboard',
+  'evaluate',
+  'sleep',
+  'screenshot',
+  'reload',
+  'request_human_input',
+] as const;
+
+export type DslAction = (typeof DSL_ACTIONS)[number];
+
+export const ZERO_FIELD_ACTIONS: DslAction[] = ['screenshot', 'reload', 'main_frame', 'popup'];
+export const SELECTOR_VALUE_ACTIONS: DslAction[] = ['fill', 'type', 'select'];
+export const SELECTOR_ONLY_ACTIONS: DslAction[] = ['click', 'wait_for', 'frame'];
+export const ON_FAILURE_ACTIONS: DslAction[] = ['goto', 'fill', 'click', 'wait_for', 'wait_for_url'];
+
+export const HUMAN_INPUT_TYPES = [
+  'otp',
+  'email',
+  'password',
+  'captcha',
+  'verification_code',
+  'url',
+  'confirm',
+] as const;
+
+export type HumanInputType = (typeof HUMAN_INPUT_TYPES)[number];
+
+export interface StepData {
+  action: DslAction;
+  [key: string]: unknown;
+  _rest?: Record<string, unknown>;
+}
+
+export const COMMON_OPTION_KEYS = [
+  'timeout_ms',
+  'retry_count',
+  'sensitive',
+  'retry_backoff',
+  'retry_delay_ms',
+  'retry_max_delay_ms',
+] as const;
+
+export const ON_FAILURE_KEY = 'on_failure';
+
+/** Keys that are serialized from StepData directly (not unknown extra keys). */
+export const INTERNAL_KEYS = new Set(['action', '_rest']);

--- a/apps/admin-ui/src/components/viewer/cdp-viewer.tsx
+++ b/apps/admin-ui/src/components/viewer/cdp-viewer.tsx
@@ -1,0 +1,174 @@
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { env } from '@/env';
+
+interface Props {
+  sessionId: string;
+  token: string;
+  onDisconnect?: () => void;
+}
+
+interface CdpMessage {
+  id?: number;
+  method?: string;
+  params?: Record<string, unknown>;
+  result?: Record<string, unknown>;
+}
+
+export function CdpViewer({ sessionId, token, onDisconnect }: Props) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+  const nextIdRef = useRef(1);
+  const [status, setStatus] = useState<'connecting' | 'connected' | 'disconnected'>('connecting');
+
+  const sendCdp = useCallback((method: string, params?: Record<string, unknown>) => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    const id = nextIdRef.current++;
+    ws.send(JSON.stringify({ id, method, params }));
+  }, []);
+
+  const connect = useCallback(() => {
+    const apiUrl = env.apiUrl();
+    const wsBase = apiUrl.replace(/^http/, 'ws');
+    const wsUrl = `${wsBase}/cdp-ws?session_id=${sessionId}&token=${encodeURIComponent(token)}`;
+    const ws = new WebSocket(wsUrl);
+    wsRef.current = ws;
+
+    ws.onopen = () => {
+      setStatus('connected');
+      sendCdp('Page.startScreencast', {
+        format: 'jpeg',
+        quality: 70,
+        maxWidth: 1920,
+        maxHeight: 1080,
+        everyNthFrame: 1,
+      });
+    };
+
+    ws.onmessage = (event) => {
+      let msg: CdpMessage;
+      try {
+        msg = JSON.parse(event.data as string);
+      } catch {
+        return;
+      }
+
+      if (msg.method === 'Page.screencastFrame') {
+        const { data, sessionId: frameSessionId } = msg.params as {
+          data: string;
+          sessionId: number;
+        };
+        sendCdp('Page.screencastFrameAck', { sessionId: frameSessionId });
+
+        const canvas = canvasRef.current;
+        if (!canvas) return;
+        const ctx = canvas.getContext('2d');
+        if (!ctx) return;
+
+        const img = new Image();
+        img.onload = () => {
+          if (canvas.width !== img.width || canvas.height !== img.height) {
+            canvas.width = img.width;
+            canvas.height = img.height;
+          }
+          ctx.drawImage(img, 0, 0);
+        };
+        img.src = `data:image/jpeg;base64,${data}`;
+      }
+    };
+
+    ws.onclose = () => {
+      setStatus('disconnected');
+      onDisconnect?.();
+    };
+
+    ws.onerror = () => {
+      setStatus('disconnected');
+    };
+  }, [sessionId, token, sendCdp, onDisconnect]);
+
+  useEffect(() => {
+    connect();
+    return () => {
+      wsRef.current?.close();
+      wsRef.current = null;
+    };
+  }, [connect]);
+
+  const handleMouseEvent = useCallback(
+    (e: React.MouseEvent<HTMLCanvasElement>, type: string) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const rect = canvas.getBoundingClientRect();
+      const x = ((e.clientX - rect.left) / rect.width) * canvas.width;
+      const y = ((e.clientY - rect.top) / rect.height) * canvas.height;
+
+      type CdpMouseType = 'mousePressed' | 'mouseReleased' | 'mouseMoved';
+      const cdpType: CdpMouseType =
+        type === 'mousedown'
+          ? 'mousePressed'
+          : type === 'mouseup'
+            ? 'mouseReleased'
+            : 'mouseMoved';
+
+      const button =
+        type === 'mousedown' || type === 'mouseup'
+          ? e.button === 0
+            ? 'left'
+            : e.button === 2
+              ? 'right'
+              : 'middle'
+          : 'none';
+
+      sendCdp('Input.dispatchMouseEvent', {
+        type: cdpType,
+        x,
+        y,
+        button,
+        clickCount: type === 'mousedown' ? 1 : 0,
+      });
+    },
+    [sendCdp],
+  );
+
+  const handleKeyEvent = useCallback(
+    (e: React.KeyboardEvent<HTMLCanvasElement>, type: 'keyDown' | 'keyUp') => {
+      e.preventDefault();
+      sendCdp('Input.dispatchKeyEvent', {
+        type,
+        key: e.key,
+        code: e.code,
+        text: type === 'keyDown' && e.key.length === 1 ? e.key : undefined,
+      });
+    },
+    [sendCdp],
+  );
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-border bg-card text-xs shrink-0">
+        <span
+          className={`inline-block w-2 h-2 rounded-full ${
+            status === 'connected'
+              ? 'bg-emerald-500'
+              : status === 'connecting'
+                ? 'bg-amber-500 animate-pulse'
+                : 'bg-red-500'
+          }`}
+        />
+        <span className="text-muted-foreground">CDP {status}</span>
+      </div>
+      <canvas
+        ref={canvasRef}
+        className="flex-1 bg-black cursor-default max-w-full"
+        style={{ objectFit: 'contain' }}
+        tabIndex={0}
+        onMouseMove={(e) => handleMouseEvent(e, 'mousemove')}
+        onMouseDown={(e) => handleMouseEvent(e, 'mousedown')}
+        onMouseUp={(e) => handleMouseEvent(e, 'mouseup')}
+        onKeyDown={(e) => handleKeyEvent(e, 'keyDown')}
+        onKeyUp={(e) => handleKeyEvent(e, 'keyUp')}
+      />
+    </div>
+  );
+}

--- a/apps/admin-ui/src/components/viewer/hitl-panel.tsx
+++ b/apps/admin-ui/src/components/viewer/hitl-panel.tsx
@@ -1,0 +1,344 @@
+import { useState, useCallback } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { sessionsApi } from '@/api/sessions';
+import { hitlApi } from '@/api/hitl';
+import { StatusBadge } from '@/components/shared/status-badge';
+
+interface Props {
+  sessionId: string;
+  open: boolean;
+  onToggle: () => void;
+  onSendClipboard?: (text: string) => void;
+}
+
+const SECTION_LABEL_STYLE: React.CSSProperties = {
+  fontSize: '11px',
+  fontWeight: 600,
+  textTransform: 'uppercase' as const,
+  letterSpacing: '0.06em',
+  color: 'var(--faint-fg)',
+  marginBottom: '10px',
+};
+
+const ROW_STYLE: React.CSSProperties = {
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  marginBottom: '8px',
+};
+
+const ROW_KEY_STYLE: React.CSSProperties = {
+  fontSize: '12px',
+  color: 'var(--muted-fg)',
+};
+
+const ROW_VALUE_STYLE: React.CSSProperties = {
+  fontSize: '12px',
+  color: 'var(--fg)',
+  fontWeight: 500,
+};
+
+export function HitlPanel({ sessionId, onSendClipboard }: Props) {
+  const qc = useQueryClient();
+  const [clipboard, setClipboard] = useState('');
+  const [resolvedStep, setResolvedStep] = useState<number | null>(null);
+  const [restartConfirm, setRestartConfirm] = useState(false);
+
+  const { data: session } = useQuery({
+    queryKey: ['session', sessionId],
+    queryFn: () => sessionsApi.get(sessionId),
+    refetchInterval: 3_000,
+  });
+
+  const resolveMutation = useMutation({
+    mutationFn: (stepIndex: number) =>
+      hitlApi.submitInput(sessionId, {
+        input_type: 'confirm',
+        value: 'resolved',
+        step_index: stepIndex,
+      }),
+    onSuccess: (_, stepIndex) => {
+      setResolvedStep(stepIndex);
+      qc.invalidateQueries({ queryKey: ['session', sessionId] });
+    },
+  });
+
+  const acknowledgeMutation = useMutation({
+    mutationFn: () => hitlApi.acknowledge(sessionId),
+    onSuccess: () => {
+      setRestartConfirm(false);
+      qc.invalidateQueries({ queryKey: ['session', sessionId] });
+    },
+  });
+
+  const handleSendClipboard = useCallback(() => {
+    if (!clipboard) return;
+    onSendClipboard?.(clipboard);
+    setClipboard('');
+  }, [clipboard, onSendClipboard]);
+
+  const pending = session?.pending_input_request as
+    | { input_type: string; label?: string; step_index: number }
+    | null
+    | undefined;
+
+  const canResolve = !!pending && resolvedStep !== pending.step_index;
+  const alreadyResolved = !!pending && resolvedStep === pending.step_index;
+
+  return (
+    <div
+      className="flex flex-col shrink-0 overflow-hidden"
+      style={{
+        width: '320px',
+        background: 'var(--card)',
+        borderLeft: '1px solid var(--border)',
+      }}
+    >
+      <div
+        className="flex-1 overflow-y-auto"
+        style={{ padding: '14px' }}
+      >
+        {/* Human input needed */}
+        {pending && (
+          <div
+            style={{
+              border: '1px solid color-mix(in srgb, var(--warning) 40%, transparent)',
+              background: 'color-mix(in srgb, var(--warning) 12%, transparent)',
+              borderRadius: '10px',
+              padding: '13px',
+              marginBottom: '18px',
+            }}
+          >
+            <div
+              className="flex items-center gap-2"
+              style={{ marginBottom: '4px' }}
+            >
+              <span style={{ fontSize: '13px' }}>⚠️</span>
+              <span
+                style={{
+                  fontSize: '12.5px',
+                  fontWeight: 700,
+                  color: 'var(--warning)',
+                }}
+              >
+                Human input needed
+              </span>
+            </div>
+            <p
+              style={{
+                fontSize: '11px',
+                textTransform: 'uppercase',
+                letterSpacing: '0.05em',
+                color: 'var(--muted-fg)',
+                marginBottom: '6px',
+              }}
+            >
+              {pending.input_type}
+            </p>
+            {pending.label && (
+              <p
+                style={{
+                  fontSize: '13px',
+                  color: 'var(--fg)',
+                  marginBottom: '12px',
+                }}
+              >
+                {pending.label}
+              </p>
+            )}
+            <button
+              onClick={() => resolveMutation.mutate(pending.step_index)}
+              disabled={!canResolve || resolveMutation.isPending}
+              style={{
+                width: '100%',
+                padding: '8px 12px',
+                borderRadius: '7px',
+                border: 'none',
+                background: alreadyResolved
+                  ? 'color-mix(in srgb, var(--success) 60%, transparent)'
+                  : 'var(--success)',
+                color: '#fff',
+                fontSize: '12.5px',
+                fontWeight: 600,
+                cursor: canResolve && !resolveMutation.isPending ? 'pointer' : 'default',
+                opacity: !canResolve || resolveMutation.isPending ? 0.6 : 1,
+                transition: 'opacity 0.15s',
+              }}
+            >
+              {resolveMutation.isPending
+                ? 'Resolving…'
+                : alreadyResolved
+                  ? 'Resolved'
+                  : 'Mark as resolved'}
+            </button>
+          </div>
+        )}
+
+        {/* Clipboard */}
+        <div style={{ marginBottom: '20px' }}>
+          <p style={SECTION_LABEL_STYLE}>Clipboard</p>
+          <div className="flex gap-2">
+            <input
+              type="password"
+              value={clipboard}
+              onChange={(e) => setClipboard(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && handleSendClipboard()}
+              placeholder="Text to paste into VNC"
+              style={{
+                flex: 1,
+                height: '34px',
+                padding: '0 10px',
+                background: 'var(--bg)',
+                border: '1px solid var(--border)',
+                borderRadius: '7px',
+                fontSize: '12px',
+                color: 'var(--fg)',
+                outline: 'none',
+              }}
+            />
+            <button
+              onClick={handleSendClipboard}
+              disabled={!clipboard || !onSendClipboard}
+              style={{
+                height: '34px',
+                padding: '0 12px',
+                background: 'var(--primary)',
+                border: 'none',
+                borderRadius: '7px',
+                fontSize: '12px',
+                fontWeight: 600,
+                color: 'var(--primary-fg)',
+                cursor: clipboard && onSendClipboard ? 'pointer' : 'default',
+                opacity: !clipboard || !onSendClipboard ? 0.45 : 1,
+                transition: 'opacity 0.15s',
+                whiteSpace: 'nowrap',
+              }}
+            >
+              Send
+            </button>
+          </div>
+          {!onSendClipboard && (
+            <p
+              style={{
+                fontSize: '11px',
+                color: 'var(--faint-fg)',
+                marginTop: '5px',
+              }}
+            >
+              Clipboard paste is available in VNC mode only.
+            </p>
+          )}
+        </div>
+
+        {/* Session status */}
+        <div style={{ marginBottom: '20px' }}>
+          <p style={SECTION_LABEL_STYLE}>Session Status</p>
+          <div style={ROW_STYLE}>
+            <span style={ROW_KEY_STYLE}>State</span>
+            <StatusBadge value={session?.state} />
+          </div>
+          <div style={ROW_STYLE}>
+            <span style={ROW_KEY_STYLE}>Health</span>
+            <StatusBadge value={session?.health_result_type} />
+          </div>
+          <div style={ROW_STYLE}>
+            <span style={ROW_KEY_STYLE}>Interventions</span>
+            <span style={ROW_VALUE_STYLE}>{session?.hitl_attempt_count ?? 0}</span>
+          </div>
+          <div style={{ ...ROW_STYLE, marginBottom: 0 }}>
+            <span style={ROW_KEY_STYLE}>Retries</span>
+            <span style={ROW_VALUE_STYLE}>{session?.retry_count ?? 0}</span>
+          </div>
+        </div>
+      </div>
+
+      {/* Danger zone */}
+      <div
+        style={{
+          padding: '14px',
+          borderTop: '1px solid var(--border)',
+          flexShrink: 0,
+        }}
+      >
+        <p
+          style={{
+            fontSize: '11px',
+            fontWeight: 600,
+            textTransform: 'uppercase',
+            letterSpacing: '0.06em',
+            color: 'var(--error)',
+            marginBottom: '10px',
+          }}
+        >
+          Danger Zone
+        </p>
+
+        {!restartConfirm ? (
+          <button
+            onClick={() => setRestartConfirm(true)}
+            style={{
+              width: '100%',
+              padding: '7px 12px',
+              background: 'transparent',
+              border: '1px solid var(--error)',
+              borderRadius: '7px',
+              fontSize: '12.5px',
+              fontWeight: 500,
+              color: 'var(--error)',
+              cursor: 'pointer',
+            }}
+          >
+            Restart session
+          </button>
+        ) : (
+          <div>
+            <p
+              style={{
+                fontSize: '12px',
+                color: 'var(--warning)',
+                marginBottom: '10px',
+              }}
+            >
+              This will acknowledge the failure and trigger a retry. Are you sure?
+            </p>
+            <div className="flex gap-2">
+              <button
+                onClick={() => setRestartConfirm(false)}
+                style={{
+                  flex: 1,
+                  height: '30px',
+                  background: 'var(--card)',
+                  border: '1px solid var(--border)',
+                  borderRadius: '6px',
+                  fontSize: '12px',
+                  color: 'var(--fg)',
+                  cursor: 'pointer',
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={() => acknowledgeMutation.mutate()}
+                disabled={acknowledgeMutation.isPending}
+                style={{
+                  flex: 1,
+                  height: '30px',
+                  background: 'var(--error)',
+                  border: 'none',
+                  borderRadius: '6px',
+                  fontSize: '12px',
+                  fontWeight: 600,
+                  color: '#fff',
+                  cursor: acknowledgeMutation.isPending ? 'default' : 'pointer',
+                  opacity: acknowledgeMutation.isPending ? 0.6 : 1,
+                }}
+              >
+                {acknowledgeMutation.isPending ? 'Sending…' : 'Confirm'}
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin-ui/src/components/viewer/viewer-page.tsx
+++ b/apps/admin-ui/src/components/viewer/viewer-page.tsx
@@ -1,0 +1,244 @@
+import { useState, useEffect, useRef, useCallback } from 'react';
+import { useParams, Link } from 'react-router';
+import { sessionsApi } from '@/api/sessions';
+import { VncViewer } from './vnc-viewer';
+import { CdpViewer } from './cdp-viewer';
+import { HitlPanel } from './hitl-panel';
+
+type ConnectionStatus = 'connecting' | 'connected' | 'disconnected';
+
+export function ViewerPage() {
+  const { id } = useParams<{ id: string }>();
+  const [panelOpen, setPanelOpen] = useState(true);
+  const [streamData, setStreamData] = useState<{ token: string; mode: string } | null>(null);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [connStatus, setConnStatus] = useState<ConnectionStatus>('connecting');
+  const rfbClipboardRef = useRef<((text: string) => void) | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    sessionsApi
+      .stream(id)
+      .then((res) => {
+        const token =
+          res.stream_token ??
+          (() => {
+            try {
+              return new URL(res.url, window.location.origin).hash.replace('#', '');
+            } catch {
+              return '';
+            }
+          })();
+        const mode = res.mode ?? 'vnc';
+        setStreamData({ token, mode });
+        // CDP has no explicit connect callback — mark connected optimistically
+        if (mode === 'cdp') setConnStatus('connected');
+      })
+      .catch((err) => {
+        const message =
+          err?.response?.data?.error?.message ??
+          err?.response?.data?.message ??
+          'Failed to get stream URL';
+        setFetchError(message);
+        setConnStatus('disconnected');
+      });
+  }, [id]);
+
+  const handleRfbReady = useCallback(
+    (rfb: { clipboardPasteFrom: (text: string) => void }) => {
+      rfbClipboardRef.current = (text: string) => rfb.clipboardPasteFrom(text);
+      setConnStatus('connected');
+    },
+    [],
+  );
+
+  const handleDisconnect = useCallback(() => {
+    setConnStatus('disconnected');
+  }, []);
+
+  const handleSendClipboard = useCallback((text: string) => {
+    rfbClipboardRef.current?.(text);
+  }, []);
+
+  const isVnc = streamData ? streamData.mode !== 'cdp' : true;
+  const modeLabel = streamData ? (isVnc ? 'VNC Stream' : 'CDP Stream') : 'Stream';
+
+  const statusDotColor =
+    connStatus === 'connected'
+      ? 'var(--success)'
+      : connStatus === 'connecting'
+        ? 'var(--warning)'
+        : 'var(--error)';
+
+  const statusDotGlow =
+    connStatus === 'connected'
+      ? '0 0 0 3px color-mix(in srgb, var(--success) 22%, transparent)'
+      : connStatus === 'connecting'
+        ? '0 0 0 3px color-mix(in srgb, var(--warning) 22%, transparent)'
+        : '0 0 0 3px color-mix(in srgb, var(--error) 22%, transparent)';
+
+  return (
+    <div
+      className="-m-6 flex flex-col overflow-hidden"
+      style={{
+        height: 'calc(100vh - 3.5rem)',
+        background: '#08090b',
+      }}
+    >
+      {/* Top connection bar */}
+      <div
+        className="flex items-center gap-3 px-3 shrink-0"
+        style={{
+          height: '38px',
+          background: 'var(--card)',
+          borderBottom: '1px solid var(--border)',
+        }}
+      >
+        {/* Back button */}
+        <Link
+          to={id ? `/sessions/${id}` : '/sessions'}
+          className="flex items-center gap-1 px-2 text-[12px] font-medium transition-colors"
+          style={{
+            height: '26px',
+            background: 'var(--card)',
+            border: '1px solid var(--border)',
+            borderRadius: '6px',
+            color: 'var(--fg)',
+            textDecoration: 'none',
+          }}
+          onMouseEnter={(e) =>
+            (e.currentTarget.style.background = 'var(--card-2)')
+          }
+          onMouseLeave={(e) =>
+            (e.currentTarget.style.background = 'var(--card)')
+          }
+        >
+          ‹ Back
+        </Link>
+
+        {/* Connection status */}
+        <div className="flex items-center gap-2 flex-1">
+          <span
+            style={{
+              width: '8px',
+              height: '8px',
+              borderRadius: '50%',
+              background: statusDotColor,
+              boxShadow: statusDotGlow,
+              display: 'inline-block',
+              flexShrink: 0,
+              transition: 'background 0.2s, box-shadow 0.2s',
+            }}
+          />
+          <span
+            style={{
+              fontSize: '12.5px',
+              fontWeight: 600,
+              color: 'var(--fg)',
+            }}
+          >
+            {modeLabel}
+          </span>
+          {id && (
+            <span
+              style={{
+                fontSize: '11px',
+                fontFamily: 'monospace',
+                color: 'var(--faint-fg)',
+              }}
+            >
+              {id}
+            </span>
+          )}
+        </div>
+
+        {/* HITL panel toggle */}
+        <button
+          onClick={() => setPanelOpen((o) => !o)}
+          style={{
+            height: '26px',
+            padding: '0 10px',
+            background: 'var(--card-2)',
+            border: '1px solid var(--border)',
+            borderRadius: '6px',
+            fontSize: '12px',
+            fontWeight: 500,
+            color: 'var(--fg)',
+            cursor: 'pointer',
+            display: 'flex',
+            alignItems: 'center',
+            gap: '5px',
+          }}
+        >
+          HITL Panel
+          <span style={{ fontSize: '10px', opacity: 0.6 }}>{panelOpen ? '›' : '‹'}</span>
+        </button>
+      </div>
+
+      {/* Main area */}
+      <div className="flex flex-1 overflow-hidden">
+        {/* Viewer */}
+        <div
+          className="flex-1 relative overflow-hidden"
+          style={{ background: '#0a0a0c' }}
+        >
+          {fetchError ? (
+            <div className="flex flex-col items-center justify-center h-full gap-3">
+              <p style={{ color: 'var(--error)', fontSize: '13px' }}>{fetchError}</p>
+              <Link
+                to={id ? `/sessions/${id}` : '/sessions'}
+                style={{ color: 'var(--primary)', fontSize: '13px' }}
+              >
+                ← Back to session
+              </Link>
+            </div>
+          ) : !streamData || !id ? (
+            <div
+              className="flex items-center justify-center h-full"
+              style={{ color: 'var(--muted-fg)', fontSize: '13px' }}
+            >
+              Connecting to stream&hellip;
+            </div>
+          ) : isVnc ? (
+            <VncViewer
+              sessionId={id}
+              token={streamData.token}
+              onRfbReady={handleRfbReady}
+              onDisconnect={handleDisconnect}
+            />
+          ) : (
+            <CdpViewer
+              sessionId={id}
+              token={streamData.token}
+              onDisconnect={handleDisconnect}
+            />
+          )}
+
+          {/* Bottom-left mode info */}
+          {streamData && (
+            <div
+              className="absolute bottom-2 left-3 pointer-events-none"
+              style={{
+                fontFamily: 'monospace',
+                fontSize: '11px',
+                color: 'var(--faint-fg)',
+              }}
+            >
+              {isVnc ? 'vnc' : 'cdp'} · {connStatus}
+            </div>
+          )}
+        </div>
+
+        {/* HITL side panel */}
+        {panelOpen && id && (
+          <HitlPanel
+            sessionId={id}
+            open={panelOpen}
+            onToggle={() => setPanelOpen((o) => !o)}
+            onSendClipboard={isVnc ? handleSendClipboard : undefined}
+          />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin-ui/src/components/viewer/vnc-viewer.tsx
+++ b/apps/admin-ui/src/components/viewer/vnc-viewer.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useRef, useCallback, useState } from 'react';
+import { env } from '@/env';
+
+interface Props {
+  sessionId: string;
+  token: string;
+  onDisconnect?: () => void;
+  onRfbReady?: (rfb: { clipboardPasteFrom: (text: string) => void }) => void;
+}
+
+export function VncViewer({ sessionId, token, onDisconnect, onRfbReady }: Props) {
+  const canvasRef = useRef<HTMLDivElement>(null);
+  const rfbRef = useRef<any>(null);
+  const [status, setStatus] = useState<'connecting' | 'connected' | 'disconnected'>('connecting');
+
+  const connect = useCallback(async () => {
+    if (!canvasRef.current) return;
+
+    const apiUrl = env.apiUrl();
+    const wsBase = apiUrl.replace(/^http/, 'ws');
+    const wsUrl = `${wsBase}/vnc-ws?session_id=${sessionId}&token=${encodeURIComponent(token)}`;
+
+    try {
+      const { default: RFB } = await import('@novnc/novnc/lib/rfb.js');
+      const rfb = new RFB(canvasRef.current, wsUrl, {
+        wsProtocols: ['binary'],
+      });
+
+      rfb.scaleViewport = true;
+      rfb.resizeSession = false;
+      rfb.showDotCursor = true;
+
+      rfb.addEventListener('connect', () => {
+        setStatus('connected');
+        onRfbReady?.(rfb);
+      });
+      rfb.addEventListener('disconnect', () => {
+        setStatus('disconnected');
+        onDisconnect?.();
+      });
+
+      rfbRef.current = rfb;
+    } catch (err) {
+      console.error('[VncViewer] Failed to initialize RFB:', err);
+      setStatus('disconnected');
+    }
+  }, [sessionId, token, onDisconnect, onRfbReady]);
+
+  useEffect(() => {
+    connect();
+    return () => {
+      rfbRef.current?.disconnect();
+      rfbRef.current = null;
+    };
+  }, [connect]);
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center gap-2 px-3 py-2 border-b border-border bg-card text-xs shrink-0">
+        <span
+          className={`inline-block w-2 h-2 rounded-full ${
+            status === 'connected'
+              ? 'bg-emerald-500'
+              : status === 'connecting'
+                ? 'bg-amber-500 animate-pulse'
+                : 'bg-red-500'
+          }`}
+        />
+        <span className="text-muted-foreground">VNC {status}</span>
+      </div>
+      <div ref={canvasRef} className="flex-1 bg-black overflow-hidden" />
+    </div>
+  );
+}

--- a/apps/admin-ui/src/env.ts
+++ b/apps/admin-ui/src/env.ts
@@ -1,0 +1,13 @@
+interface AppEnv {
+  API_URL: string;
+}
+
+declare global {
+  interface Window {
+    __env?: Partial<AppEnv>;
+  }
+}
+
+export const env = {
+  apiUrl: (): string => window.__env?.API_URL ?? 'http://localhost:8000',
+};

--- a/apps/admin-ui/src/hooks/use-role.spec.ts
+++ b/apps/admin-ui/src/hooks/use-role.spec.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+
+const mockSessionStorage = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { store = {}; },
+  };
+})();
+
+Object.defineProperty(window, 'sessionStorage', { value: mockSessionStorage });
+
+describe('useRole', () => {
+  beforeEach(() => {
+    mockSessionStorage.clear();
+    vi.resetModules();
+  });
+
+  it('returns null when not authenticated', async () => {
+    const { useRole } = await import('./use-role');
+    const { result } = renderHook(() => useRole());
+    expect(result.current).toBeNull();
+  });
+
+  it('returns role from token', async () => {
+    const payload = { sub: 'u1', tenant_id: 't1', role: 'Operator' };
+    const token = `h.${btoa(JSON.stringify(payload))}.s`;
+    const { useAuthStore } = await import('@/stores/auth');
+    useAuthStore.getState().setToken(token);
+
+    const { useRole, useHasRole } = await import('./use-role');
+    const { result: roleResult } = renderHook(() => useRole());
+    expect(roleResult.current).toBe('Operator');
+
+    const { result: hasResult } = renderHook(() => useHasRole('Admin', 'Operator'));
+    expect(hasResult.current).toBe(true);
+
+    const { result: noResult } = renderHook(() => useHasRole('Admin'));
+    expect(noResult.current).toBe(false);
+  });
+});

--- a/apps/admin-ui/src/hooks/use-role.ts
+++ b/apps/admin-ui/src/hooks/use-role.ts
@@ -1,0 +1,14 @@
+import { useAuthStore } from '@/stores/auth';
+
+export type AppRole = 'Admin' | 'Editor' | 'Operator' | 'Viewer' | 'Agent';
+
+export function useRole(): AppRole | null {
+  const user = useAuthStore((s) => s.user);
+  return (user?.role as AppRole) ?? null;
+}
+
+export function useHasRole(...roles: AppRole[]): boolean {
+  const role = useRole();
+  if (!role) return false;
+  return roles.includes(role);
+}

--- a/apps/admin-ui/src/index.css
+++ b/apps/admin-ui/src/index.css
@@ -1,0 +1,99 @@
+@import "tailwindcss";
+
+@theme {
+  --color-background: var(--bg);
+  --color-foreground: var(--fg);
+  --color-card: var(--card);
+  --color-card-2: var(--card-2);
+  --color-card-foreground: var(--fg);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-fg);
+  --color-faint: var(--faint-fg);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-fg);
+  --color-destructive: var(--error);
+  --color-accent: var(--accent);
+  --color-border: var(--border);
+  --color-border-2: var(--border-2);
+  --color-ring: var(--ring);
+  --color-elev: var(--elev);
+  --color-success: var(--success);
+  --color-warning: var(--warning);
+  --color-error: var(--error);
+  --color-info: var(--info);
+  --color-violet: var(--violet);
+  --color-neutral-badge: var(--neutral);
+  --radius-sm: 0.25rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 0.75rem;
+}
+
+:root {
+  --bg: #0b0d10;
+  --card: #111318;
+  --card-2: #15181e;
+  --muted: #14171d;
+  --elev: #181b22;
+  --fg: #e7e9ec;
+  --muted-fg: #8b9198;
+  --faint-fg: #5f656d;
+  --border: #1e222a;
+  --border-2: #2a2f39;
+  --primary: #6b6ef4;
+  --primary-fg: #ffffff;
+  --ring: #6b6ef4;
+  --accent: #2dd4bf;
+  --success: #34d399;
+  --warning: #fbbf24;
+  --error: #fb7185;
+  --info: #60a5fa;
+  --violet: #a78bfa;
+  --neutral: #98a0aa;
+}
+
+.light {
+  --bg: #f7f8f9;
+  --card: #ffffff;
+  --card-2: #f3f4f6;
+  --muted: #f3f4f6;
+  --elev: #ffffff;
+  --fg: #12141a;
+  --muted-fg: #5c636e;
+  --faint-fg: #9aa1ab;
+  --border: #e6e8ec;
+  --border-2: #d5d9df;
+  --primary: #5a57e6;
+  --primary-fg: #ffffff;
+  --ring: #6b6ef4;
+  --accent: #0d9488;
+  --success: #059669;
+  --warning: #c2740b;
+  --error: #e11d48;
+  --info: #2563eb;
+  --violet: #7c3aed;
+  --neutral: #6b7280;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; padding: 0; }
+
+body {
+  font-family: ui-sans-serif, system-ui, -apple-system, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+  background-color: var(--bg);
+  color: var(--fg);
+  font-size: 13px;
+  line-height: 1.45;
+  -webkit-font-smoothing: antialiased;
+}
+
+::-webkit-scrollbar { width: 10px; height: 10px; }
+::-webkit-scrollbar-thumb { background: var(--border-2); border-radius: 6px; }
+::-webkit-scrollbar-thumb:hover { background: var(--faint-fg); }
+::-webkit-scrollbar-track { background: transparent; }
+
+input, textarea, select, button { font-family: inherit; }
+input:focus, textarea:focus, select:focus { outline: none; }
+
+@keyframes tb-spin { to { transform: rotate(360deg); } }
+@keyframes tb-pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.45; } }
+@keyframes tb-scan { 0% { transform: translateY(-100%); } 100% { transform: translateY(400%); } }

--- a/apps/admin-ui/src/lib/utils.ts
+++ b/apps/admin-ui/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/apps/admin-ui/src/main.tsx
+++ b/apps/admin-ui/src/main.tsx
@@ -1,0 +1,23 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { RouterProvider } from 'react-router';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { router } from './router';
+import './index.css';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+  },
+});
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <RouterProvider router={router} />
+    </QueryClientProvider>
+  </StrictMode>,
+);

--- a/apps/admin-ui/src/router.tsx
+++ b/apps/admin-ui/src/router.tsx
@@ -1,0 +1,53 @@
+import { createBrowserRouter, Navigate } from 'react-router';
+import { AuthLayout } from './routes/auth-layout';
+import { LoginPage } from './routes/login';
+import { AuthCallback } from './routes/auth-callback';
+import { ShellLayout } from './routes/shell-layout';
+import { DashboardPage } from './routes/dashboard';
+import { SessionsPage } from './routes/sessions';
+import { SessionDetailPage } from './routes/session-detail';
+import { SessionViewerPage } from './routes/session-viewer';
+import { AppsPage } from './routes/apps';
+import { AppDetailPage } from './routes/app-detail';
+import { AppNewPage } from './routes/app-new';
+import { TemplatesPage } from './routes/templates';
+import { TemplateDetailPage } from './routes/template-detail';
+import { TemplateNewPage } from './routes/template-new';
+import { ProfilesPage } from './routes/profiles';
+import { ProfileDetailPage } from './routes/profile-detail';
+import { TenantsPage } from './routes/tenants';
+import { UsersPage } from './routes/users';
+import { IdentityProvidersPage } from './routes/identity-providers';
+import { AgentClientsPage } from './routes/agent-clients';
+
+export const router = createBrowserRouter([
+  {
+    element: <AuthLayout />,
+    children: [
+      { path: '/login', element: <LoginPage /> },
+      { path: '/auth/callback', element: <AuthCallback /> },
+    ],
+  },
+  {
+    element: <ShellLayout />,
+    children: [
+      { index: true, element: <Navigate to="/dashboard" replace /> },
+      { path: '/dashboard', element: <DashboardPage /> },
+      { path: '/sessions', element: <SessionsPage /> },
+      { path: '/sessions/:id', element: <SessionDetailPage /> },
+      { path: '/sessions/:id/viewer', element: <SessionViewerPage /> },
+      { path: '/apps', element: <AppsPage /> },
+      { path: '/apps/new', element: <AppNewPage /> },
+      { path: '/apps/:id', element: <AppDetailPage /> },
+      { path: '/templates', element: <TemplatesPage /> },
+      { path: '/templates/new', element: <TemplateNewPage /> },
+      { path: '/templates/:id', element: <TemplateDetailPage /> },
+      { path: '/profiles', element: <ProfilesPage /> },
+      { path: '/profiles/:id', element: <ProfileDetailPage /> },
+      { path: '/tenants', element: <TenantsPage /> },
+      { path: '/users', element: <UsersPage /> },
+      { path: '/identity-providers', element: <IdentityProvidersPage /> },
+      { path: '/agent-clients', element: <AgentClientsPage /> },
+    ],
+  },
+]);

--- a/apps/admin-ui/src/routes/agent-clients.tsx
+++ b/apps/admin-ui/src/routes/agent-clients.tsx
@@ -1,0 +1,738 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { agentClientsApi, type AgentClient } from '@/api/agent-clients';
+import { useHasRole } from '@/hooks/use-role';
+import { useAuthStore } from '@/stores/auth';
+import { ConfirmDialog } from '@/components/shared/confirm-dialog';
+import { EmptyState } from '@/components/shared/empty-state';
+
+function LockIcon() {
+  return (
+    <svg
+      width="48"
+      height="48"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={{ color: 'var(--faint-fg)', marginBottom: 12 }}
+    >
+      <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+      <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+    </svg>
+  );
+}
+
+const INPUT_STYLE: React.CSSProperties = {
+  width: '100%',
+  height: 36,
+  padding: '0 11px',
+  borderRadius: 8,
+  border: '1px solid var(--border-2)',
+  background: 'var(--bg)',
+  color: 'var(--fg)',
+  fontSize: 13,
+  boxSizing: 'border-box',
+  outline: 'none',
+};
+
+const TEXTAREA_STYLE: React.CSSProperties = {
+  width: '100%',
+  padding: '8px 11px',
+  borderRadius: 8,
+  border: '1px solid var(--border-2)',
+  background: 'var(--bg)',
+  color: 'var(--fg)',
+  fontSize: 13,
+  boxSizing: 'border-box',
+  outline: 'none',
+  resize: 'vertical',
+};
+
+const LABEL_STYLE: React.CSSProperties = {
+  fontSize: 12,
+  fontWeight: 500,
+  color: 'var(--muted-fg)',
+  marginBottom: 5,
+  display: 'block',
+};
+
+const BADGE_BASE: React.CSSProperties = {
+  display: 'inline-block',
+  padding: '2px 8px',
+  borderRadius: 9999,
+  fontSize: 11,
+  fontWeight: 500,
+};
+
+interface RegisterDialogProps {
+  open: boolean;
+  defaultTenantId: string;
+  onClose: () => void;
+  onRegistered: (clientId: string, clientSecret: string) => void;
+}
+
+function RegisterDialog({ open, defaultTenantId, onClose, onRegistered }: RegisterDialogProps) {
+  const [name, setName] = useState('');
+  const [tenantId, setTenantId] = useState(defaultTenantId);
+  const [allowedProfiles, setAllowedProfiles] = useState('');
+  const [unrestrictedProfiles, setUnrestrictedProfiles] = useState(false);
+  const [tokenTtl, setTokenTtl] = useState('');
+  const [rateLimit, setRateLimit] = useState('');
+  const [error, setError] = useState('');
+
+  const parsedProfiles = allowedProfiles
+    .split('\n')
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      agentClientsApi.register({
+        name,
+        tenant_id: tenantId,
+        ...(unrestrictedProfiles
+          ? { unrestricted_profiles: true }
+          : { allowed_profiles: parsedProfiles }),
+        ...(tokenTtl ? { token_ttl_seconds: Number(tokenTtl) } : {}),
+        ...(rateLimit ? { rate_limit_per_minute: Number(rateLimit) } : {}),
+      }),
+    onSuccess: (data) => {
+      onRegistered(data.client_id, data.client_secret);
+      setName('');
+      setAllowedProfiles('');
+      setUnrestrictedProfiles(false);
+      setTokenTtl('');
+      setRateLimit('');
+      setError('');
+    },
+    onError: (err: Error) => setError(err.message),
+  });
+
+  if (!open) return null;
+
+  const profilesInvalid = !unrestrictedProfiles && parsedProfiles.length === 0;
+  const isDisabled =
+    mutation.isPending || !name.trim() || !tenantId.trim() || profilesInvalid;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (isDisabled) return;
+    mutation.mutate();
+  };
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 50,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'rgba(0,0,0,0.6)',
+      }}
+      onClick={onClose}
+    >
+      <div
+        style={{
+          background: 'var(--elev)',
+          border: '1px solid var(--border-2)',
+          borderRadius: 12,
+          padding: 24,
+          width: 480,
+          maxHeight: '85vh',
+          overflowY: 'auto',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 style={{ fontSize: 18, fontWeight: 700, marginBottom: 18 }}>Register Agent Client</h3>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label style={LABEL_STYLE}>
+              Name<span style={{ color: '#dc2626', marginLeft: 2 }}>*</span>
+            </label>
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="my-agent"
+              required
+              style={INPUT_STYLE}
+            />
+          </div>
+
+          <div>
+            <label style={LABEL_STYLE}>
+              Tenant ID<span style={{ color: '#dc2626', marginLeft: 2 }}>*</span>
+            </label>
+            <input
+              value={tenantId}
+              onChange={(e) => setTenantId(e.target.value)}
+              placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+              required
+              style={INPUT_STYLE}
+            />
+          </div>
+
+          <div>
+            <label
+              style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, cursor: 'pointer' }}
+            >
+              <input
+                type="checkbox"
+                checked={unrestrictedProfiles}
+                onChange={(e) => setUnrestrictedProfiles(e.target.checked)}
+                style={{ width: 15, height: 15 }}
+              />
+              Unrestricted Profiles
+            </label>
+          </div>
+
+          {!unrestrictedProfiles && (
+            <div>
+              <label style={LABEL_STYLE}>
+                Allowed Profiles<span style={{ color: '#dc2626', marginLeft: 2 }}>*</span>
+                <span style={{ fontSize: 11, color: 'var(--faint-fg)', fontWeight: 400, marginLeft: 4 }}>
+                  (one per line, min 1)
+                </span>
+              </label>
+              <textarea
+                value={allowedProfiles}
+                onChange={(e) => setAllowedProfiles(e.target.value)}
+                rows={3}
+                placeholder={'salesforce-prod\nhubspot-staging'}
+                style={TEXTAREA_STYLE}
+              />
+            </div>
+          )}
+
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label style={LABEL_STYLE}>Token TTL Seconds</label>
+              <input
+                type="number"
+                min={1}
+                value={tokenTtl}
+                onChange={(e) => setTokenTtl(e.target.value)}
+                placeholder="3600"
+                style={INPUT_STYLE}
+              />
+            </div>
+            <div>
+              <label style={LABEL_STYLE}>Rate Limit Per Minute</label>
+              <input
+                type="number"
+                min={1}
+                max={1000}
+                value={rateLimit}
+                onChange={(e) => setRateLimit(e.target.value)}
+                placeholder="60"
+                style={INPUT_STYLE}
+              />
+            </div>
+          </div>
+
+          {error && <p style={{ fontSize: 12, color: '#dc2626' }}>{error}</p>}
+
+          <div className="flex justify-end gap-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              style={{
+                background: 'var(--card)',
+                border: '1px solid var(--border)',
+                color: 'var(--fg)',
+                borderRadius: 8,
+                padding: '0 16px',
+                height: 36,
+                fontSize: 13,
+                cursor: 'pointer',
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isDisabled}
+              style={{
+                background: 'var(--primary)',
+                color: 'var(--primary-fg)',
+                border: 'none',
+                borderRadius: 8,
+                padding: '0 16px',
+                height: 36,
+                fontSize: 13,
+                fontWeight: 500,
+                cursor: isDisabled ? 'not-allowed' : 'pointer',
+                opacity: isDisabled ? 0.5 : 1,
+              }}
+            >
+              {mutation.isPending ? 'Registering...' : 'Register'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+interface SecretRevealDialogProps {
+  open: boolean;
+  clientId: string;
+  clientSecret: string;
+  title: string;
+  onClose: () => void;
+}
+
+function SecretRevealDialog({
+  open,
+  clientId,
+  clientSecret,
+  title,
+  onClose,
+}: SecretRevealDialogProps) {
+  const [copied, setCopied] = useState<'id' | 'secret' | null>(null);
+
+  if (!open) return null;
+
+  const copy = async (text: string, field: 'id' | 'secret') => {
+    await navigator.clipboard.writeText(text);
+    setCopied(field);
+    setTimeout(() => setCopied(null), 2000);
+  };
+
+  const copyBtnStyle = (active: boolean): React.CSSProperties => ({
+    flexShrink: 0,
+    background: 'var(--card)',
+    border: '1px solid var(--border)',
+    color: active ? '#16a34a' : 'var(--fg)',
+    borderRadius: 8,
+    padding: '0 12px',
+    height: 32,
+    fontSize: 12,
+    cursor: 'pointer',
+    whiteSpace: 'nowrap',
+  });
+
+  return (
+    // Non-dismissable: no onClick on the backdrop
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 50,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'rgba(0,0,0,0.6)',
+      }}
+    >
+      <div
+        style={{
+          background: 'var(--elev)',
+          border: '1px solid var(--border-2)',
+          borderRadius: 12,
+          padding: 24,
+          width: 480,
+          maxHeight: '85vh',
+          overflowY: 'auto',
+        }}
+      >
+        <h3 style={{ fontSize: 18, fontWeight: 700, marginBottom: 18 }}>{title}</h3>
+
+        <div className="space-y-3">
+          <div>
+            <label style={LABEL_STYLE}>Client ID</label>
+            <div className="flex items-center gap-2">
+              <code
+                style={{
+                  flex: 1,
+                  fontFamily: 'monospace',
+                  fontSize: 12,
+                  background: 'var(--card-2)',
+                  borderRadius: 8,
+                  padding: '8px 11px',
+                  wordBreak: 'break-all',
+                  display: 'block',
+                }}
+              >
+                {clientId}
+              </code>
+              <button onClick={() => copy(clientId, 'id')} style={copyBtnStyle(copied === 'id')}>
+                {copied === 'id' ? 'Copied!' : 'Copy'}
+              </button>
+            </div>
+          </div>
+
+          <div>
+            <label style={LABEL_STYLE}>Client Secret</label>
+            <div className="flex items-center gap-2">
+              <code
+                style={{
+                  flex: 1,
+                  fontFamily: 'monospace',
+                  fontSize: 12,
+                  background: 'var(--card-2)',
+                  borderRadius: 8,
+                  padding: '8px 11px',
+                  wordBreak: 'break-all',
+                  display: 'block',
+                }}
+              >
+                {clientSecret}
+              </code>
+              <button
+                onClick={() => copy(clientSecret, 'secret')}
+                style={copyBtnStyle(copied === 'secret')}
+              >
+                {copied === 'secret' ? 'Copied!' : 'Copy'}
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <p
+          style={{
+            fontSize: 13,
+            color: '#dc2626',
+            marginTop: 16,
+            padding: '10px 12px',
+            background: '#fee2e2',
+            borderRadius: 8,
+          }}
+        >
+          ⚠ Save this secret now. It cannot be retrieved again.
+        </p>
+
+        <div className="flex justify-end mt-6">
+          <button
+            onClick={onClose}
+            style={{
+              background: 'var(--primary)',
+              color: 'var(--primary-fg)',
+              border: 'none',
+              borderRadius: 8,
+              padding: '0 16px',
+              height: 36,
+              fontSize: 13,
+              fontWeight: 500,
+              cursor: 'pointer',
+            }}
+          >
+            Done, I've saved the secret
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function AgentClientsPage() {
+  const isAdmin = useHasRole('Admin');
+  const currentTenantId = useAuthStore((s) => s.user?.tenant_id ?? '');
+  const qc = useQueryClient();
+  const [selectedTenantId, setSelectedTenantId] = useState(currentTenantId);
+  const [registerOpen, setRegisterOpen] = useState(false);
+  const [secret, setSecret] = useState<{
+    clientId: string;
+    clientSecret: string;
+    title: string;
+  } | null>(null);
+  const [revokeTarget, setRevokeTarget] = useState<AgentClient | null>(null);
+  const [rotateTarget, setRotateTarget] = useState<AgentClient | null>(null);
+  const [hoveredRow, setHoveredRow] = useState<string | null>(null);
+
+  const { data: clients, isLoading } = useQuery({
+    queryKey: ['agent-clients', selectedTenantId],
+    queryFn: () => agentClientsApi.list(selectedTenantId),
+    enabled: isAdmin && !!selectedTenantId.trim(),
+  });
+
+  const revokeMutation = useMutation({
+    mutationFn: (id: string) => agentClientsApi.revoke(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['agent-clients', selectedTenantId] });
+      setRevokeTarget(null);
+    },
+  });
+
+  const rotateMutation = useMutation({
+    mutationFn: (id: string) => agentClientsApi.rotateSecret(id),
+    onSuccess: (data, id) => {
+      const client = clients?.find((c) => c.id === id);
+      setRotateTarget(null);
+      setSecret({
+        clientId: client?.client_id ?? id,
+        clientSecret: data.client_secret,
+        title: 'New Client Secret',
+      });
+      qc.invalidateQueries({ queryKey: ['agent-clients', selectedTenantId] });
+    },
+  });
+
+  if (!isAdmin) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24 text-center">
+        <LockIcon />
+        <p style={{ fontSize: 15, fontWeight: 500, color: 'var(--fg)' }}>
+          You don't have permission to view this page.
+        </p>
+      </div>
+    );
+  }
+
+  const thStyle: React.CSSProperties = {
+    padding: '11px 14px',
+    fontSize: 11,
+    textTransform: 'uppercase',
+    letterSpacing: '0.06em',
+    fontWeight: 500,
+    color: 'var(--faint-fg)',
+    textAlign: 'left',
+    background: 'var(--card-2)',
+  };
+
+  const tdStyle: React.CSSProperties = {
+    padding: '11px 14px',
+    fontSize: 13,
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 style={{ fontSize: 22, fontWeight: 700, color: 'var(--fg)' }}>Agent Clients</h1>
+          <p style={{ fontSize: 13, color: 'var(--muted-fg)', marginTop: 2 }}>
+            OAuth client credentials for AI agents
+          </p>
+        </div>
+        <button
+          onClick={() => setRegisterOpen(true)}
+          style={{
+            background: 'var(--primary)',
+            color: 'var(--primary-fg)',
+            border: 'none',
+            borderRadius: 8,
+            padding: '0 16px',
+            height: 36,
+            fontSize: 13,
+            fontWeight: 500,
+            cursor: 'pointer',
+          }}
+        >
+          + Register Client
+        </button>
+      </div>
+
+      <div className="flex items-center gap-3 mb-4">
+        <label style={{ fontSize: 12, fontWeight: 500, color: 'var(--muted-fg)' }}>Tenant</label>
+        <input
+          value={selectedTenantId}
+          onChange={(e) => setSelectedTenantId(e.target.value)}
+          placeholder="tenant-id"
+          style={{
+            height: 36,
+            padding: '0 11px',
+            borderRadius: 8,
+            border: '1px solid var(--border-2)',
+            background: 'var(--bg)',
+            color: 'var(--fg)',
+            fontSize: 13,
+            width: 300,
+            boxSizing: 'border-box',
+            outline: 'none',
+          }}
+        />
+      </div>
+
+      {!selectedTenantId.trim() && (
+        <p style={{ color: 'var(--muted-fg)', fontSize: 13 }}>
+          Enter a tenant ID to view agent clients.
+        </p>
+      )}
+
+      {selectedTenantId.trim() && isLoading && (
+        <p style={{ color: 'var(--muted-fg)', fontSize: 13 }}>Loading...</p>
+      )}
+
+      {selectedTenantId.trim() && !isLoading && (clients ?? []).length === 0 && (
+        <EmptyState
+          title="No agent clients"
+          description="Register an agent client to allow programmatic access."
+          action={
+            <button
+              onClick={() => setRegisterOpen(true)}
+              style={{
+                background: 'var(--primary)',
+                color: 'var(--primary-fg)',
+                border: 'none',
+                borderRadius: 8,
+                padding: '0 16px',
+                height: 36,
+                fontSize: 13,
+                fontWeight: 500,
+                cursor: 'pointer',
+              }}
+            >
+              + Register Client
+            </button>
+          }
+        />
+      )}
+
+      {(clients ?? []).length > 0 && (
+        <div
+          className="overflow-x-auto"
+          style={{
+            background: 'var(--card)',
+            border: '1px solid var(--border)',
+            borderRadius: 12,
+            overflow: 'hidden',
+          }}
+        >
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr>
+                <th style={thStyle}>Name</th>
+                <th style={thStyle}>Client ID</th>
+                <th style={thStyle}>Allowed Profiles</th>
+                <th style={thStyle}>Revoked</th>
+                <th style={thStyle}>Last Used</th>
+                <th style={{ ...thStyle, textAlign: 'right' }}>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {clients!.map((c) => (
+                <tr
+                  key={c.id}
+                  onMouseEnter={() => setHoveredRow(c.id)}
+                  onMouseLeave={() => setHoveredRow(null)}
+                  style={{
+                    borderTop: '1px solid var(--border)',
+                    opacity: c.revoked_at ? 0.5 : 1,
+                    background:
+                      hoveredRow === c.id
+                        ? 'color-mix(in srgb, var(--fg) 4%, transparent)'
+                        : undefined,
+                  }}
+                >
+                  <td style={{ ...tdStyle, fontWeight: 500 }}>{c.name}</td>
+                  <td style={{ ...tdStyle, fontFamily: 'monospace', fontSize: 12 }}>
+                    {c.client_id}
+                  </td>
+                  <td style={tdStyle}>
+                    {c.unrestricted_profiles ? (
+                      <span
+                        style={{ ...BADGE_BASE, background: '#fef9c3', color: '#854d0e' }}
+                      >
+                        Unrestricted
+                      </span>
+                    ) : c.allowed_profiles && c.allowed_profiles.length > 0 ? (
+                      <span style={{ fontSize: 12, color: 'var(--fg)' }}>
+                        {c.allowed_profiles.join(', ')}
+                      </span>
+                    ) : (
+                      <span style={{ fontSize: 12, color: 'var(--faint-fg)' }}>None</span>
+                    )}
+                  </td>
+                  <td style={tdStyle}>
+                    {c.revoked_at ? (
+                      <span style={{ ...BADGE_BASE, background: '#fee2e2', color: '#991b1b' }}>
+                        Revoked
+                      </span>
+                    ) : (
+                      <span style={{ ...BADGE_BASE, background: '#dcfce7', color: '#15803d' }}>
+                        Active
+                      </span>
+                    )}
+                  </td>
+                  <td style={{ ...tdStyle, color: 'var(--muted-fg)', fontSize: 12 }}>
+                    {c.last_used_at ? new Date(c.last_used_at).toLocaleString() : '—'}
+                  </td>
+                  <td style={{ ...tdStyle, textAlign: 'right' }}>
+                    {!c.revoked_at && (
+                      <div className="flex items-center justify-end gap-3">
+                        <button
+                          onClick={() => setRotateTarget(c)}
+                          style={{
+                            fontSize: 12,
+                            color: 'var(--primary)',
+                            background: 'none',
+                            border: 'none',
+                            cursor: 'pointer',
+                            textDecoration: 'underline',
+                            padding: 0,
+                          }}
+                        >
+                          Rotate Secret
+                        </button>
+                        <button
+                          onClick={() => setRevokeTarget(c)}
+                          style={{
+                            fontSize: 12,
+                            color: '#dc2626',
+                            background: 'none',
+                            border: 'none',
+                            cursor: 'pointer',
+                            textDecoration: 'underline',
+                            padding: 0,
+                          }}
+                        >
+                          Revoke
+                        </button>
+                      </div>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <RegisterDialog
+        open={registerOpen}
+        defaultTenantId={selectedTenantId}
+        onClose={() => setRegisterOpen(false)}
+        onRegistered={(clientId, clientSecret) => {
+          setRegisterOpen(false);
+          setSecret({ clientId, clientSecret, title: 'Client Registered' });
+          qc.invalidateQueries({ queryKey: ['agent-clients', selectedTenantId] });
+        }}
+      />
+
+      {secret && (
+        <SecretRevealDialog
+          open
+          clientId={secret.clientId}
+          clientSecret={secret.clientSecret}
+          title={secret.title}
+          onClose={() => setSecret(null)}
+        />
+      )}
+
+      <ConfirmDialog
+        open={!!rotateTarget}
+        title={`Rotate secret for "${rotateTarget?.name}"`}
+        description="The current client secret will be invalidated immediately. Any agent using the old secret will start receiving 401 errors until updated."
+        confirmLabel="Rotate Secret"
+        destructive
+        onConfirm={() => rotateMutation.mutate(rotateTarget!.id)}
+        onCancel={() => setRotateTarget(null)}
+      />
+
+      <ConfirmDialog
+        open={!!revokeTarget}
+        title={`Revoke client "${revokeTarget?.name}"`}
+        description="This client will be permanently revoked. It will no longer be able to obtain tokens. This cannot be undone."
+        confirmLabel="Revoke Client"
+        destructive
+        onConfirm={() => revokeMutation.mutate(revokeTarget!.id)}
+        onCancel={() => setRevokeTarget(null)}
+      />
+    </div>
+  );
+}

--- a/apps/admin-ui/src/routes/app-detail.tsx
+++ b/apps/admin-ui/src/routes/app-detail.tsx
@@ -1,0 +1,565 @@
+import { useState } from 'react';
+import { useParams, useNavigate, Link } from 'react-router';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { appsApi } from '@/api/apps';
+import { sessionsApi } from '@/api/sessions';
+import { StatusBadge } from '@/components/shared/status-badge';
+import { ConfirmDialog } from '@/components/shared/confirm-dialog';
+import { useHasRole } from '@/hooks/use-role';
+import { DslStepBuilder } from '@/components/templates/dsl-step-builder';
+
+const LABEL_STYLE: React.CSSProperties = {
+  fontSize: 11,
+  textTransform: 'uppercase',
+  letterSpacing: '0.06em',
+  fontWeight: 500,
+  color: 'var(--faint-fg)',
+  marginBottom: 4,
+};
+
+const FIELD_MONO: React.CSSProperties = {
+  fontFamily: 'ui-monospace, Menlo, monospace',
+  fontSize: 12,
+  color: 'var(--fg)',
+  wordBreak: 'break-all',
+};
+
+const FIELD_TEXT: React.CSSProperties = { fontSize: 13, color: 'var(--fg)' };
+
+const PRE_STYLE: React.CSSProperties = {
+  fontFamily: 'ui-monospace, Menlo, monospace',
+  fontSize: 12,
+  overflowX: 'auto',
+  background: 'var(--card-2)',
+  padding: '12px 14px',
+  borderRadius: 8,
+  margin: 0,
+  color: 'var(--fg)',
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-all',
+};
+
+const FORM_LABEL: React.CSSProperties = {
+  fontSize: 12,
+  fontWeight: 500,
+  color: 'var(--muted-fg)',
+  display: 'block',
+  marginBottom: 5,
+};
+
+const FORM_INPUT: React.CSSProperties = {
+  width: '100%',
+  height: 36,
+  padding: '0 11px',
+  borderRadius: 8,
+  border: '1px solid var(--border-2)',
+  background: 'var(--bg)',
+  color: 'var(--fg)',
+  fontSize: 13,
+  outline: 'none',
+  boxSizing: 'border-box',
+};
+
+const FORM_TEXTAREA: React.CSSProperties = {
+  width: '100%',
+  minHeight: 80,
+  padding: '8px 11px',
+  borderRadius: 8,
+  border: '1px solid var(--border-2)',
+  background: 'var(--bg)',
+  color: 'var(--fg)',
+  fontSize: 13,
+  outline: 'none',
+  boxSizing: 'border-box',
+  resize: 'vertical',
+};
+
+const CARD: React.CSSProperties = {
+  background: 'var(--card)',
+  border: '1px solid var(--border)',
+  borderRadius: 12,
+  padding: '20px 24px',
+};
+
+function tryParseJson(raw: string): unknown {
+  if (!raw.trim()) return null;
+  try { return JSON.parse(raw); } catch { return undefined; }
+}
+
+export function AppDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const qc = useQueryClient();
+  const canWrite = useHasRole('Admin', 'Editor');
+
+  const [scaleValue, setScaleValue] = useState('');
+  const [showDeactivate, setShowDeactivate] = useState(false);
+  const [showDestroy, setShowDestroy] = useState(false);
+  const [showEdit, setShowEdit] = useState(false);
+
+  // Edit dialog state
+  const [editName, setEditName] = useState('');
+  const [editTargetUrls, setEditTargetUrls] = useState('');
+  const [editExecuteEnabled, setEditExecuteEnabled] = useState(false);
+  const [editDesiredCount, setEditDesiredCount] = useState('');
+  const [editLoginConfigSteps, setEditLoginConfigSteps] = useState<unknown[]>([]);
+  const [editLoginConfigExtra, setEditLoginConfigExtra] = useState<Record<string, unknown>>({});
+  const [editKeepaliveConfig, setEditKeepaliveConfig] = useState('');
+  const [editExportPolicy, setEditExportPolicy] = useState('');
+  const [editBrowserPolicy, setEditBrowserPolicy] = useState('');
+  const [editNotificationConfig, setEditNotificationConfig] = useState('');
+  const [editExtraEgress, setEditExtraEgress] = useState('');
+  const [editErrors, setEditErrors] = useState<Record<string, string>>({});
+
+  const { data: app, isLoading } = useQuery({
+    queryKey: ['app', id],
+    queryFn: () => appsApi.get(id!),
+    enabled: !!id,
+  });
+
+  const scaleMutation = useMutation({
+    mutationFn: () => sessionsApi.scale(id!, Number(scaleValue)),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['app', id] });
+      setScaleValue('');
+    },
+  });
+
+  const deactivateMutation = useMutation({
+    mutationFn: () => appsApi.deactivate(id!),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['apps'] });
+      navigate('/apps');
+    },
+  });
+
+  const destroyMutation = useMutation({
+    mutationFn: () => appsApi.destroy(id!),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['apps'] });
+      navigate('/apps');
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: (payload: Parameters<typeof appsApi.update>[1]) => appsApi.update(id!, payload),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['app', id] });
+      qc.invalidateQueries({ queryKey: ['apps'] });
+      setShowEdit(false);
+    },
+  });
+
+  if (isLoading || !app) {
+    return <p style={{ color: 'var(--muted-fg)', fontSize: 13 }}>Loading…</p>;
+  }
+
+  function openEdit() {
+    setEditName(app!.name);
+    setEditTargetUrls(app!.target_urls.join('\n'));
+    setEditExecuteEnabled(app!.execute_enabled);
+    setEditDesiredCount(String(app!.desired_session_count));
+    if (app!.login_config && typeof app!.login_config === 'object') {
+      const { steps, ...rest } = app!.login_config as Record<string, unknown>;
+      setEditLoginConfigSteps(Array.isArray(steps) ? steps : []);
+      setEditLoginConfigExtra(rest);
+    } else {
+      setEditLoginConfigSteps([]);
+      setEditLoginConfigExtra({});
+    }
+    setEditKeepaliveConfig(app!.keepalive_config ? JSON.stringify(app!.keepalive_config, null, 2) : '');
+    setEditExportPolicy(app!.export_policy ? JSON.stringify(app!.export_policy, null, 2) : '');
+    setEditBrowserPolicy(app!.browser_policy ? JSON.stringify(app!.browser_policy, null, 2) : '');
+    setEditNotificationConfig(app!.notification_config ? JSON.stringify(app!.notification_config, null, 2) : '');
+    setEditExtraEgress(app!.extra_egress_allowlist?.join('\n') ?? '');
+    setEditErrors({});
+    setShowEdit(true);
+  }
+
+  function handleEditSubmit() {
+    const errors: Record<string, string> = {};
+    if (!editName.trim()) errors.name = 'Name is required.';
+
+    const jsonChecks: [string, string][] = [
+      ['keepalive_config', editKeepaliveConfig],
+      ['export_policy', editExportPolicy],
+      ['browser_policy', editBrowserPolicy],
+      ['notification_config', editNotificationConfig],
+    ];
+    for (const [key, raw] of jsonChecks) {
+      if (raw.trim() && tryParseJson(raw) === undefined) errors[key] = 'Invalid JSON.';
+    }
+
+    if (Object.keys(errors).length) {
+      setEditErrors(errors);
+      return;
+    }
+
+    updateMutation.mutate({
+      name: editName.trim(),
+      target_urls: editTargetUrls.split('\n').map((u) => u.trim()).filter(Boolean),
+      execute_enabled: editExecuteEnabled,
+      desired_session_count: editDesiredCount !== '' ? Number(editDesiredCount) : (app?.desired_session_count ?? 0),
+      login_config: { ...editLoginConfigExtra, steps: editLoginConfigSteps },
+      keepalive_config: tryParseJson(editKeepaliveConfig),
+      export_policy: tryParseJson(editExportPolicy),
+      browser_policy: tryParseJson(editBrowserPolicy),
+      notification_config: tryParseJson(editNotificationConfig),
+      extra_egress_allowlist: editExtraEgress.split('\n').map((s) => s.trim()).filter(Boolean),
+    });
+  }
+
+  const configSections = [
+    { label: 'Login Config', value: app.login_config },
+    { label: 'Keepalive Config', value: app.keepalive_config },
+    { label: 'Export Policy', value: app.export_policy },
+    { label: 'Browser Policy', value: app.browser_policy },
+  ];
+
+  return (
+    <div>
+      {/* Confirm dialogs */}
+      <ConfirmDialog
+        open={showDeactivate}
+        title="Deactivate Application"
+        description="This will deactivate the application and stop new sessions from being created."
+        confirmLabel="Deactivate"
+        destructive
+        onConfirm={async () => { await deactivateMutation.mutateAsync(); setShowDeactivate(false); }}
+        onCancel={() => setShowDeactivate(false)}
+      />
+      <ConfirmDialog
+        open={showDestroy}
+        title="Destroy Application"
+        description="This will permanently destroy the application and all associated sessions. This cannot be undone."
+        confirmLabel="Destroy"
+        destructive
+        requireInput={app.name}
+        onConfirm={async () => { await destroyMutation.mutateAsync(); setShowDestroy(false); }}
+        onCancel={() => setShowDestroy(false)}
+      />
+
+      {/* Edit dialog */}
+      {showEdit && (
+        <div
+          style={{
+            position: 'fixed', inset: 0, zIndex: 50,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            background: 'rgba(0,0,0,0.5)',
+          }}
+          onClick={() => setShowEdit(false)}
+        >
+          <div
+            style={{
+              width: '100%', maxWidth: 900, maxHeight: '90vh', overflowY: 'auto',
+              background: 'var(--card)', borderRadius: 12, padding: '24px',
+            }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 style={{ fontSize: 16, fontWeight: 700, color: 'var(--fg)', margin: '0 0 20px' }}>
+              Edit Application
+            </h3>
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+              <div>
+                <label style={FORM_LABEL}>
+                  Name <span style={{ color: 'var(--error)' }}>*</span>
+                </label>
+                <input value={editName} onChange={(e) => setEditName(e.target.value)} style={FORM_INPUT} />
+                {editErrors.name && <p style={{ fontSize: 11, color: 'var(--error)', marginTop: 4 }}>{editErrors.name}</p>}
+              </div>
+
+              <div>
+                <label style={FORM_LABEL}>Target URLs</label>
+                <textarea
+                  value={editTargetUrls}
+                  onChange={(e) => setEditTargetUrls(e.target.value)}
+                  placeholder="https://example.com&#10;https://example.com/app"
+                  style={{ ...FORM_TEXTAREA, fontFamily: 'ui-monospace, Menlo, monospace', minHeight: 72 }}
+                />
+                <p style={{ fontSize: 11, color: 'var(--muted-fg)', marginTop: 3 }}>One URL per line.</p>
+              </div>
+
+              <div>
+                <label style={FORM_LABEL}>Desired Session Count</label>
+                <input
+                  type="number" min={0} step={1}
+                  value={editDesiredCount}
+                  onChange={(e) => setEditDesiredCount(e.target.value)}
+                  style={{ ...FORM_INPUT, width: 120 }}
+                />
+              </div>
+
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                <input
+                  id="edit_execute_enabled"
+                  type="checkbox"
+                  checked={editExecuteEnabled}
+                  onChange={(e) => setEditExecuteEnabled(e.target.checked)}
+                  style={{ width: 16, height: 16, accentColor: 'var(--primary)', cursor: 'pointer' }}
+                />
+                <label htmlFor="edit_execute_enabled" style={{ fontSize: 13, color: 'var(--fg)', cursor: 'pointer' }}>
+                  Execute enabled
+                </label>
+              </div>
+
+              <div>
+                <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--muted-fg)', marginBottom: 5 }}>
+                  Login Config <span style={{ color: 'var(--error)' }}>*</span>
+                </div>
+                <DslStepBuilder
+                  value={editLoginConfigSteps}
+                  onChange={setEditLoginConfigSteps}
+                />
+              </div>
+
+              {([
+                ['keepalive_config', 'Keepalive Config', editKeepaliveConfig, setEditKeepaliveConfig],
+                ['export_policy', 'Export Policy', editExportPolicy, setEditExportPolicy],
+                ['browser_policy', 'Browser Policy', editBrowserPolicy, setEditBrowserPolicy],
+                ['notification_config', 'Notification Config', editNotificationConfig, setEditNotificationConfig],
+              ] as [string, string, string, React.Dispatch<React.SetStateAction<string>>][]).map(
+                ([key, label, value, setter]) => (
+                  <div key={key}>
+                    <label style={FORM_LABEL}>{label}</label>
+                    <textarea
+                      value={value}
+                      onChange={(e) => setter(e.target.value)}
+                      rows={4}
+                      style={{ ...FORM_TEXTAREA, fontFamily: 'ui-monospace, Menlo, monospace' }}
+                    />
+                    {editErrors[key] && (
+                      <p style={{ fontSize: 11, color: 'var(--error)', marginTop: 4 }}>{editErrors[key]}</p>
+                    )}
+                  </div>
+                ),
+              )}
+
+              <div>
+                <label style={FORM_LABEL}>Extra Egress Allowlist</label>
+                <textarea
+                  value={editExtraEgress}
+                  onChange={(e) => setEditExtraEgress(e.target.value)}
+                  placeholder="api.example.com&#10;cdn.example.com"
+                  style={{ ...FORM_TEXTAREA, fontFamily: 'ui-monospace, Menlo, monospace', minHeight: 60 }}
+                />
+                <p style={{ fontSize: 11, color: 'var(--muted-fg)', marginTop: 3 }}>One entry per line.</p>
+              </div>
+            </div>
+
+            {updateMutation.isError && (
+              <p style={{ fontSize: 12, color: 'var(--error)', marginTop: 12 }}>
+                Failed to update application. Check your inputs and try again.
+              </p>
+            )}
+
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 10, marginTop: 24 }}>
+              <button
+                onClick={() => setShowEdit(false)}
+                style={{
+                  height: 34, padding: '0 14px', borderRadius: 8,
+                  border: '1px solid var(--border-2)', background: 'var(--card)',
+                  color: 'var(--fg)', fontSize: 12.5, cursor: 'pointer',
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleEditSubmit}
+                disabled={updateMutation.isPending}
+                style={{
+                  height: 34, padding: '0 14px', borderRadius: 8,
+                  background: 'var(--primary)', color: 'var(--primary-fg)',
+                  fontWeight: 600, fontSize: 12.5, border: 'none',
+                  cursor: updateMutation.isPending ? 'default' : 'pointer',
+                  opacity: updateMutation.isPending ? 0.6 : 1,
+                }}
+              >
+                {updateMutation.isPending ? 'Saving…' : 'Save'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Breadcrumb + header */}
+      <div style={{ marginBottom: 4 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 8 }}>
+          <Link to="/apps" style={{ fontSize: 12.5, color: 'var(--muted-fg)', textDecoration: 'none' }}>
+            Applications
+          </Link>
+          <span style={{ color: 'var(--faint-fg)', fontSize: 12.5 }}>/</span>
+          <span style={{ fontSize: 12.5, color: 'var(--fg)' }}>{app.name}</span>
+        </div>
+      </div>
+
+      <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', marginBottom: 24 }}>
+        <div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            <h1 style={{ fontSize: 22, fontWeight: 800, letterSpacing: '-0.02em', margin: 0, color: 'var(--fg)' }}>
+              {app.name}
+            </h1>
+            <StatusBadge value={app.execute_enabled ? 'ENABLED' : 'DISABLED'} />
+          </div>
+          <p style={{
+            fontFamily: 'ui-monospace, Menlo, monospace',
+            fontSize: 12, color: 'var(--faint-fg)', marginTop: 4, marginBottom: 0,
+          }}>
+            {app.id}
+          </p>
+        </div>
+
+        <div style={{ display: 'flex', gap: 8, flexShrink: 0 }}>
+          {canWrite && (
+            <button
+              onClick={openEdit}
+              style={{
+                height: 34, padding: '0 14px', borderRadius: 8,
+                border: '1px solid var(--border-2)', background: 'var(--card)',
+                color: 'var(--fg)', fontSize: 12.5, cursor: 'pointer',
+              }}
+            >
+              Edit
+            </button>
+          )}
+          {canWrite && (
+            <button
+              onClick={() => setShowDeactivate(true)}
+              style={{
+                height: 34, padding: '0 14px', borderRadius: 8,
+                border: `1px solid color-mix(in srgb, var(--warning) 40%, transparent)`,
+                background: 'var(--card)',
+                color: 'var(--warning)', fontSize: 12.5, cursor: 'pointer',
+              }}
+            >
+              Deactivate
+            </button>
+          )}
+          {canWrite && (
+            <button
+              onClick={() => setShowDestroy(true)}
+              style={{
+                height: 34, padding: '0 14px', borderRadius: 8,
+                border: `1px solid color-mix(in srgb, var(--error) 40%, transparent)`,
+                background: 'var(--card)',
+                color: 'var(--error)', fontSize: 12.5, cursor: 'pointer',
+              }}
+            >
+              Destroy
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Two-column: details + scale */}
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 280px', gap: 16, marginBottom: 16 }}>
+        {/* Details card */}
+        <div style={CARD}>
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '20px 32px' }}>
+            {[
+              { label: 'Application ID', value: app.id, mono: true },
+              { label: 'Tenant ID', value: app.tenant_id, mono: true },
+              { label: 'Template ID', value: app.template_id ?? '—', mono: true },
+              { label: 'Owner User ID', value: app.owner_user_id ?? '—', mono: true },
+              { label: 'Created', value: new Date(app.created_at).toLocaleString(), mono: false },
+              { label: 'Updated', value: new Date(app.updated_at).toLocaleString(), mono: false },
+            ].map(({ label, value, mono }) => (
+              <div key={label}>
+                <div style={LABEL_STYLE}>{label}</div>
+                <div style={mono ? FIELD_MONO : FIELD_TEXT}>{value}</div>
+              </div>
+            ))}
+          </div>
+        </div>
+
+        {/* Scale card */}
+        <div style={CARD}>
+          <div style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.06em', fontWeight: 500, color: 'var(--faint-fg)', marginBottom: 16 }}>
+            SCALE
+          </div>
+          <div style={{ fontSize: 12, color: 'var(--muted-fg)', marginBottom: 6 }}>Desired sessions</div>
+          <div style={{ fontSize: 26, fontWeight: 700, color: 'var(--fg)', marginBottom: 16 }}>
+            {app.desired_session_count}
+          </div>
+          {canWrite && (
+            <>
+              <div style={{ display: 'flex', gap: 8 }}>
+                <input
+                  type="number"
+                  min={0}
+                  step={1}
+                  value={scaleValue}
+                  onChange={(e) => setScaleValue(e.target.value)}
+                  placeholder="Count"
+                  style={{
+                    width: 80, height: 34, padding: '0 10px', borderRadius: 8,
+                    border: '1px solid var(--border-2)', background: 'var(--bg)',
+                    color: 'var(--fg)', fontSize: 13, outline: 'none', boxSizing: 'border-box',
+                  }}
+                />
+                <button
+                  onClick={() => scaleMutation.mutate()}
+                  disabled={scaleMutation.isPending || scaleValue === ''}
+                  style={{
+                    height: 34, padding: '0 14px', borderRadius: 8,
+                    background: 'var(--primary)', color: 'var(--primary-fg)',
+                    fontWeight: 600, fontSize: 12.5, border: 'none',
+                    cursor: scaleValue === '' || scaleMutation.isPending ? 'default' : 'pointer',
+                    opacity: scaleValue === '' || scaleMutation.isPending ? 0.5 : 1,
+                  }}
+                >
+                  {scaleMutation.isPending ? 'Scaling…' : 'Scale'}
+                </button>
+              </div>
+              {scaleMutation.isError && (
+                <p style={{ fontSize: 12, color: 'var(--error)', marginTop: 8 }}>Scale failed.</p>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Target URLs */}
+      <div style={{ ...CARD, marginBottom: 16 }}>
+        <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--fg)', marginBottom: 12 }}>Target URLs</div>
+        {app.target_urls.length === 0 ? (
+          <p style={{ fontSize: 13, color: 'var(--muted-fg)', margin: 0 }}>None configured.</p>
+        ) : (
+          <ul style={{ margin: 0, padding: 0, listStyle: 'none', display: 'flex', flexDirection: 'column', gap: 4 }}>
+            {app.target_urls.map((url) => (
+              <li key={url} style={{ fontFamily: 'ui-monospace, Menlo, monospace', fontSize: 12, color: 'var(--fg)' }}>
+                {url}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* Extra Egress Allowlist */}
+      {(app.extra_egress_allowlist?.length ?? 0) > 0 && (
+        <div style={{ ...CARD, marginBottom: 16 }}>
+          <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--fg)', marginBottom: 12 }}>Extra Egress Allowlist</div>
+          <ul style={{ margin: 0, padding: 0, listStyle: 'none', display: 'flex', flexDirection: 'column', gap: 4 }}>
+            {app.extra_egress_allowlist!.map((entry) => (
+              <li key={entry} style={{ fontFamily: 'ui-monospace, Menlo, monospace', fontSize: 12, color: 'var(--fg)' }}>
+                {entry}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {/* Config sections */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        {configSections.map(({ label, value }) => (
+          <div key={label} style={CARD}>
+            <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--fg)', marginBottom: 12 }}>{label}</div>
+            <pre style={PRE_STYLE}>
+              {value ? JSON.stringify(value, null, 2) : 'null'}
+            </pre>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin-ui/src/routes/app-new.tsx
+++ b/apps/admin-ui/src/routes/app-new.tsx
@@ -1,0 +1,361 @@
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { appsApi } from '@/api/apps';
+import { DslStepBuilder } from '@/components/templates/dsl-step-builder';
+
+const LABEL: React.CSSProperties = {
+  fontSize: 12,
+  fontWeight: 500,
+  color: 'var(--muted-fg)',
+  display: 'block',
+  marginBottom: 5,
+};
+
+const INPUT: React.CSSProperties = {
+  width: '100%',
+  height: 36,
+  padding: '0 11px',
+  borderRadius: 8,
+  border: '1px solid var(--border-2)',
+  background: 'var(--bg)',
+  color: 'var(--fg)',
+  fontSize: 13,
+  outline: 'none',
+  boxSizing: 'border-box',
+};
+
+const TEXTAREA: React.CSSProperties = {
+  width: '100%',
+  minHeight: 80,
+  padding: '8px 11px',
+  borderRadius: 8,
+  border: '1px solid var(--border-2)',
+  background: 'var(--bg)',
+  color: 'var(--fg)',
+  fontSize: 13,
+  outline: 'none',
+  boxSizing: 'border-box',
+  resize: 'vertical',
+};
+
+const TEXTAREA_MONO: React.CSSProperties = {
+  ...TEXTAREA,
+  fontFamily: 'ui-monospace, Menlo, monospace',
+};
+
+const REQUIRED_MARK = <span style={{ color: 'var(--error)' }}> *</span>;
+const HELPER: React.CSSProperties = { fontSize: 11, color: 'var(--muted-fg)', marginTop: 4 };
+const ERR: React.CSSProperties = { fontSize: 11, color: 'var(--error)', marginTop: 4 };
+
+const DEFAULT_KEEPALIVE_CONFIG = JSON.stringify({ health_checks: [] }, null, 2);
+const DEFAULT_EXPORT_POLICY = JSON.stringify({ artifact_types: ['cookies'] }, null, 2);
+
+function tryParseJson(raw: string): unknown {
+  if (!raw.trim()) return null;
+  try { return JSON.parse(raw); } catch { return undefined; }
+}
+
+export function AppNewPage() {
+  const navigate = useNavigate();
+  const qc = useQueryClient();
+
+  const [name, setName] = useState('');
+  const [tenantId, setTenantId] = useState('');
+  const [targetUrlsRaw, setTargetUrlsRaw] = useState('');
+  const [desiredCount, setDesiredCount] = useState('');
+  const [executeEnabled, setExecuteEnabled] = useState(false);
+  const [loginConfigSteps, setLoginConfigSteps] = useState<unknown[]>([]);
+  const [loginConfigExtra] = useState<Record<string, unknown>>({});
+  const [keepaliveConfigRaw, setKeepaliveConfigRaw] = useState(DEFAULT_KEEPALIVE_CONFIG);
+  const [exportPolicyRaw, setExportPolicyRaw] = useState(DEFAULT_EXPORT_POLICY);
+  const [browserPolicyRaw, setBrowserPolicyRaw] = useState('');
+  const [notificationConfigRaw, setNotificationConfigRaw] = useState('');
+  const [extraEgressRaw, setExtraEgressRaw] = useState('');
+  const [showBrowserPolicy, setShowBrowserPolicy] = useState(false);
+  const [showNotificationConfig, setShowNotificationConfig] = useState(false);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const createMutation = useMutation({
+    mutationFn: appsApi.create,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['apps'] });
+      navigate('/apps');
+    },
+  });
+
+  function validate(): boolean {
+    const next: Record<string, string> = {};
+
+    if (!name.trim()) next.name = 'Name is required.';
+
+    const targetUrls = targetUrlsRaw.split('\n').map((u) => u.trim()).filter(Boolean);
+    if (targetUrls.length === 0) next.target_urls = 'At least one URL is required.';
+
+    const requiredJsonFields: [string, string][] = [
+      ['keepalive_config', keepaliveConfigRaw],
+      ['export_policy', exportPolicyRaw],
+    ];
+    for (const [key, raw] of requiredJsonFields) {
+      if (!raw.trim()) {
+        next[key] = 'This field is required.';
+      } else if (tryParseJson(raw) === undefined) {
+        next[key] = 'Invalid JSON.';
+      }
+    }
+
+    const optionalJsonFields: [string, string][] = [
+      ['browser_policy', browserPolicyRaw],
+      ['notification_config', notificationConfigRaw],
+    ];
+    for (const [key, raw] of optionalJsonFields) {
+      if (raw.trim() && tryParseJson(raw) === undefined) next[key] = 'Invalid JSON.';
+    }
+
+    setErrors(next);
+    return Object.keys(next).length === 0;
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!validate()) return;
+
+    const targetUrls = targetUrlsRaw.split('\n').map((u) => u.trim()).filter(Boolean);
+    const extraEgress = extraEgressRaw.split('\n').map((s) => s.trim()).filter(Boolean);
+
+    createMutation.mutate({
+      name: name.trim(),
+      ...(tenantId.trim() ? { tenant_id: tenantId.trim() } : {}),
+      target_urls: targetUrls,
+      desired_session_count: desiredCount !== '' ? Number(desiredCount) : undefined,
+      execute_enabled: executeEnabled,
+      login_config: { ...loginConfigExtra, steps: loginConfigSteps },
+      keepalive_config: tryParseJson(keepaliveConfigRaw) ?? { health_checks: [] },
+      export_policy: tryParseJson(exportPolicyRaw) ?? { artifact_types: ['cookies'] },
+      ...(browserPolicyRaw.trim() ? { browser_policy: tryParseJson(browserPolicyRaw) } : {}),
+      ...(notificationConfigRaw.trim() ? { notification_config: tryParseJson(notificationConfigRaw) } : {}),
+      ...(extraEgress.length > 0 ? { extra_egress_allowlist: extraEgress } : {}),
+    });
+  }
+
+  const sectionGap = 20;
+
+  return (
+    <div style={{ maxWidth: 600 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 8 }}>
+        <Link to="/apps" style={{ fontSize: 12.5, color: 'var(--muted-fg)', textDecoration: 'none' }}>
+          Applications
+        </Link>
+        <span style={{ color: 'var(--faint-fg)', fontSize: 12.5 }}>/</span>
+        <span style={{ fontSize: 12.5, color: 'var(--fg)' }}>New</span>
+      </div>
+
+      <h1 style={{ fontSize: 24, fontWeight: 800, letterSpacing: '-0.02em', margin: '0 0 24px', color: 'var(--fg)' }}>
+        New Application
+      </h1>
+
+      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: sectionGap }}>
+
+        {/* Name */}
+        <div>
+          <label style={LABEL}>Name{REQUIRED_MARK}</label>
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="my-app"
+            style={INPUT}
+          />
+          {errors.name && <p style={ERR}>{errors.name}</p>}
+        </div>
+
+        {/* Tenant ID */}
+        <div>
+          <label style={LABEL}>Tenant ID</label>
+          <input
+            value={tenantId}
+            onChange={(e) => setTenantId(e.target.value)}
+            placeholder="optional"
+            style={INPUT}
+          />
+        </div>
+
+        {/* Target URLs */}
+        <div>
+          <label style={LABEL}>Target URLs{REQUIRED_MARK}</label>
+          <textarea
+            value={targetUrlsRaw}
+            onChange={(e) => setTargetUrlsRaw(e.target.value)}
+            placeholder={'https://example.com\nhttps://example.com/app'}
+            style={{ ...TEXTAREA_MONO, minHeight: 72 }}
+          />
+          <p style={HELPER}>One URL per line, minimum 1.</p>
+          {errors.target_urls && <p style={ERR}>{errors.target_urls}</p>}
+        </div>
+
+        {/* Desired Session Count */}
+        <div>
+          <label style={LABEL}>Desired Session Count</label>
+          <input
+            type="number"
+            min={0}
+            step={1}
+            value={desiredCount}
+            onChange={(e) => setDesiredCount(e.target.value)}
+            placeholder="0"
+            style={{ ...INPUT, width: 120 }}
+          />
+        </div>
+
+        {/* Execute Enabled */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <input
+            id="execute_enabled"
+            type="checkbox"
+            checked={executeEnabled}
+            onChange={(e) => setExecuteEnabled(e.target.checked)}
+            style={{ width: 16, height: 16, accentColor: 'var(--primary)', cursor: 'pointer' }}
+          />
+          <label htmlFor="execute_enabled" style={{ fontSize: 13, color: 'var(--fg)', cursor: 'pointer' }}>
+            Execute enabled
+          </label>
+        </div>
+
+        {/* Login Config */}
+        <div>
+          <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--muted-fg)', marginBottom: 5 }}>
+            Login Config <span style={{ color: 'var(--error)' }}>*</span>
+          </div>
+          <DslStepBuilder
+            value={loginConfigSteps}
+            onChange={setLoginConfigSteps}
+          />
+        </div>
+
+        {/* Keepalive Config */}
+        <div>
+          <label style={LABEL}>Keepalive Config{REQUIRED_MARK}</label>
+          <textarea
+            value={keepaliveConfigRaw}
+            onChange={(e) => setKeepaliveConfigRaw(e.target.value)}
+            rows={5}
+            style={TEXTAREA_MONO}
+          />
+          {errors.keepalive_config && <p style={ERR}>{errors.keepalive_config}</p>}
+        </div>
+
+        {/* Export Policy */}
+        <div>
+          <label style={LABEL}>Export Policy{REQUIRED_MARK}</label>
+          <textarea
+            value={exportPolicyRaw}
+            onChange={(e) => setExportPolicyRaw(e.target.value)}
+            rows={4}
+            style={TEXTAREA_MONO}
+          />
+          {errors.export_policy && <p style={ERR}>{errors.export_policy}</p>}
+        </div>
+
+        {/* Extra Egress Allowlist */}
+        <div>
+          <label style={LABEL}>Extra Egress Allowlist</label>
+          <textarea
+            value={extraEgressRaw}
+            onChange={(e) => setExtraEgressRaw(e.target.value)}
+            placeholder={'api.example.com\ncdn.example.com'}
+            style={{ ...TEXTAREA_MONO, minHeight: 60 }}
+          />
+          <p style={HELPER}>One hostname per line.</p>
+        </div>
+
+        {/* Browser Policy (collapsible) */}
+        <div>
+          <button
+            type="button"
+            onClick={() => setShowBrowserPolicy((v) => !v)}
+            style={{
+              background: 'none', border: 'none', padding: 0, cursor: 'pointer',
+              fontSize: 12, fontWeight: 500, color: 'var(--muted-fg)',
+              display: 'flex', alignItems: 'center', gap: 6,
+            }}
+          >
+            <span style={{ fontSize: 10 }}>{showBrowserPolicy ? '▾' : '▸'}</span>
+            Browser Policy
+          </button>
+          {showBrowserPolicy && (
+            <div style={{ marginTop: 8 }}>
+              <textarea
+                value={browserPolicyRaw}
+                onChange={(e) => setBrowserPolicyRaw(e.target.value)}
+                rows={5}
+                placeholder='{"streaming_mode": "vnc"}'
+                style={TEXTAREA_MONO}
+              />
+              {errors.browser_policy && <p style={ERR}>{errors.browser_policy}</p>}
+            </div>
+          )}
+        </div>
+
+        {/* Notification Config (collapsible) */}
+        <div>
+          <button
+            type="button"
+            onClick={() => setShowNotificationConfig((v) => !v)}
+            style={{
+              background: 'none', border: 'none', padding: 0, cursor: 'pointer',
+              fontSize: 12, fontWeight: 500, color: 'var(--muted-fg)',
+              display: 'flex', alignItems: 'center', gap: 6,
+            }}
+          >
+            <span style={{ fontSize: 10 }}>{showNotificationConfig ? '▾' : '▸'}</span>
+            Notification Config
+          </button>
+          {showNotificationConfig && (
+            <div style={{ marginTop: 8 }}>
+              <textarea
+                value={notificationConfigRaw}
+                onChange={(e) => setNotificationConfigRaw(e.target.value)}
+                rows={5}
+                placeholder="{}"
+                style={TEXTAREA_MONO}
+              />
+              {errors.notification_config && <p style={ERR}>{errors.notification_config}</p>}
+            </div>
+          )}
+        </div>
+
+        {createMutation.isError && (
+          <p style={{ fontSize: 12, color: 'var(--error)' }}>
+            Failed to create application. Check your inputs and try again.
+          </p>
+        )}
+
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 10, paddingTop: 8 }}>
+          <Link
+            to="/apps"
+            style={{
+              display: 'inline-flex', alignItems: 'center',
+              height: 34, padding: '0 14px', borderRadius: 8,
+              border: '1px solid var(--border-2)', background: 'var(--card)',
+              color: 'var(--fg)', fontSize: 12.5, textDecoration: 'none',
+            }}
+          >
+            Cancel
+          </Link>
+          <button
+            type="submit"
+            disabled={createMutation.isPending}
+            style={{
+              height: 34, padding: '0 14px', borderRadius: 8,
+              background: 'var(--primary)', color: 'var(--primary-fg)',
+              fontWeight: 600, fontSize: 12.5, border: 'none',
+              cursor: createMutation.isPending ? 'default' : 'pointer',
+              opacity: createMutation.isPending ? 0.6 : 1,
+            }}
+          >
+            {createMutation.isPending ? 'Creating…' : 'Create Application'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/apps/admin-ui/src/routes/apps.tsx
+++ b/apps/admin-ui/src/routes/apps.tsx
@@ -1,0 +1,191 @@
+import { useState } from 'react';
+import { Link } from 'react-router';
+import { useQuery } from '@tanstack/react-query';
+import { appsApi } from '@/api/apps';
+import { StatusBadge } from '@/components/shared/status-badge';
+import { useHasRole } from '@/hooks/use-role';
+
+const PAGE_SIZE = 20;
+
+const TH: React.CSSProperties = {
+  padding: '11px 14px',
+  fontSize: 11,
+  textTransform: 'uppercase',
+  letterSpacing: '0.06em',
+  fontWeight: 500,
+  color: 'var(--faint-fg)',
+  textAlign: 'left',
+};
+
+const TD: React.CSSProperties = { padding: '11px 14px', fontSize: 13, color: 'var(--fg)' };
+const TD_MONO: React.CSSProperties = {
+  padding: '11px 14px',
+  fontFamily: 'ui-monospace, Menlo, monospace',
+  fontSize: 12,
+  color: 'var(--muted-fg)',
+};
+
+export function AppsPage() {
+  const [page, setPage] = useState(0);
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+  const canWrite = useHasRole('Admin', 'Editor', 'Operator');
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['apps', { limit: PAGE_SIZE, offset: page * PAGE_SIZE }],
+    queryFn: () => appsApi.list({ limit: PAGE_SIZE, offset: page * PAGE_SIZE }),
+  });
+
+  const apps = data?.data ?? [];
+  const total = data?.total ?? 0;
+  const hasNext = (page + 1) * PAGE_SIZE < total;
+
+  return (
+    <div>
+      <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', marginBottom: 24 }}>
+        <div>
+          <h1 style={{ fontSize: 24, fontWeight: 800, letterSpacing: '-0.02em', margin: 0, color: 'var(--fg)' }}>
+            Applications
+          </h1>
+          <p style={{ color: 'var(--muted-fg)', fontSize: 12.5, marginTop: 3, marginBottom: 0 }}>
+            Configured browser automation applications
+          </p>
+        </div>
+        {canWrite && (
+          <Link
+            to="/apps/new"
+            style={{
+              display: 'inline-flex', alignItems: 'center',
+              height: 34, padding: '0 14px', borderRadius: 8,
+              background: 'var(--primary)', color: 'var(--primary-fg)',
+              fontWeight: 600, fontSize: 12.5, textDecoration: 'none',
+            }}
+          >
+            + New Application
+          </Link>
+        )}
+      </div>
+
+      {isLoading && (
+        <p style={{ color: 'var(--muted-fg)', fontSize: 13 }}>Loading…</p>
+      )}
+
+      {!isLoading && apps.length === 0 && (
+        <div style={{
+          border: '1px dashed var(--border-2)', borderRadius: 12,
+          padding: '48px 24px', textAlign: 'center',
+        }}>
+          <p style={{ fontSize: 15, fontWeight: 600, color: 'var(--fg)', margin: '0 0 6px' }}>
+            No applications
+          </p>
+          <p style={{ fontSize: 13, color: 'var(--muted-fg)', margin: 0 }}>
+            Create an application to start automating browser sessions.
+          </p>
+          {canWrite && (
+            <Link
+              to="/apps/new"
+              style={{
+                display: 'inline-flex', alignItems: 'center', marginTop: 16,
+                height: 34, padding: '0 14px', borderRadius: 8,
+                background: 'var(--primary)', color: 'var(--primary-fg)',
+                fontWeight: 600, fontSize: 12.5, textDecoration: 'none',
+              }}
+            >
+              + New Application
+            </Link>
+          )}
+        </div>
+      )}
+
+      {apps.length > 0 && (
+        <div style={{ background: 'var(--card)', border: '1px solid var(--border)', borderRadius: 12, overflow: 'hidden' }}>
+          <div style={{ overflowX: 'auto' }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse', minWidth: 720 }}>
+              <thead>
+                <tr style={{ background: 'var(--card-2)' }}>
+                  <th style={TH}>NAME</th>
+                  <th style={TH}>TENANT</th>
+                  <th style={TH}>SESSIONS</th>
+                  <th style={TH}>EXECUTE</th>
+                  <th style={TH}>CREATED</th>
+                </tr>
+              </thead>
+              <tbody>
+                {apps.map((app, i) => (
+                  <tr
+                    key={app.id}
+                    onMouseEnter={() => setHoveredId(app.id)}
+                    onMouseLeave={() => setHoveredId(null)}
+                    style={{
+                      borderBottom: i < apps.length - 1 ? '1px solid var(--border)' : 'none',
+                      background: hoveredId === app.id
+                        ? 'color-mix(in srgb, var(--fg) 4%, transparent)'
+                        : undefined,
+                    }}
+                  >
+                    <td style={{ ...TD, fontWeight: 500 }}>
+                      <Link
+                        to={`/apps/${app.id}`}
+                        style={{ color: 'var(--fg)', textDecoration: 'none' }}
+                      >
+                        {app.name}
+                      </Link>
+                    </td>
+                    <td style={TD_MONO}>{app.tenant_id}</td>
+                    <td style={{ ...TD, fontVariantNumeric: 'tabular-nums' }}>
+                      {app.desired_session_count}
+                    </td>
+                    <td style={TD}>
+                      <StatusBadge value={app.execute_enabled ? 'ENABLED' : 'DISABLED'} />
+                    </td>
+                    <td style={{ ...TD, color: 'var(--muted-fg)' }}>
+                      {new Date(app.created_at).toLocaleString()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div style={{
+            borderTop: '1px solid var(--border)', padding: '10px 14px',
+            display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+            fontSize: 12, color: 'var(--muted-fg)',
+          }}>
+            <span>
+              {total === 0
+                ? '0 results'
+                : `${page * PAGE_SIZE + 1}–${Math.min((page + 1) * PAGE_SIZE, total)} of ${total}`}
+            </span>
+            <div style={{ display: 'flex', gap: 8 }}>
+              <button
+                onClick={() => setPage((p) => Math.max(0, p - 1))}
+                disabled={page === 0}
+                style={{
+                  height: 28, padding: '0 11px', borderRadius: 7,
+                  border: '1px solid var(--border-2)', background: 'var(--card)',
+                  color: 'var(--fg)', fontSize: 12,
+                  cursor: page === 0 ? 'default' : 'pointer',
+                  opacity: page === 0 ? 0.4 : 1,
+                }}
+              >
+                Prev
+              </button>
+              <button
+                onClick={() => setPage((p) => p + 1)}
+                disabled={!hasNext}
+                style={{
+                  height: 28, padding: '0 11px', borderRadius: 7,
+                  border: '1px solid var(--border-2)', background: 'var(--card)',
+                  color: 'var(--fg)', fontSize: 12,
+                  cursor: !hasNext ? 'default' : 'pointer',
+                  opacity: !hasNext ? 0.4 : 1,
+                }}
+              >
+                Next
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/admin-ui/src/routes/auth-callback.tsx
+++ b/apps/admin-ui/src/routes/auth-callback.tsx
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router';
+import { useAuthStore } from '@/stores/auth';
+
+export function AuthCallback() {
+  const navigate = useNavigate();
+  const setToken = useAuthStore((s) => s.setToken);
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const token = params.get('_token');
+    if (token) {
+      setToken(token);
+      navigate('/dashboard', { replace: true });
+    } else {
+      navigate('/login', { replace: true });
+    }
+  }, [navigate, setToken]);
+
+  return <p className="text-center text-muted-foreground">Authenticating...</p>;
+}

--- a/apps/admin-ui/src/routes/auth-layout.tsx
+++ b/apps/admin-ui/src/routes/auth-layout.tsx
@@ -1,0 +1,11 @@
+import { Outlet } from 'react-router';
+
+export function AuthLayout() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-background">
+      <div className="w-full max-w-md p-6">
+        <Outlet />
+      </div>
+    </div>
+  );
+}

--- a/apps/admin-ui/src/routes/dashboard.tsx
+++ b/apps/admin-ui/src/routes/dashboard.tsx
@@ -1,0 +1,259 @@
+import { useQuery } from '@tanstack/react-query';
+import { sessionsApi } from '@/api/sessions';
+import { appsApi } from '@/api/apps';
+import { StatusBadge } from '@/components/shared/status-badge';
+
+const STATE_CARDS: Array<{ state: string; color: string }> = [
+  { state: 'HEALTHY', color: 'var(--success)' },
+  { state: 'STARTING', color: 'var(--info)' },
+  { state: 'LOGIN_NEEDED', color: 'var(--warning)' },
+  { state: 'LOGIN_IN_PROGRESS', color: 'var(--violet)' },
+  { state: 'UNHEALTHY', color: 'var(--warning)' },
+  { state: 'FAILED', color: 'var(--error)' },
+  { state: 'TERMINATED', color: 'var(--neutral)' },
+];
+
+const ATTENTION_STATES = new Set([
+  'LOGIN_NEEDED',
+  'UNHEALTHY',
+  'FAILED',
+  'AUTH_FAIL',
+  'TRANSIENT_FAIL',
+]);
+
+export function DashboardPage() {
+  const { data: sessionsData } = useQuery({
+    queryKey: ['sessions', { limit: 200 }],
+    queryFn: () => sessionsApi.list({ limit: 200 }),
+    refetchInterval: 10_000,
+  });
+
+  const { data: appsData } = useQuery({
+    queryKey: ['apps', {}],
+    queryFn: () => appsApi.list({}),
+    refetchInterval: 10_000,
+  });
+
+  const sessions = sessionsData?.data ?? [];
+  const counts: Record<string, number> = {};
+  for (const s of sessions) {
+    counts[s.state] = (counts[s.state] ?? 0) + 1;
+  }
+
+  const needsAttention = sessions.filter((s) => ATTENTION_STATES.has(s.state)).length;
+  const appCount = appsData?.total ?? 0;
+
+  return (
+    <div>
+      {/* Title row */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          justifyContent: 'space-between',
+          marginBottom: '20px',
+        }}
+      >
+        <div>
+          <h1
+            style={{
+              fontSize: '24px',
+              fontWeight: 800,
+              letterSpacing: '-0.02em',
+              color: 'var(--fg)',
+              margin: 0,
+            }}
+          >
+            Dashboard
+          </h1>
+          <p style={{ fontSize: '12.5px', color: 'var(--muted-fg)', marginTop: '4px' }}>
+            Session health across all applications · refreshes every 10s
+          </p>
+        </div>
+        <div style={{ display: 'flex', alignItems: 'center', gap: '7px', paddingTop: '4px' }}>
+          <span
+            style={{
+              width: '8px',
+              height: '8px',
+              borderRadius: '50%',
+              backgroundColor: 'var(--success)',
+              display: 'inline-block',
+              animation: 'pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite',
+            }}
+          />
+          <span style={{ fontSize: '13px', fontWeight: 500, color: 'var(--success)' }}>Live</span>
+        </div>
+      </div>
+
+      {/* Health cards grid */}
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(7, 1fr)',
+          gap: '10px',
+          marginBottom: '14px',
+        }}
+      >
+        {STATE_CARDS.map(({ state, color }) => (
+          <div
+            key={state}
+            style={{
+              background: 'var(--card)',
+              border: '1px solid var(--border)',
+              borderRadius: '12px',
+              padding: '16px 18px',
+            }}
+          >
+            <StatusBadge value={state} />
+            <p
+              style={{
+                fontSize: '30px',
+                fontWeight: 800,
+                fontVariantNumeric: 'tabular-nums',
+                letterSpacing: '-0.02em',
+                color: 'var(--fg)',
+                margin: '10px 0 12px',
+                lineHeight: 1,
+              }}
+            >
+              {counts[state] ?? 0}
+            </p>
+            <div
+              style={{
+                height: '3px',
+                borderRadius: '2px',
+                backgroundColor: color,
+                opacity: 0.7,
+              }}
+            />
+          </div>
+        ))}
+      </div>
+
+      {/* Summary row */}
+      <div style={{ display: 'flex', gap: '14px' }}>
+        {/* Stats card */}
+        <div
+          style={{
+            flex: 1,
+            background: 'var(--card)',
+            border: '1px solid var(--border)',
+            borderRadius: '12px',
+            padding: '16px 18px',
+            display: 'flex',
+            alignItems: 'center',
+          }}
+        >
+          <div style={{ flex: 1, textAlign: 'center' }}>
+            <p
+              style={{
+                fontSize: '11px',
+                fontWeight: 500,
+                textTransform: 'uppercase',
+                letterSpacing: '0.06em',
+                color: 'var(--faint-fg)',
+                marginBottom: '6px',
+              }}
+            >
+              Total Sessions
+            </p>
+            <p
+              style={{
+                fontSize: '26px',
+                fontWeight: 800,
+                color: 'var(--fg)',
+                lineHeight: 1,
+                margin: 0,
+              }}
+            >
+              {sessions.length}
+            </p>
+          </div>
+
+          <div style={{ width: '1px', height: '40px', background: 'var(--border)' }} />
+
+          <div style={{ flex: 1, textAlign: 'center' }}>
+            <p
+              style={{
+                fontSize: '11px',
+                fontWeight: 500,
+                textTransform: 'uppercase',
+                letterSpacing: '0.06em',
+                color: 'var(--faint-fg)',
+                marginBottom: '6px',
+              }}
+            >
+              Needs Attention
+            </p>
+            <p
+              style={{
+                fontSize: '26px',
+                fontWeight: 800,
+                color: needsAttention > 0 ? 'var(--warning)' : 'var(--fg)',
+                lineHeight: 1,
+                margin: 0,
+              }}
+            >
+              {needsAttention}
+            </p>
+          </div>
+
+          <div style={{ width: '1px', height: '40px', background: 'var(--border)' }} />
+
+          <div style={{ flex: 1, textAlign: 'center' }}>
+            <p
+              style={{
+                fontSize: '11px',
+                fontWeight: 500,
+                textTransform: 'uppercase',
+                letterSpacing: '0.06em',
+                color: 'var(--faint-fg)',
+                marginBottom: '6px',
+              }}
+            >
+              Applications
+            </p>
+            <p
+              style={{
+                fontSize: '26px',
+                fontWeight: 800,
+                color: 'var(--fg)',
+                lineHeight: 1,
+                margin: 0,
+              }}
+            >
+              {appCount}
+            </p>
+          </div>
+        </div>
+
+        {/* Recent activity card */}
+        <div
+          style={{
+            width: '340px',
+            background: 'var(--card)',
+            border: '1px solid var(--border)',
+            borderRadius: '12px',
+            padding: '16px 18px',
+          }}
+        >
+          <p
+            style={{
+              fontSize: '11px',
+              fontWeight: 500,
+              textTransform: 'uppercase',
+              letterSpacing: '0.06em',
+              color: 'var(--faint-fg)',
+              marginBottom: '12px',
+            }}
+          >
+            Recent Activity
+          </p>
+          <p style={{ fontSize: '13px', color: 'var(--muted-fg)', margin: 0 }}>
+            No recent activity.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin-ui/src/routes/identity-providers.tsx
+++ b/apps/admin-ui/src/routes/identity-providers.tsx
@@ -1,0 +1,857 @@
+import { useState, useEffect } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { idpApi, type IdentityProviderConfig } from '@/api/identity-providers';
+import { useHasRole } from '@/hooks/use-role';
+import { ConfirmDialog } from '@/components/shared/confirm-dialog';
+import { EmptyState } from '@/components/shared/empty-state';
+
+const DEFAULT_ROLES = ['Admin', 'Editor', 'Operator', 'Viewer'] as const;
+
+function LockIcon() {
+  return (
+    <svg
+      width="48"
+      height="48"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={{ color: 'var(--faint-fg)', marginBottom: 12 }}
+    >
+      <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+      <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+    </svg>
+  );
+}
+
+type IdpFormState = {
+  provider_type: string;
+  name: string;
+  issuer_url: string;
+  jwks_uri: string;
+  auth_url: string;
+  token_url: string;
+  userinfo_url: string;
+  audience: string;
+  scopes: string;
+  user_id_claim: string;
+  email_claim: string;
+  name_claim: string;
+  tenant_id_claim: string;
+  allow_auto_provision: boolean;
+  enabled: boolean;
+  admin_domains: string;
+  default_role: string;
+  role_claim: string;
+  admin_role_values: string;
+  editor_role_values: string;
+};
+
+const emptyForm = (): IdpFormState => ({
+  provider_type: 'oidc',
+  name: '',
+  issuer_url: '',
+  jwks_uri: '',
+  auth_url: '',
+  token_url: '',
+  userinfo_url: '',
+  audience: '',
+  scopes: 'openid email profile',
+  user_id_claim: 'sub',
+  email_claim: 'email',
+  name_claim: '',
+  tenant_id_claim: '',
+  allow_auto_provision: false,
+  enabled: true,
+  admin_domains: '',
+  default_role: 'Operator',
+  role_claim: '',
+  admin_role_values: '',
+  editor_role_values: '',
+});
+
+type ExtendedIdp = IdentityProviderConfig & {
+  provider_type?: string;
+  jwks_uri?: string;
+  scopes?: string;
+  name_claim?: string;
+  enabled?: boolean;
+};
+
+function idpToForm(idp: IdentityProviderConfig): IdpFormState {
+  const ext = idp as ExtendedIdp;
+  return {
+    provider_type: ext.provider_type ?? 'oidc',
+    name: idp.name,
+    issuer_url: idp.issuer_url ?? '',
+    jwks_uri: ext.jwks_uri ?? '',
+    auth_url: idp.auth_url ?? '',
+    token_url: idp.token_url ?? '',
+    userinfo_url: idp.userinfo_url ?? '',
+    audience: idp.audience ?? '',
+    scopes: ext.scopes ?? 'openid email profile',
+    user_id_claim: idp.user_id_claim,
+    email_claim: idp.email_claim,
+    name_claim: ext.name_claim ?? '',
+    tenant_id_claim: idp.tenant_id_claim ?? '',
+    allow_auto_provision: idp.allow_auto_provision,
+    enabled: ext.enabled ?? true,
+    admin_domains: (idp.admin_domains ?? []).join('\n'),
+    default_role: idp.default_role,
+    role_claim: idp.role_claim ?? '',
+    admin_role_values: (idp.admin_role_values ?? []).join('\n'),
+    editor_role_values: (idp.editor_role_values ?? []).join('\n'),
+  };
+}
+
+function formToPayload(form: IdpFormState): Partial<IdentityProviderConfig> {
+  const splitLines = (s: string) =>
+    s
+      .split('\n')
+      .map((v) => v.trim())
+      .filter(Boolean);
+
+  return {
+    provider_type: form.provider_type,
+    name: form.name,
+    issuer_url: form.issuer_url,
+    jwks_uri: form.jwks_uri || null,
+    auth_url: form.auth_url || null,
+    token_url: form.token_url || null,
+    userinfo_url: form.userinfo_url || null,
+    audience: form.audience || null,
+    scopes: form.scopes || null,
+    user_id_claim: form.user_id_claim,
+    email_claim: form.email_claim,
+    name_claim: form.name_claim || null,
+    tenant_id_claim: form.tenant_id_claim || null,
+    allow_auto_provision: form.allow_auto_provision,
+    enabled: form.enabled,
+    admin_domains: splitLines(form.admin_domains),
+    default_role: form.default_role,
+    role_claim: form.role_claim || null,
+    admin_role_values: splitLines(form.admin_role_values),
+    editor_role_values: splitLines(form.editor_role_values),
+  } as Partial<IdentityProviderConfig>;
+}
+
+const INPUT_STYLE: React.CSSProperties = {
+  width: '100%',
+  height: 36,
+  padding: '0 11px',
+  borderRadius: 8,
+  border: '1px solid var(--border-2)',
+  background: 'var(--bg)',
+  color: 'var(--fg)',
+  fontSize: 13,
+  boxSizing: 'border-box',
+  outline: 'none',
+};
+
+const TEXTAREA_STYLE: React.CSSProperties = {
+  width: '100%',
+  padding: '8px 11px',
+  borderRadius: 8,
+  border: '1px solid var(--border-2)',
+  background: 'var(--bg)',
+  color: 'var(--fg)',
+  fontSize: 13,
+  boxSizing: 'border-box',
+  outline: 'none',
+  resize: 'vertical',
+};
+
+const LABEL_STYLE: React.CSSProperties = {
+  fontSize: 12,
+  fontWeight: 500,
+  color: 'var(--muted-fg)',
+  marginBottom: 5,
+  display: 'block',
+};
+
+const SECTION_HEADER_STYLE: React.CSSProperties = {
+  fontSize: 11,
+  fontWeight: 600,
+  textTransform: 'uppercase',
+  letterSpacing: '0.08em',
+  color: 'var(--faint-fg)',
+  paddingBottom: 8,
+  borderBottom: '1px solid var(--border)',
+  marginTop: 8,
+  marginBottom: 12,
+};
+
+function SectionHeader({ children }: { children: React.ReactNode }) {
+  return <div style={SECTION_HEADER_STYLE}>{children}</div>;
+}
+
+function Field({
+  label,
+  required,
+  children,
+}: {
+  label: string;
+  required?: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <div>
+      <label style={LABEL_STYLE}>
+        {label}
+        {required && <span style={{ color: '#dc2626', marginLeft: 2 }}>*</span>}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+interface IdpFormDialogProps {
+  open: boolean;
+  editing: IdentityProviderConfig | null;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+function IdpFormDialog({ open, editing, onClose, onSaved }: IdpFormDialogProps) {
+  const [form, setForm] = useState<IdpFormState>(emptyForm);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (open) {
+      setForm(editing ? idpToForm(editing) : emptyForm());
+      setError('');
+    }
+  }, [open, editing?.id]);
+
+  const set = <K extends keyof IdpFormState>(field: K, value: IdpFormState[K]) =>
+    setForm((f) => ({ ...f, [field]: value }));
+
+  const mutation = useMutation({
+    mutationFn: () => {
+      const payload = formToPayload(form);
+      return editing
+        ? idpApi.update(editing.id, payload)
+        : idpApi.create(payload);
+    },
+    onSuccess: () => {
+      onSaved();
+      onClose();
+      setError('');
+    },
+    onError: (err: Error) => setError(err.message),
+  });
+
+  if (!open) return null;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    mutation.mutate();
+  };
+
+  const isDisabled =
+    mutation.isPending ||
+    !form.name.trim() ||
+    !form.issuer_url.trim() ||
+    !form.provider_type;
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 50,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'rgba(0,0,0,0.6)',
+      }}
+      onClick={onClose}
+    >
+      <div
+        style={{
+          background: 'var(--elev)',
+          border: '1px solid var(--border-2)',
+          borderRadius: 12,
+          padding: 24,
+          width: 600,
+          maxHeight: '85vh',
+          overflowY: 'auto',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 style={{ fontSize: 18, fontWeight: 700, marginBottom: 18 }}>
+          {editing ? 'Edit Identity Provider' : 'New Identity Provider'}
+        </h3>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {/* Top-level required fields */}
+          <div className="grid grid-cols-2 gap-4">
+            <Field label="Provider Type" required>
+              <select
+                value={form.provider_type}
+                onChange={(e) => set('provider_type', e.target.value)}
+                required
+                style={INPUT_STYLE}
+              >
+                <option value="oidc">oidc</option>
+                <option value="saml">saml</option>
+              </select>
+            </Field>
+            <Field label="Name" required>
+              <input
+                value={form.name}
+                onChange={(e) => set('name', e.target.value)}
+                placeholder="My IdP"
+                required
+                style={INPUT_STYLE}
+              />
+            </Field>
+          </div>
+
+          {/* OIDC Configuration */}
+          <SectionHeader>OIDC Configuration</SectionHeader>
+
+          <div className="grid grid-cols-2 gap-4">
+            <Field label="Issuer URL">
+              <input
+                value={form.issuer_url}
+                onChange={(e) => set('issuer_url', e.target.value)}
+                placeholder="https://idp.example.com"
+                style={INPUT_STYLE}
+              />
+            </Field>
+            <Field label="JWKS URI">
+              <input
+                value={form.jwks_uri}
+                onChange={(e) => set('jwks_uri', e.target.value)}
+                placeholder="https://idp.example.com/.well-known/jwks.json"
+                style={INPUT_STYLE}
+              />
+            </Field>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <Field label="Auth URL">
+              <input
+                value={form.auth_url}
+                onChange={(e) => set('auth_url', e.target.value)}
+                placeholder="https://idp.example.com/authorize"
+                style={INPUT_STYLE}
+              />
+            </Field>
+            <Field label="Token URL">
+              <input
+                value={form.token_url}
+                onChange={(e) => set('token_url', e.target.value)}
+                placeholder="https://idp.example.com/token"
+                style={INPUT_STYLE}
+              />
+            </Field>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <Field label="Userinfo URL">
+              <input
+                value={form.userinfo_url}
+                onChange={(e) => set('userinfo_url', e.target.value)}
+                placeholder="https://idp.example.com/userinfo"
+                style={INPUT_STYLE}
+              />
+            </Field>
+            <Field label="Audience">
+              <input
+                value={form.audience}
+                onChange={(e) => set('audience', e.target.value)}
+                placeholder="api://my-app"
+                style={INPUT_STYLE}
+              />
+            </Field>
+          </div>
+
+          <Field label="Scopes">
+            <input
+              value={form.scopes}
+              onChange={(e) => set('scopes', e.target.value)}
+              placeholder="openid email profile"
+              style={INPUT_STYLE}
+            />
+          </Field>
+
+          {/* User Identity Mapping */}
+          <SectionHeader>User Identity Mapping</SectionHeader>
+
+          <div className="grid grid-cols-2 gap-4">
+            <Field label="User ID Claim">
+              <input
+                value={form.user_id_claim}
+                onChange={(e) => set('user_id_claim', e.target.value)}
+                style={INPUT_STYLE}
+              />
+            </Field>
+            <Field label="Email Claim">
+              <input
+                value={form.email_claim}
+                onChange={(e) => set('email_claim', e.target.value)}
+                style={INPUT_STYLE}
+              />
+            </Field>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <Field label="Name Claim">
+              <input
+                value={form.name_claim}
+                onChange={(e) => set('name_claim', e.target.value)}
+                placeholder="name"
+                style={INPUT_STYLE}
+              />
+            </Field>
+            <Field label="Tenant ID Claim">
+              <input
+                value={form.tenant_id_claim}
+                onChange={(e) => set('tenant_id_claim', e.target.value)}
+                placeholder="tenant_id"
+                style={INPUT_STYLE}
+              />
+            </Field>
+          </div>
+
+          {/* Role Mapping */}
+          <SectionHeader>Role Mapping</SectionHeader>
+
+          <div className="grid grid-cols-2 gap-4">
+            <Field label="Role Claim">
+              <input
+                value={form.role_claim}
+                onChange={(e) => set('role_claim', e.target.value)}
+                placeholder="roles"
+                style={INPUT_STYLE}
+              />
+            </Field>
+            <Field label="Default Role">
+              <select
+                value={form.default_role}
+                onChange={(e) => set('default_role', e.target.value)}
+                style={INPUT_STYLE}
+              >
+                {DEFAULT_ROLES.map((r) => (
+                  <option key={r} value={r}>
+                    {r}
+                  </option>
+                ))}
+              </select>
+            </Field>
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <Field label="Admin Role Values (one per line)">
+              <textarea
+                value={form.admin_role_values}
+                onChange={(e) => set('admin_role_values', e.target.value)}
+                rows={3}
+                placeholder={'admin\nsuperuser'}
+                style={TEXTAREA_STYLE}
+              />
+            </Field>
+            <Field label="Editor Role Values (one per line)">
+              <textarea
+                value={form.editor_role_values}
+                onChange={(e) => set('editor_role_values', e.target.value)}
+                rows={3}
+                placeholder="editor"
+                style={TEXTAREA_STYLE}
+              />
+            </Field>
+          </div>
+
+          <Field label="Admin Domains (one per line)">
+            <textarea
+              value={form.admin_domains}
+              onChange={(e) => set('admin_domains', e.target.value)}
+              rows={3}
+              placeholder={'example.com\ncorp.example.com'}
+              style={TEXTAREA_STYLE}
+            />
+          </Field>
+
+          {/* Provisioning */}
+          <SectionHeader>Provisioning</SectionHeader>
+
+          <div className="flex flex-col gap-3">
+            <label
+              style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, cursor: 'pointer' }}
+            >
+              <input
+                type="checkbox"
+                checked={form.enabled}
+                onChange={(e) => set('enabled', e.target.checked)}
+                style={{ width: 15, height: 15 }}
+              />
+              Enabled
+            </label>
+            <label
+              style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, cursor: 'pointer' }}
+            >
+              <input
+                type="checkbox"
+                checked={form.allow_auto_provision}
+                onChange={(e) => set('allow_auto_provision', e.target.checked)}
+                style={{ width: 15, height: 15 }}
+              />
+              Allow Auto-Provision (create tenants/users on first JWT validation)
+            </label>
+          </div>
+
+          {error && <p style={{ fontSize: 12, color: '#dc2626' }}>{error}</p>}
+
+          <div className="flex justify-end gap-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              style={{
+                background: 'var(--card)',
+                border: '1px solid var(--border)',
+                color: 'var(--fg)',
+                borderRadius: 8,
+                padding: '0 16px',
+                height: 36,
+                fontSize: 13,
+                cursor: 'pointer',
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isDisabled}
+              style={{
+                background: 'var(--primary)',
+                color: 'var(--primary-fg)',
+                border: 'none',
+                borderRadius: 8,
+                padding: '0 16px',
+                height: 36,
+                fontSize: 13,
+                fontWeight: 500,
+                cursor: isDisabled ? 'not-allowed' : 'pointer',
+                opacity: isDisabled ? 0.5 : 1,
+              }}
+            >
+              {mutation.isPending ? 'Saving...' : editing ? 'Save Changes' : 'Create'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+interface TestResult {
+  key_count: number;
+  latency_ms: number;
+}
+
+function TestJwksButton({ idpId }: { idpId: string }) {
+  const [result, setResult] = useState<TestResult | null>(null);
+  const [testError, setTestError] = useState('');
+
+  const mutation = useMutation({
+    mutationFn: () => idpApi.test(idpId),
+    onSuccess: (data) => {
+      setResult(data);
+      setTestError('');
+    },
+    onError: (err: Error) => {
+      setTestError(err.message);
+      setResult(null);
+    },
+  });
+
+  return (
+    <div className="flex items-center gap-2">
+      <button
+        onClick={() => mutation.mutate()}
+        disabled={mutation.isPending}
+        style={{
+          fontSize: 12,
+          color: 'var(--primary)',
+          background: 'none',
+          border: 'none',
+          cursor: mutation.isPending ? 'not-allowed' : 'pointer',
+          textDecoration: 'underline',
+          opacity: mutation.isPending ? 0.5 : 1,
+          padding: 0,
+        }}
+      >
+        {mutation.isPending ? 'Testing...' : 'Test JWKS'}
+      </button>
+      {result && (
+        <span style={{ fontSize: 11, color: '#16a34a' }}>
+          ✓ {result.key_count} key{result.key_count !== 1 ? 's' : ''} ({result.latency_ms}ms)
+        </span>
+      )}
+      {testError && (
+        <span style={{ fontSize: 11, color: '#dc2626' }}>{testError}</span>
+      )}
+    </div>
+  );
+}
+
+const BADGE_BASE: React.CSSProperties = {
+  display: 'inline-block',
+  padding: '2px 8px',
+  borderRadius: 9999,
+  fontSize: 11,
+  fontWeight: 500,
+};
+
+export function IdentityProvidersPage() {
+  const isAdmin = useHasRole('Admin');
+  const qc = useQueryClient();
+  const [formOpen, setFormOpen] = useState(false);
+  const [editing, setEditing] = useState<IdentityProviderConfig | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<IdentityProviderConfig | null>(null);
+  const [hoveredRow, setHoveredRow] = useState<string | null>(null);
+
+  const { data: idps, isLoading } = useQuery({
+    queryKey: ['identity-providers'],
+    queryFn: () => idpApi.list(),
+    enabled: isAdmin,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => idpApi.remove(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['identity-providers'] });
+      setDeleteTarget(null);
+    },
+  });
+
+  if (!isAdmin) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24 text-center">
+        <LockIcon />
+        <p style={{ fontSize: 15, fontWeight: 500, color: 'var(--fg)' }}>
+          You don't have permission to view this page.
+        </p>
+      </div>
+    );
+  }
+
+  const handleEdit = (idp: IdentityProviderConfig) => {
+    setEditing(idp);
+    setFormOpen(true);
+  };
+
+  const handleCloseForm = () => {
+    setFormOpen(false);
+    setEditing(null);
+  };
+
+  const thStyle: React.CSSProperties = {
+    padding: '11px 14px',
+    fontSize: 11,
+    textTransform: 'uppercase',
+    letterSpacing: '0.06em',
+    fontWeight: 500,
+    color: 'var(--faint-fg)',
+    textAlign: 'left',
+    background: 'var(--card-2)',
+  };
+
+  const tdStyle: React.CSSProperties = {
+    padding: '11px 14px',
+    fontSize: 13,
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 style={{ fontSize: 22, fontWeight: 700, color: 'var(--fg)' }}>
+            Identity Providers
+          </h1>
+          <p style={{ fontSize: 13, color: 'var(--muted-fg)', marginTop: 2 }}>
+            OIDC and SAML provider configuration
+          </p>
+        </div>
+        <button
+          onClick={() => {
+            setEditing(null);
+            setFormOpen(true);
+          }}
+          style={{
+            background: 'var(--primary)',
+            color: 'var(--primary-fg)',
+            border: 'none',
+            borderRadius: 8,
+            padding: '0 16px',
+            height: 36,
+            fontSize: 13,
+            fontWeight: 500,
+            cursor: 'pointer',
+          }}
+        >
+          + New IdP
+        </button>
+      </div>
+
+      {isLoading && (
+        <p style={{ color: 'var(--muted-fg)', fontSize: 13 }}>Loading...</p>
+      )}
+
+      {!isLoading && (idps ?? []).length === 0 && (
+        <EmptyState
+          title="No identity providers"
+          description="Add an IdP to enable OAuth/OIDC login."
+          action={
+            <button
+              onClick={() => setFormOpen(true)}
+              style={{
+                background: 'var(--primary)',
+                color: 'var(--primary-fg)',
+                border: 'none',
+                borderRadius: 8,
+                padding: '0 16px',
+                height: 36,
+                fontSize: 13,
+                fontWeight: 500,
+                cursor: 'pointer',
+              }}
+            >
+              + New IdP
+            </button>
+          }
+        />
+      )}
+
+      {(idps ?? []).length > 0 && (
+        <div
+          className="overflow-x-auto"
+          style={{
+            background: 'var(--card)',
+            border: '1px solid var(--border)',
+            borderRadius: 12,
+            overflow: 'hidden',
+          }}
+        >
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr>
+                <th style={thStyle}>Name</th>
+                <th style={thStyle}>Issuer URL</th>
+                <th style={thStyle}>Auto-Provision</th>
+                <th style={thStyle}>Default Role</th>
+                <th style={{ ...thStyle, textAlign: 'right' }}>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {idps!.map((idp) => (
+                <tr
+                  key={idp.id}
+                  onMouseEnter={() => setHoveredRow(idp.id)}
+                  onMouseLeave={() => setHoveredRow(null)}
+                  style={{
+                    borderTop: '1px solid var(--border)',
+                    background:
+                      hoveredRow === idp.id
+                        ? 'color-mix(in srgb, var(--fg) 4%, transparent)'
+                        : undefined,
+                  }}
+                >
+                  <td style={{ ...tdStyle, fontWeight: 500 }}>{idp.name}</td>
+                  <td
+                    style={{
+                      ...tdStyle,
+                      fontFamily: 'monospace',
+                      fontSize: 12,
+                      maxWidth: 240,
+                      overflow: 'hidden',
+                      textOverflow: 'ellipsis',
+                      whiteSpace: 'nowrap',
+                    }}
+                    title={idp.issuer_url ?? ''}
+                  >
+                    {idp.issuer_url ?? '—'}
+                  </td>
+                  <td style={tdStyle}>
+                    {idp.allow_auto_provision ? (
+                      <span style={{ ...BADGE_BASE, background: '#dcfce7', color: '#15803d' }}>
+                        Yes
+                      </span>
+                    ) : (
+                      <span
+                        style={{ ...BADGE_BASE, background: 'var(--card-2)', color: 'var(--muted-fg)' }}
+                      >
+                        No
+                      </span>
+                    )}
+                  </td>
+                  <td style={tdStyle}>
+                    <span
+                      style={{ ...BADGE_BASE, background: 'var(--card-2)', color: 'var(--muted-fg)' }}
+                    >
+                      {idp.default_role}
+                    </span>
+                  </td>
+                  <td style={{ ...tdStyle, textAlign: 'right' }}>
+                    <div className="flex items-center justify-end gap-3">
+                      <TestJwksButton idpId={idp.id} />
+                      <button
+                        onClick={() => handleEdit(idp)}
+                        style={{
+                          fontSize: 12,
+                          color: 'var(--primary)',
+                          background: 'none',
+                          border: 'none',
+                          cursor: 'pointer',
+                          textDecoration: 'underline',
+                          padding: 0,
+                        }}
+                      >
+                        Edit
+                      </button>
+                      <button
+                        onClick={() => setDeleteTarget(idp)}
+                        style={{
+                          fontSize: 12,
+                          color: '#dc2626',
+                          background: 'none',
+                          border: 'none',
+                          cursor: 'pointer',
+                          textDecoration: 'underline',
+                          padding: 0,
+                        }}
+                      >
+                        Delete
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <IdpFormDialog
+        open={formOpen}
+        editing={editing}
+        onClose={handleCloseForm}
+        onSaved={() => qc.invalidateQueries({ queryKey: ['identity-providers'] })}
+      />
+
+      <ConfirmDialog
+        open={!!deleteTarget}
+        title={`Delete IdP "${deleteTarget?.name}"`}
+        description="This will remove the identity provider. Users who only have access via this IdP will no longer be able to sign in."
+        confirmLabel="Delete IdP"
+        destructive
+        onConfirm={() => deleteMutation.mutate(deleteTarget!.id)}
+        onCancel={() => setDeleteTarget(null)}
+      />
+    </div>
+  );
+}

--- a/apps/admin-ui/src/routes/login.tsx
+++ b/apps/admin-ui/src/routes/login.tsx
@@ -1,0 +1,321 @@
+import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router';
+import { useAuthStore } from '@/stores/auth';
+import { authApi, type OAuthProvider } from '@/api/auth';
+import { env } from '@/env';
+
+export function LoginPage() {
+  const navigate = useNavigate();
+  const { token, setToken } = useAuthStore();
+
+  const [providers, setProviders] = useState<OAuthProvider[]>([]);
+  const [email, setEmail] = useState('admin@browser-hitl.local');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [showEmailForm, setShowEmailForm] = useState(false);
+
+  useEffect(() => {
+    if (token) navigate('/dashboard', { replace: true });
+  }, [token, navigate]);
+
+  useEffect(() => {
+    authApi
+      .listOAuthProviders()
+      .then((list) => {
+        setProviders(list);
+        // Auto-expand email form when no OAuth options are available
+        if (list.length === 0) setShowEmailForm(true);
+      })
+      .catch(() => {
+        setShowEmailForm(true);
+      });
+  }, []);
+
+  const handleLogin = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+    try {
+      const res = await authApi.login({ email, password });
+      setToken(res.token);
+      navigate('/dashboard', { replace: true });
+    } catch {
+      setError('Invalid credentials');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleOAuth = (idpId: string) => {
+    const callbackUrl = `${window.location.origin}/auth/callback`;
+    window.location.href = `${env.apiUrl()}/auth/oauth/${idpId}/login?redirect_uri=${encodeURIComponent(callbackUrl)}`;
+  };
+
+  return (
+    <>
+      {/* Full-page radial gradient overlay */}
+      <div
+        style={{
+          position: 'fixed',
+          inset: 0,
+          background:
+            'radial-gradient(1200px 600px at 50% -10%, color-mix(in srgb, var(--primary) 10%, transparent), transparent)',
+          pointerEvents: 'none',
+          zIndex: 0,
+        }}
+      />
+
+      {/* Content */}
+      <div style={{ position: 'relative', zIndex: 1, width: '100%' }}>
+        {/* Logo */}
+        <div style={{ textAlign: 'center', marginBottom: 24 }}>
+          <div
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 10,
+              marginBottom: 8,
+            }}
+          >
+            <div
+              style={{
+                width: 30,
+                height: 30,
+                background: 'var(--primary)',
+                borderRadius: 8,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                color: '#fff',
+                fontSize: 14,
+                fontWeight: 800,
+              }}
+            >
+              T
+            </div>
+            <span
+              style={{
+                fontSize: 22,
+                fontWeight: 800,
+                letterSpacing: '-0.02em',
+                color: 'var(--fg)',
+              }}
+            >
+              Tabby
+            </span>
+          </div>
+          <p
+            style={{
+              fontSize: 12.5,
+              color: 'var(--muted-fg)',
+              margin: 0,
+            }}
+          >
+            Browser HITL control plane · sign in to continue
+          </p>
+        </div>
+
+        {/* Card */}
+        <div
+          style={{
+            background: 'var(--card)',
+            border: '1px solid var(--border)',
+            borderRadius: 12,
+            padding: 20,
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 10,
+          }}
+        >
+          {/* OAuth buttons */}
+          {providers.map((p) => (
+            <button
+              key={p.id}
+              onClick={() => handleOAuth(p.id)}
+              style={{
+                width: '100%',
+                height: 40,
+                background: 'var(--card-2)',
+                border: '1px solid var(--border-2)',
+                borderRadius: 8,
+                fontSize: 13,
+                fontWeight: 600,
+                color: 'var(--fg)',
+                cursor: 'pointer',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                transition: 'background 120ms ease',
+              }}
+              onMouseEnter={(e) => {
+                (e.currentTarget as HTMLButtonElement).style.background = 'var(--muted)';
+              }}
+              onMouseLeave={(e) => {
+                (e.currentTarget as HTMLButtonElement).style.background = 'var(--card-2)';
+              }}
+            >
+              Sign in with {p.name}
+            </button>
+          ))}
+
+          {/* "or" divider */}
+          {providers.length > 0 && (
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: 10,
+                margin: '2px 0',
+              }}
+            >
+              <div style={{ flex: 1, height: 1, background: 'var(--border)' }} />
+              <span style={{ fontSize: 11, color: 'var(--faint-fg)' }}>or</span>
+              <div style={{ flex: 1, height: 1, background: 'var(--border)' }} />
+            </div>
+          )}
+
+          {/* Email form toggle */}
+          {providers.length > 0 && (
+            <button
+              onClick={() => setShowEmailForm((v) => !v)}
+              style={{
+                background: 'transparent',
+                border: 'none',
+                cursor: 'pointer',
+                fontSize: 12,
+                color: 'var(--muted-fg)',
+                padding: '2px 0',
+                textAlign: 'center',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: 5,
+              }}
+            >
+              <span>{showEmailForm ? '▾' : '▸'}</span>
+              Sign in with email &amp; password
+            </button>
+          )}
+
+          {/* Email + password form */}
+          {showEmailForm && (
+            <form
+              onSubmit={handleLogin}
+              style={{ display: 'flex', flexDirection: 'column', gap: 8 }}
+            >
+              <div>
+                <label
+                  style={{
+                    display: 'block',
+                    fontSize: 11.5,
+                    fontWeight: 600,
+                    color: 'var(--muted-fg)',
+                    marginBottom: 5,
+                  }}
+                >
+                  Email
+                </label>
+                <input
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  style={{
+                    width: '100%',
+                    height: 36,
+                    background: 'var(--card-2)',
+                    border: '1px solid var(--border-2)',
+                    borderRadius: 8,
+                    padding: '0 10px',
+                    fontSize: 13,
+                    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+                    color: 'var(--fg)',
+                    boxSizing: 'border-box',
+                  }}
+                />
+              </div>
+
+              <div>
+                <label
+                  style={{
+                    display: 'block',
+                    fontSize: 11.5,
+                    fontWeight: 600,
+                    color: 'var(--muted-fg)',
+                    marginBottom: 5,
+                  }}
+                >
+                  Password
+                </label>
+                <input
+                  type="password"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  placeholder="••••••••••"
+                  style={{
+                    width: '100%',
+                    height: 36,
+                    background: 'var(--card-2)',
+                    border: '1px solid var(--border-2)',
+                    borderRadius: 8,
+                    padding: '0 10px',
+                    fontSize: 13,
+                    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace',
+                    color: 'var(--fg)',
+                    boxSizing: 'border-box',
+                  }}
+                />
+              </div>
+
+              {error && (
+                <p
+                  style={{
+                    margin: 0,
+                    fontSize: 12,
+                    color: 'var(--error)',
+                  }}
+                >
+                  {error}
+                </p>
+              )}
+
+              <button
+                type="submit"
+                disabled={loading}
+                style={{
+                  width: '100%',
+                  height: 38,
+                  background: 'var(--primary)',
+                  border: 'none',
+                  borderRadius: 8,
+                  fontSize: 13,
+                  fontWeight: 600,
+                  color: 'var(--primary-fg)',
+                  cursor: loading ? 'not-allowed' : 'pointer',
+                  opacity: loading ? 0.6 : 1,
+                  transition: 'opacity 120ms ease',
+                  marginTop: 2,
+                }}
+              >
+                {loading ? 'Signing in…' : 'Sign in'}
+              </button>
+            </form>
+          )}
+        </div>
+
+        {/* Below-card hint */}
+        <p
+          style={{
+            textAlign: 'center',
+            fontSize: 11,
+            color: 'var(--faint-fg)',
+            marginTop: 16,
+            marginBottom: 0,
+          }}
+        >
+          admin@browser-hitl.local · local development
+        </p>
+      </div>
+    </>
+  );
+}

--- a/apps/admin-ui/src/routes/profile-detail.tsx
+++ b/apps/admin-ui/src/routes/profile-detail.tsx
@@ -1,0 +1,299 @@
+import { useState } from 'react';
+import { useParams, Link } from 'react-router';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { profilesApi } from '@/api/profiles';
+import { StatusBadge } from '@/components/shared/status-badge';
+import { ConfirmDialog } from '@/components/shared/confirm-dialog';
+import { useHasRole } from '@/hooks/use-role';
+
+const LABEL_STYLE: React.CSSProperties = {
+  fontSize: 11,
+  textTransform: 'uppercase',
+  letterSpacing: '0.06em',
+  fontWeight: 500,
+  color: 'var(--faint-fg)',
+  marginBottom: 4,
+};
+
+const FIELD_MONO: React.CSSProperties = {
+  fontFamily: 'ui-monospace, Menlo, monospace',
+  fontSize: 12,
+  color: 'var(--fg)',
+  wordBreak: 'break-all',
+};
+
+const FIELD_TEXT: React.CSSProperties = { fontSize: 13, color: 'var(--fg)' };
+
+const PRE_STYLE: React.CSSProperties = {
+  fontFamily: 'ui-monospace, Menlo, monospace',
+  fontSize: 12,
+  overflowX: 'auto',
+  background: 'var(--card-2)',
+  padding: '12px 14px',
+  borderRadius: 8,
+  margin: 0,
+  color: 'var(--fg)',
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-all',
+};
+
+const CARD: React.CSSProperties = {
+  background: 'var(--card)',
+  border: '1px solid var(--border)',
+  borderRadius: 12,
+  padding: '20px 24px',
+};
+
+const STAT_CARD: React.CSSProperties = {
+  background: 'var(--card)',
+  border: '1px solid var(--border)',
+  borderRadius: 12,
+  padding: '16px 20px',
+};
+
+export function ProfileDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const qc = useQueryClient();
+  const canWrite = useHasRole('Admin', 'Editor');
+
+  const [showPromote, setShowPromote] = useState(false);
+  const [showRollback, setShowRollback] = useState(false);
+
+  const { data: profile, isLoading } = useQuery({
+    queryKey: ['profile', id],
+    queryFn: () => profilesApi.get(id!),
+    enabled: !!id,
+  });
+
+  const promoteMutation = useMutation({
+    mutationFn: () => profilesApi.promote(id!),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['profile', id] });
+      qc.invalidateQueries({ queryKey: ['profiles'] });
+      setShowPromote(false);
+    },
+  });
+
+  const rollbackMutation = useMutation({
+    mutationFn: () => profilesApi.rollback(id!),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['profile', id] });
+      qc.invalidateQueries({ queryKey: ['profiles'] });
+      setShowRollback(false);
+    },
+  });
+
+  if (isLoading || !profile) {
+    return <p style={{ color: 'var(--muted-fg)', fontSize: 13 }}>Loading…</p>;
+  }
+
+  const canPromote = canWrite && (profile.version_state === 'STAGING' || profile.version_state === 'CANARY');
+  const canRollback = canWrite && profile.version_state === 'ACTIVE' && !!profile.parent_version_id;
+
+  const errorRate =
+    profile.version_state === 'CANARY' && profile.canary_request_count > 0
+      ? ((profile.canary_error_count / profile.canary_request_count) * 100).toFixed(1)
+      : null;
+
+  const configSections = [
+    { label: 'Login Config', value: profile.login_config },
+    { label: 'Credential Types', value: profile.credential_types },
+  ];
+
+  return (
+    <div>
+      <ConfirmDialog
+        open={showPromote}
+        title="Promote Profile"
+        description={
+          profile.version_state === 'STAGING'
+            ? 'This will move the profile from STAGING to CANARY.'
+            : 'This will promote the profile from CANARY to ACTIVE.'
+        }
+        confirmLabel="Promote"
+        onConfirm={async () => { await promoteMutation.mutateAsync(); }}
+        onCancel={() => setShowPromote(false)}
+      />
+      <ConfirmDialog
+        open={showRollback}
+        title="Rollback Profile"
+        description="This will roll back to the parent version. The current ACTIVE profile will be retired."
+        confirmLabel="Rollback"
+        destructive
+        onConfirm={async () => { await rollbackMutation.mutateAsync(); }}
+        onCancel={() => setShowRollback(false)}
+      />
+
+      {/* Breadcrumb */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 8 }}>
+        <Link to="/profiles" style={{ fontSize: 12.5, color: 'var(--muted-fg)', textDecoration: 'none' }}>
+          Profiles
+        </Link>
+        <span style={{ color: 'var(--faint-fg)', fontSize: 12.5 }}>/</span>
+        <span style={{
+          fontSize: 12.5, color: 'var(--fg)',
+          fontFamily: 'ui-monospace, Menlo, monospace',
+        }}>
+          {profile.profile_id}
+        </span>
+      </div>
+
+      {/* Header */}
+      <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', marginBottom: 24 }}>
+        <div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+            <h1 style={{ fontSize: 22, fontWeight: 800, letterSpacing: '-0.02em', margin: 0, color: 'var(--fg)' }}>
+              {profile.profile_id}
+            </h1>
+            <span style={{
+              fontFamily: 'ui-monospace, Menlo, monospace',
+              fontSize: 12, color: 'var(--muted-fg)',
+              background: 'var(--card-2)', padding: '2px 8px', borderRadius: 6,
+            }}>
+              v{profile.version}
+            </span>
+            <StatusBadge value={profile.version_state} />
+          </div>
+          <p style={{
+            fontFamily: 'ui-monospace, Menlo, monospace',
+            fontSize: 12, color: 'var(--faint-fg)', marginTop: 4, marginBottom: 0,
+          }}>
+            {profile.id}
+          </p>
+        </div>
+
+        <div style={{ display: 'flex', gap: 8 }}>
+          {canPromote && (
+            <button
+              onClick={() => setShowPromote(true)}
+              disabled={promoteMutation.isPending}
+              style={{
+                height: 34, padding: '0 14px', borderRadius: 8,
+                background: 'var(--primary)', color: 'var(--primary-fg)',
+                fontWeight: 600, fontSize: 12.5, border: 'none',
+                cursor: promoteMutation.isPending ? 'default' : 'pointer',
+                opacity: promoteMutation.isPending ? 0.6 : 1,
+              }}
+            >
+              {promoteMutation.isPending ? 'Promoting…' : 'Promote'}
+            </button>
+          )}
+          {canRollback && (
+            <button
+              onClick={() => setShowRollback(true)}
+              disabled={rollbackMutation.isPending}
+              style={{
+                height: 34, padding: '0 14px', borderRadius: 8,
+                border: `1px solid color-mix(in srgb, var(--warning) 40%, transparent)`,
+                background: 'var(--card)',
+                color: 'var(--warning)', fontSize: 12.5,
+                cursor: rollbackMutation.isPending ? 'default' : 'pointer',
+                opacity: rollbackMutation.isPending ? 0.6 : 1,
+              }}
+            >
+              {rollbackMutation.isPending ? 'Rolling back…' : 'Rollback'}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Canary stats row */}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(4, 1fr)', gap: 12, marginBottom: 16 }}>
+        <div style={STAT_CARD}>
+          <div style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.06em', fontWeight: 500, color: 'var(--faint-fg)', marginBottom: 6 }}>
+            State
+          </div>
+          <StatusBadge value={profile.version_state} />
+        </div>
+        <div style={STAT_CARD}>
+          <div style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.06em', fontWeight: 500, color: 'var(--faint-fg)', marginBottom: 6 }}>
+            Version
+          </div>
+          <div style={{ fontSize: 20, fontWeight: 700, color: 'var(--fg)' }}>{profile.version}</div>
+        </div>
+        <div style={STAT_CARD}>
+          <div style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.06em', fontWeight: 500, color: 'var(--faint-fg)', marginBottom: 6 }}>
+            Canary Requests
+          </div>
+          <div style={{ fontSize: 20, fontWeight: 700, color: 'var(--fg)', fontVariantNumeric: 'tabular-nums' }}>
+            {profile.canary_request_count}
+          </div>
+        </div>
+        <div style={STAT_CARD}>
+          <div style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.06em', fontWeight: 500, color: 'var(--faint-fg)', marginBottom: 6 }}>
+            Canary Errors
+          </div>
+          <div style={{ fontSize: 20, fontWeight: 700, color: profile.canary_error_count > 0 ? 'var(--error)' : 'var(--fg)', fontVariantNumeric: 'tabular-nums' }}>
+            {profile.canary_error_count}
+          </div>
+        </div>
+      </div>
+
+      {/* Error rate callout */}
+      {errorRate !== null && (
+        <div style={{ ...STAT_CARD, marginBottom: 16, display: 'flex', alignItems: 'center', gap: 24 }}>
+          <div>
+            <div style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.06em', fontWeight: 500, color: 'var(--faint-fg)', marginBottom: 4 }}>
+              Canary Error Rate
+            </div>
+            <div style={{ fontSize: 28, fontWeight: 800, color: Number(errorRate) > 5 ? 'var(--error)' : 'var(--success)' }}>
+              {errorRate}%
+            </div>
+          </div>
+          <div style={{ fontSize: 12, color: 'var(--muted-fg)' }}>
+            {profile.canary_error_count} errors / {profile.canary_request_count} requests
+          </div>
+        </div>
+      )}
+
+      {/* Details card */}
+      <div style={{ ...CARD, marginBottom: 16 }}>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '20px 32px' }}>
+          {[
+            { label: 'Profile ID', value: profile.profile_id, mono: true },
+            { label: 'Record ID', value: profile.id, mono: true },
+            { label: 'App ID', value: profile.app_id, mono: true },
+            { label: 'Tenant ID', value: profile.tenant_id, mono: true },
+            { label: 'Parent Version ID', value: profile.parent_version_id ?? '—', mono: true },
+            { label: 'Owner User ID', value: profile.owner_user_id ?? '—', mono: true },
+            { label: 'Created', value: new Date(profile.created_at).toLocaleString(), mono: false },
+            { label: 'Updated', value: new Date(profile.updated_at).toLocaleString(), mono: false },
+          ].map(({ label, value, mono }) => (
+            <div key={label}>
+              <div style={LABEL_STYLE}>{label}</div>
+              <div style={mono ? FIELD_MONO : FIELD_TEXT}>{value}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Target Domains */}
+      <div style={{ ...CARD, marginBottom: 16 }}>
+        <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--fg)', marginBottom: 12 }}>Target Domains</div>
+        {profile.target_domains.length === 0 ? (
+          <p style={{ fontSize: 13, color: 'var(--muted-fg)', margin: 0 }}>None configured.</p>
+        ) : (
+          <ul style={{ margin: 0, padding: 0, listStyle: 'none', display: 'flex', flexDirection: 'column', gap: 4 }}>
+            {profile.target_domains.map((d) => (
+              <li key={d} style={{ fontFamily: 'ui-monospace, Menlo, monospace', fontSize: 12, color: 'var(--fg)' }}>
+                {d}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {/* Config sections */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        {configSections.map(({ label, value }) => (
+          <div key={label} style={CARD}>
+            <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--fg)', marginBottom: 12 }}>{label}</div>
+            <pre style={PRE_STYLE}>
+              {value ? JSON.stringify(value, null, 2) : 'null'}
+            </pre>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin-ui/src/routes/profiles.tsx
+++ b/apps/admin-ui/src/routes/profiles.tsx
@@ -1,0 +1,203 @@
+import { useState } from 'react';
+import { Link } from 'react-router';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { profilesApi } from '@/api/profiles';
+import { StatusBadge } from '@/components/shared/status-badge';
+import { ConfirmDialog } from '@/components/shared/confirm-dialog';
+import { useHasRole } from '@/hooks/use-role';
+
+const TH: React.CSSProperties = {
+  padding: '11px 14px',
+  fontSize: 11,
+  textTransform: 'uppercase',
+  letterSpacing: '0.06em',
+  fontWeight: 500,
+  color: 'var(--faint-fg)',
+  textAlign: 'left',
+};
+
+const TD: React.CSSProperties = { padding: '11px 14px', fontSize: 13, color: 'var(--fg)' };
+const TD_MONO: React.CSSProperties = {
+  padding: '11px 14px',
+  fontFamily: 'ui-monospace, Menlo, monospace',
+  fontSize: 12,
+  color: 'var(--muted-fg)',
+};
+
+type ConfirmAction = { type: 'promote' | 'rollback'; id: string };
+
+export function ProfilesPage() {
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+  const [confirmAction, setConfirmAction] = useState<ConfirmAction | null>(null);
+  const canWrite = useHasRole('Admin', 'Editor');
+  const qc = useQueryClient();
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['profiles'],
+    queryFn: () => profilesApi.list(),
+  });
+
+  const profiles = data ?? [];
+
+  const promoteMutation = useMutation({
+    mutationFn: (id: string) => profilesApi.promote(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['profiles'] });
+      setConfirmAction(null);
+    },
+  });
+
+  const rollbackMutation = useMutation({
+    mutationFn: (id: string) => profilesApi.rollback(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['profiles'] });
+      setConfirmAction(null);
+    },
+  });
+
+  const isPending = promoteMutation.isPending || rollbackMutation.isPending;
+
+  return (
+    <div>
+      <ConfirmDialog
+        open={confirmAction?.type === 'promote'}
+        title="Promote Profile"
+        description="This will advance the profile to the next stage. STAGING → CANARY → ACTIVE."
+        confirmLabel="Promote"
+        onConfirm={async () => {
+          if (confirmAction) await promoteMutation.mutateAsync(confirmAction.id);
+        }}
+        onCancel={() => setConfirmAction(null)}
+      />
+      <ConfirmDialog
+        open={confirmAction?.type === 'rollback'}
+        title="Rollback Profile"
+        description="This will roll back the active profile to its parent version."
+        confirmLabel="Rollback"
+        destructive
+        onConfirm={async () => {
+          if (confirmAction) await rollbackMutation.mutateAsync(confirmAction.id);
+        }}
+        onCancel={() => setConfirmAction(null)}
+      />
+
+      <div style={{ marginBottom: 24 }}>
+        <h1 style={{ fontSize: 24, fontWeight: 800, letterSpacing: '-0.02em', margin: 0, color: 'var(--fg)' }}>
+          Profiles
+        </h1>
+        <p style={{ color: 'var(--muted-fg)', fontSize: 12.5, marginTop: 3, marginBottom: 0 }}>
+          Service profile versions and canary management
+        </p>
+      </div>
+
+      {isLoading && (
+        <p style={{ color: 'var(--muted-fg)', fontSize: 13 }}>Loading…</p>
+      )}
+
+      {!isLoading && profiles.length === 0 && (
+        <div style={{
+          border: '1px dashed var(--border-2)', borderRadius: 12,
+          padding: '48px 24px', textAlign: 'center',
+        }}>
+          <p style={{ fontSize: 15, fontWeight: 600, color: 'var(--fg)', margin: '0 0 6px' }}>
+            No profiles
+          </p>
+          <p style={{ fontSize: 13, color: 'var(--muted-fg)', margin: 0 }}>
+            Service profiles are created automatically when applications run.
+          </p>
+        </div>
+      )}
+
+      {profiles.length > 0 && (
+        <div style={{ background: 'var(--card)', border: '1px solid var(--border)', borderRadius: 12, overflow: 'hidden' }}>
+          <div style={{ overflowX: 'auto' }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse', minWidth: 720 }}>
+              <thead>
+                <tr style={{ background: 'var(--card-2)' }}>
+                  <th style={TH}>PROFILE ID</th>
+                  <th style={TH}>VERSION</th>
+                  <th style={TH}>STATE</th>
+                  <th style={TH}>APP ID</th>
+                  <th style={TH}>CANARY REQ</th>
+                  <th style={TH}>CANARY ERR</th>
+                  <th style={{ ...TH, textAlign: 'right' }}>ACTIONS</th>
+                </tr>
+              </thead>
+              <tbody>
+                {profiles.map((p, i) => (
+                  <tr
+                    key={p.id}
+                    onMouseEnter={() => setHoveredId(p.id)}
+                    onMouseLeave={() => setHoveredId(null)}
+                    style={{
+                      borderBottom: i < profiles.length - 1 ? '1px solid var(--border)' : 'none',
+                      background: hoveredId === p.id
+                        ? 'color-mix(in srgb, var(--fg) 4%, transparent)'
+                        : undefined,
+                    }}
+                  >
+                    <td style={TD_MONO}>
+                      <Link
+                        to={`/profiles/${p.id}`}
+                        style={{ color: 'var(--primary)', textDecoration: 'none' }}
+                      >
+                        {p.profile_id}
+                      </Link>
+                    </td>
+                    <td style={{ ...TD, fontVariantNumeric: 'tabular-nums' }}>{p.version}</td>
+                    <td style={TD}>
+                      <StatusBadge value={p.version_state} />
+                    </td>
+                    <td style={{ ...TD_MONO, color: 'var(--muted-fg)' }}>{p.app_id}</td>
+                    <td style={{ ...TD, fontVariantNumeric: 'tabular-nums' }}>{p.canary_request_count}</td>
+                    <td style={{ ...TD, fontVariantNumeric: 'tabular-nums' }}>{p.canary_error_count}</td>
+                    <td style={{ ...TD, textAlign: 'right' }}>
+                      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'flex-end', gap: 8 }}>
+                        {canWrite && (p.version_state === 'STAGING' || p.version_state === 'CANARY') && (
+                          <button
+                            onClick={() => setConfirmAction({ type: 'promote', id: p.id })}
+                            disabled={isPending}
+                            style={{
+                              height: 26, padding: '0 10px', borderRadius: 6,
+                              border: '1px solid var(--border-2)', background: 'var(--card)',
+                              color: 'var(--fg)', fontSize: 12, cursor: isPending ? 'default' : 'pointer',
+                              opacity: isPending ? 0.5 : 1,
+                            }}
+                          >
+                            Promote
+                          </button>
+                        )}
+                        {canWrite && p.version_state === 'ACTIVE' && p.parent_version_id && (
+                          <button
+                            onClick={() => setConfirmAction({ type: 'rollback', id: p.id })}
+                            disabled={isPending}
+                            style={{
+                              height: 26, padding: '0 10px', borderRadius: 6,
+                              border: `1px solid color-mix(in srgb, var(--warning) 40%, transparent)`,
+                              background: 'var(--card)',
+                              color: 'var(--warning)', fontSize: 12,
+                              cursor: isPending ? 'default' : 'pointer',
+                              opacity: isPending ? 0.5 : 1,
+                            }}
+                          >
+                            Rollback
+                          </button>
+                        )}
+                        <Link
+                          to={`/profiles/${p.id}`}
+                          style={{ fontSize: 12, color: 'var(--primary)', textDecoration: 'none' }}
+                        >
+                          Details
+                        </Link>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/admin-ui/src/routes/session-detail.tsx
+++ b/apps/admin-ui/src/routes/session-detail.tsx
@@ -1,0 +1,420 @@
+import { useParams, Link } from 'react-router';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { sessionsApi } from '@/api/sessions';
+import { hitlApi } from '@/api/hitl';
+import { StatusBadge } from '@/components/shared/status-badge';
+import { useHasRole } from '@/hooks/use-role';
+import { useAuthStore } from '@/stores/auth';
+
+const INTERVENTION_HEADERS = ['Type', 'Outcome', 'Created', 'Completed'] as const;
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+}
+
+function StatCard({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div
+      style={{
+        background: 'var(--card)',
+        border: '1px solid var(--border)',
+        borderRadius: '12px',
+        padding: '14px 16px',
+      }}
+    >
+      <p
+        style={{
+          fontSize: '11px',
+          fontWeight: 500,
+          textTransform: 'uppercase',
+          letterSpacing: '0.06em',
+          color: 'var(--faint-fg)',
+          marginBottom: '8px',
+          margin: '0 0 8px',
+        }}
+      >
+        {label}
+      </p>
+      {children}
+    </div>
+  );
+}
+
+export function SessionDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const qc = useQueryClient();
+  const canOperate = useHasRole('Admin', 'Editor', 'Operator');
+  const isAdmin = useHasRole('Admin');
+  const currentUser = useAuthStore((s) => s.user);
+
+  const { data: session, isLoading } = useQuery({
+    queryKey: ['session', id],
+    queryFn: () => sessionsApi.get(id!),
+    refetchInterval: 5_000,
+    enabled: !!id,
+  });
+
+  const { data: interventions } = useQuery({
+    queryKey: ['interventions', id],
+    queryFn: () => sessionsApi.interventions(id!, { limit: 20 }),
+    enabled: !!id,
+  });
+
+  const streamMutation = useMutation({
+    mutationFn: () => sessionsApi.stream(id!),
+    onSuccess: (data) => window.open(data.url, '_blank'),
+  });
+
+  const takeoverMutation = useMutation({
+    mutationFn: () => hitlApi.takeover(id!),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['session', id] }),
+  });
+
+  const releaseMutation = useMutation({
+    mutationFn: () => hitlApi.release(id!),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ['session', id] }),
+  });
+
+  if (isLoading || !session) {
+    return (
+      <p style={{ color: 'var(--muted-fg)', fontSize: '13px' }}>Loading…</p>
+    );
+  }
+
+  const isHitlState =
+    session.state === 'LOGIN_IN_PROGRESS' || session.state === 'LOGIN_NEEDED';
+
+  const canOpenViewer =
+    isAdmin || session.owner_user_id === currentUser?.owner_user_id;
+
+  const interventionRows = interventions?.data ?? [];
+
+  return (
+    <div>
+      {/* Header */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'flex-start',
+          justifyContent: 'space-between',
+          marginBottom: '24px',
+        }}
+      >
+        <div>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: '10px',
+              marginBottom: '4px',
+              flexWrap: 'wrap',
+            }}
+          >
+            <h1
+              style={{
+                fontSize: '22px',
+                fontWeight: 800,
+                letterSpacing: '-0.02em',
+                color: 'var(--fg)',
+                margin: 0,
+                fontFamily: 'ui-monospace, Menlo, monospace',
+              }}
+            >
+              {session.id.slice(0, 8)}…
+            </h1>
+            <StatusBadge value={session.state} />
+            {session.health_result_type && (
+              <StatusBadge value={session.health_result_type} />
+            )}
+          </div>
+          <p
+            style={{
+              fontSize: '12px',
+              color: 'var(--faint-fg)',
+              fontFamily: 'ui-monospace, Menlo, monospace',
+              margin: 0,
+            }}
+          >
+            {session.application?.name ?? session.app_id}
+          </p>
+        </div>
+
+        <div style={{ display: 'flex', gap: '8px', flexShrink: 0 }}>
+          {canOpenViewer ? (
+            <Link
+              to={`/sessions/${id}/viewer`}
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                height: '34px',
+                padding: '0 14px',
+                borderRadius: '8px',
+                background: 'var(--primary)',
+                color: '#fff',
+                fontSize: '13px',
+                fontWeight: 500,
+                textDecoration: 'none',
+              }}
+            >
+              Open Viewer
+            </Link>
+          ) : (
+            <div title="You can only view sessions you own">
+              <button
+                disabled
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  height: '34px',
+                  padding: '0 14px',
+                  borderRadius: '8px',
+                  background: 'var(--card-2)',
+                  color: 'var(--faint-fg)',
+                  fontSize: '13px',
+                  fontWeight: 500,
+                  border: '1px solid var(--border)',
+                  cursor: 'not-allowed',
+                  opacity: 0.6,
+                }}
+              >
+                Open Viewer
+              </button>
+            </div>
+          )}
+          <button
+            onClick={() => streamMutation.mutate()}
+            disabled={streamMutation.isPending}
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              height: '34px',
+              padding: '0 14px',
+              borderRadius: '8px',
+              border: '1px solid var(--border)',
+              background: 'var(--card)',
+              color: 'var(--fg)',
+              fontSize: '13px',
+              fontWeight: 500,
+              cursor: streamMutation.isPending ? 'default' : 'pointer',
+              opacity: streamMutation.isPending ? 0.6 : 1,
+            }}
+          >
+            Stream URL
+          </button>
+        </div>
+      </div>
+
+      {/* Stats grid */}
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(4, 1fr)',
+          gap: '10px',
+          marginBottom: '24px',
+        }}
+      >
+        <StatCard label="State">
+          <StatusBadge value={session.state} />
+        </StatCard>
+        <StatCard label="Health">
+          <StatusBadge value={session.health_result_type} />
+        </StatCard>
+        <StatCard label="Retries">
+          <p
+            style={{
+              fontSize: '22px',
+              fontWeight: 800,
+              color: 'var(--fg)',
+              margin: 0,
+              lineHeight: 1,
+            }}
+          >
+            {session.retry_count}
+          </p>
+        </StatCard>
+        <StatCard label="HITL Attempts">
+          <p
+            style={{
+              fontSize: '22px',
+              fontWeight: 800,
+              color: 'var(--fg)',
+              margin: 0,
+              lineHeight: 1,
+            }}
+          >
+            {session.hitl_attempt_count}
+          </p>
+        </StatCard>
+      </div>
+
+      {/* HITL controls */}
+      {canOperate && isHitlState && (
+        <div
+          style={{
+            marginBottom: '24px',
+            background: 'var(--card)',
+            border: '1px solid var(--border)',
+            borderRadius: '12px',
+            padding: '16px 18px',
+          }}
+        >
+          <p
+            style={{
+              fontSize: '11px',
+              fontWeight: 500,
+              textTransform: 'uppercase',
+              letterSpacing: '0.06em',
+              color: 'var(--faint-fg)',
+              margin: '0 0 12px',
+            }}
+          >
+            HITL Controls
+          </p>
+          <div style={{ display: 'flex', gap: '8px' }}>
+            <button
+              onClick={() => takeoverMutation.mutate()}
+              disabled={takeoverMutation.isPending}
+              style={{
+                height: '34px',
+                padding: '0 14px',
+                borderRadius: '8px',
+                background: 'var(--primary)',
+                color: '#fff',
+                fontSize: '13px',
+                fontWeight: 500,
+                border: 'none',
+                cursor: takeoverMutation.isPending ? 'default' : 'pointer',
+                opacity: takeoverMutation.isPending ? 0.6 : 1,
+              }}
+            >
+              {takeoverMutation.isPending ? 'Taking over…' : 'Takeover Baton'}
+            </button>
+            <button
+              onClick={() => releaseMutation.mutate()}
+              disabled={releaseMutation.isPending}
+              style={{
+                height: '34px',
+                padding: '0 14px',
+                borderRadius: '8px',
+                border: '1px solid var(--border)',
+                background: 'var(--card)',
+                color: 'var(--fg)',
+                fontSize: '13px',
+                fontWeight: 500,
+                cursor: releaseMutation.isPending ? 'default' : 'pointer',
+                opacity: releaseMutation.isPending ? 0.6 : 1,
+              }}
+            >
+              {releaseMutation.isPending ? 'Releasing…' : 'Release Baton'}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Interventions */}
+      <h2
+        style={{
+          fontSize: '15px',
+          fontWeight: 600,
+          color: 'var(--fg)',
+          margin: '0 0 12px',
+        }}
+      >
+        Interventions
+      </h2>
+      <div
+        style={{
+          border: '1px solid var(--border)',
+          borderRadius: '12px',
+          overflow: 'hidden',
+          background: 'var(--card)',
+        }}
+      >
+        {interventionRows.length === 0 ? (
+          <div
+            style={{
+              padding: '32px',
+              textAlign: 'center',
+              color: 'var(--muted-fg)',
+              fontSize: '13px',
+            }}
+          >
+            No interventions recorded.
+          </div>
+        ) : (
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr style={{ background: 'var(--card-2)' }}>
+                {INTERVENTION_HEADERS.map((col) => (
+                  <th
+                    key={col}
+                    style={{
+                      padding: '11px 14px',
+                      textAlign: 'left',
+                      fontSize: '11px',
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.06em',
+                      fontWeight: 500,
+                      color: 'var(--faint-fg)',
+                      borderBottom: '1px solid var(--border)',
+                    }}
+                  >
+                    {col}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {interventionRows.map((item, i) => (
+                <tr
+                  key={item.id}
+                  style={{
+                    borderBottom:
+                      i < interventionRows.length - 1
+                        ? '1px solid var(--border)'
+                        : 'none',
+                  }}
+                >
+                  <td
+                    style={{
+                      padding: '11px 14px',
+                      fontSize: '13px',
+                      color: 'var(--fg)',
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.02em',
+                    }}
+                  >
+                    {item.type}
+                  </td>
+                  <td style={{ padding: '11px 14px' }}>
+                    <StatusBadge value={item.outcome} />
+                  </td>
+                  <td
+                    style={{
+                      padding: '11px 14px',
+                      fontFamily: 'ui-monospace, Menlo, monospace',
+                      fontSize: '12px',
+                      color: 'var(--muted-fg)',
+                    }}
+                  >
+                    {formatDate(item.created_at)}
+                  </td>
+                  <td
+                    style={{
+                      padding: '11px 14px',
+                      fontFamily: 'ui-monospace, Menlo, monospace',
+                      fontSize: '12px',
+                      color: 'var(--muted-fg)',
+                    }}
+                  >
+                    {item.completed_at ? formatDate(item.completed_at) : '—'}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin-ui/src/routes/session-viewer.tsx
+++ b/apps/admin-ui/src/routes/session-viewer.tsx
@@ -1,0 +1,5 @@
+import { ViewerPage } from '@/components/viewer/viewer-page';
+
+export function SessionViewerPage() {
+  return <ViewerPage />;
+}

--- a/apps/admin-ui/src/routes/sessions.tsx
+++ b/apps/admin-ui/src/routes/sessions.tsx
@@ -1,0 +1,268 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router';
+import { useQuery } from '@tanstack/react-query';
+import { sessionsApi } from '@/api/sessions';
+import { StatusBadge } from '@/components/shared/status-badge';
+import { useAuthStore } from '@/stores/auth';
+import { useHasRole } from '@/hooks/use-role';
+
+const PAGE_SIZE = 20;
+
+const TABLE_HEADERS = ['Application', 'State', 'Health', 'Created'] as const;
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+}
+
+export function SessionsPage() {
+  const [page, setPage] = useState(0);
+  const [filterMode, setFilterMode] = useState<'all' | 'mine' | null>(null);
+  const navigate = useNavigate();
+  const isAdmin = useHasRole('Admin');
+  const user = useAuthStore((s) => s.user);
+  const effectiveMode = filterMode ?? (isAdmin ? 'all' : 'mine');
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['sessions', { limit: PAGE_SIZE, offset: page * PAGE_SIZE }],
+    queryFn: () => sessionsApi.list({ limit: PAGE_SIZE, offset: page * PAGE_SIZE }),
+    refetchInterval: 10_000,
+  });
+
+  const allSessions = data?.data ?? [];
+  const sessions =
+    effectiveMode === 'mine'
+      ? allSessions.filter((s) => s.owner_user_id === user?.owner_user_id)
+      : allSessions;
+  const total = data?.total ?? 0;
+  const from = total === 0 ? 0 : page * PAGE_SIZE + 1;
+  const to = Math.min((page + 1) * PAGE_SIZE, total);
+  const hasPrev = page > 0;
+  const hasNext = (page + 1) * PAGE_SIZE < total;
+
+  return (
+    <div>
+      {/* Page header */}
+      <div style={{ marginBottom: '20px', display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between' }}>
+        <div>
+          <h1
+            style={{
+              fontSize: '24px',
+              fontWeight: 800,
+              letterSpacing: '-0.02em',
+              color: 'var(--fg)',
+              margin: 0,
+            }}
+          >
+            Sessions
+          </h1>
+          <p style={{ fontSize: '12.5px', color: 'var(--muted-fg)', marginTop: '4px', marginBottom: 0 }}>
+            All active and recent sessions · refreshes every 10s
+          </p>
+        </div>
+
+        {/* Segmented filter control */}
+        <div
+          style={{
+            display: 'flex',
+            height: '28px',
+            background: 'var(--card)',
+            border: '1px solid var(--border)',
+            borderRadius: '8px',
+            overflow: 'hidden',
+            flexShrink: 0,
+          }}
+        >
+          {(['all', 'mine'] as const).map((mode, idx) => {
+            const active = effectiveMode === mode;
+            return (
+              <button
+                key={mode}
+                onClick={() => setFilterMode(mode)}
+                style={{
+                  height: '100%',
+                  padding: '0 12px',
+                  fontSize: '12px',
+                  fontWeight: active ? 600 : 400,
+                  border: 'none',
+                  borderLeft: idx > 0 ? '1px solid var(--border)' : 'none',
+                  background: active ? 'var(--primary)' : 'transparent',
+                  color: active ? 'var(--primary-fg)' : 'var(--muted-fg)',
+                  cursor: 'pointer',
+                  transition: 'background 100ms, color 100ms',
+                }}
+              >
+                {mode === 'all' ? 'All Sessions' : 'My Sessions'}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Table card */}
+      <div
+        style={{
+          border: '1px solid var(--border)',
+          borderRadius: '12px',
+          overflow: 'hidden',
+          background: 'var(--card)',
+        }}
+      >
+        {isLoading ? (
+          <div
+            style={{
+              padding: '48px',
+              textAlign: 'center',
+              color: 'var(--muted-fg)',
+              fontSize: '13px',
+            }}
+          >
+            Loading…
+          </div>
+        ) : sessions.length === 0 ? (
+          <div
+            style={{
+              padding: '48px',
+              textAlign: 'center',
+              color: 'var(--muted-fg)',
+              fontSize: '13px',
+            }}
+          >
+            No sessions found.
+          </div>
+        ) : (
+          <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+            <thead>
+              <tr style={{ background: 'var(--card-2)' }}>
+                {TABLE_HEADERS.map((col) => (
+                  <th
+                    key={col}
+                    style={{
+                      padding: '11px 14px',
+                      textAlign: 'left',
+                      fontSize: '11px',
+                      textTransform: 'uppercase',
+                      letterSpacing: '0.06em',
+                      fontWeight: 500,
+                      color: 'var(--faint-fg)',
+                      borderBottom: '1px solid var(--border)',
+                    }}
+                  >
+                    {col}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {sessions.map((s, i) => (
+                <tr
+                  key={s.id}
+                  onClick={() => navigate(`/sessions/${s.id}`)}
+                  style={{
+                    borderBottom: i < sessions.length - 1 ? '1px solid var(--border)' : 'none',
+                    cursor: 'pointer',
+                    transition: 'background 80ms',
+                  }}
+                  onMouseEnter={(e) => {
+                    (e.currentTarget as HTMLTableRowElement).style.background =
+                      'color-mix(in srgb, var(--fg) 4%, transparent)';
+                  }}
+                  onMouseLeave={(e) => {
+                    (e.currentTarget as HTMLTableRowElement).style.background = 'transparent';
+                  }}
+                >
+                  {/* Application */}
+                  <td style={{ padding: '11px 14px', fontSize: '13px', color: 'var(--fg)' }}>
+                    <span style={{ display: 'block' }}>
+                      {s.application?.name ?? s.app_id}
+                    </span>
+                    <span
+                      style={{
+                        display: 'block',
+                        fontFamily: 'ui-monospace, Menlo, monospace',
+                        fontSize: '11px',
+                        color: 'var(--faint-fg)',
+                        marginTop: '2px',
+                      }}
+                    >
+                      {s.app_id}
+                    </span>
+                  </td>
+                  {/* State */}
+                  <td style={{ padding: '11px 14px' }}>
+                    <StatusBadge value={s.state} />
+                  </td>
+                  {/* Health */}
+                  <td style={{ padding: '11px 14px' }}>
+                    <StatusBadge value={s.health_result_type} />
+                  </td>
+                  {/* Created */}
+                  <td
+                    style={{
+                      padding: '11px 14px',
+                      fontFamily: 'ui-monospace, Menlo, monospace',
+                      fontSize: '12px',
+                      color: 'var(--muted-fg)',
+                    }}
+                  >
+                    {formatDate(s.created_at)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+
+        {/* Pagination footer */}
+        <div
+          style={{
+            borderTop: sessions.length > 0 || isLoading ? '1px solid var(--border)' : 'none',
+            padding: '10px 14px',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          <span style={{ fontSize: '12px', color: 'var(--muted-fg)' }}>
+            {total === 0 ? 'No results' : `Showing ${from}–${to} of ${total}`}
+          </span>
+          <div style={{ display: 'flex', gap: '6px' }}>
+            <button
+              onClick={() => setPage((p) => Math.max(0, p - 1))}
+              disabled={!hasPrev}
+              style={{
+                height: '28px',
+                padding: '0 10px',
+                borderRadius: '7px',
+                border: '1px solid var(--border)',
+                background: hasPrev ? 'var(--card)' : 'var(--card-2)',
+                color: hasPrev ? 'var(--fg)' : 'var(--faint-fg)',
+                fontSize: '12px',
+                cursor: hasPrev ? 'pointer' : 'default',
+                opacity: hasPrev ? 1 : 0.5,
+              }}
+            >
+              Previous
+            </button>
+            <button
+              onClick={() => setPage((p) => p + 1)}
+              disabled={!hasNext}
+              style={{
+                height: '28px',
+                padding: '0 10px',
+                borderRadius: '7px',
+                border: '1px solid var(--border)',
+                background: hasNext ? 'var(--card)' : 'var(--card-2)',
+                color: hasNext ? 'var(--fg)' : 'var(--faint-fg)',
+                fontSize: '12px',
+                cursor: hasNext ? 'pointer' : 'default',
+                opacity: hasNext ? 1 : 0.5,
+              }}
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin-ui/src/routes/shell-layout.tsx
+++ b/apps/admin-ui/src/routes/shell-layout.tsx
@@ -1,0 +1,61 @@
+import { useEffect } from 'react';
+import { Outlet, useNavigate, useLocation } from 'react-router';
+import { useAuthStore } from '@/stores/auth';
+import { useUiStore } from '@/stores/ui';
+import { Sidebar } from '@/components/layout/sidebar';
+import { Topbar } from '@/components/layout/topbar';
+import { ErrorBoundary } from '@/components/shared/error-boundary';
+
+export function ShellLayout() {
+  const token = useAuthStore((s) => s.token);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const collapsed = useUiStore((s) => s.sidebarCollapsed);
+
+  useEffect(() => {
+    if (!token) navigate('/login', { replace: true });
+  }, [token, navigate]);
+
+  if (!token) return null;
+
+  const sidebarWidth = collapsed ? 64 : 240;
+  const isViewerPage = location.pathname.includes('/viewer');
+
+  return (
+    <div style={{ display: 'flex', minHeight: '100vh' }}>
+      <Sidebar />
+
+      <div
+        style={{
+          marginLeft: sidebarWidth,
+          flex: 1,
+          display: 'flex',
+          flexDirection: 'column',
+          height: '100vh',
+          overflow: 'hidden',
+          transition: 'margin-left 200ms ease',
+        }}
+      >
+        <Topbar />
+
+        <main style={{ flex: 1, overflow: 'auto', position: 'relative' }}>
+          <ErrorBoundary>
+            {isViewerPage ? (
+              <Outlet />
+            ) : (
+              <div
+                style={{
+                  maxWidth: 1200,
+                  margin: '0 auto',
+                  padding: '26px 30px 60px',
+                }}
+              >
+                <Outlet />
+              </div>
+            )}
+          </ErrorBoundary>
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin-ui/src/routes/template-detail.tsx
+++ b/apps/admin-ui/src/routes/template-detail.tsx
@@ -1,0 +1,451 @@
+import { useState } from 'react';
+import { useParams, useNavigate, Link } from 'react-router';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { templatesApi } from '@/api/templates';
+import { ConfirmDialog } from '@/components/shared/confirm-dialog';
+import { useHasRole } from '@/hooks/use-role';
+import { DslStepBuilder } from '@/components/templates/dsl-step-builder';
+
+const LABEL_STYLE: React.CSSProperties = {
+  fontSize: 11,
+  textTransform: 'uppercase',
+  letterSpacing: '0.06em',
+  fontWeight: 500,
+  color: 'var(--faint-fg)',
+  marginBottom: 4,
+};
+
+const FIELD_MONO: React.CSSProperties = {
+  fontFamily: 'ui-monospace, Menlo, monospace',
+  fontSize: 12,
+  color: 'var(--fg)',
+  wordBreak: 'break-all',
+};
+
+const FIELD_TEXT: React.CSSProperties = { fontSize: 13, color: 'var(--fg)' };
+
+const PRE_STYLE: React.CSSProperties = {
+  fontFamily: 'ui-monospace, Menlo, monospace',
+  fontSize: 12,
+  overflowX: 'auto',
+  background: 'var(--card-2)',
+  padding: '12px 14px',
+  borderRadius: 8,
+  margin: 0,
+  color: 'var(--fg)',
+  whiteSpace: 'pre-wrap',
+  wordBreak: 'break-all',
+};
+
+const CARD: React.CSSProperties = {
+  background: 'var(--card)',
+  border: '1px solid var(--border)',
+  borderRadius: 12,
+  padding: '20px 24px',
+};
+
+const FORM_LABEL: React.CSSProperties = {
+  fontSize: 12,
+  fontWeight: 500,
+  color: 'var(--muted-fg)',
+  display: 'block',
+  marginBottom: 5,
+};
+
+const FORM_INPUT: React.CSSProperties = {
+  width: '100%',
+  height: 36,
+  padding: '0 11px',
+  borderRadius: 8,
+  border: '1px solid var(--border-2)',
+  background: 'var(--bg)',
+  color: 'var(--fg)',
+  fontSize: 13,
+  outline: 'none',
+  boxSizing: 'border-box',
+};
+
+const FORM_TEXTAREA: React.CSSProperties = {
+  width: '100%',
+  minHeight: 80,
+  padding: '8px 11px',
+  borderRadius: 8,
+  border: '1px solid var(--border-2)',
+  background: 'var(--bg)',
+  color: 'var(--fg)',
+  fontSize: 13,
+  outline: 'none',
+  boxSizing: 'border-box',
+  resize: 'vertical',
+};
+
+const ERR: React.CSSProperties = { fontSize: 11, color: 'var(--error)', marginTop: 4 };
+
+function tryParseJson(raw: string): unknown {
+  if (!raw.trim()) return null;
+  try { return JSON.parse(raw); } catch { return undefined; }
+}
+
+export function TemplateDetailPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const qc = useQueryClient();
+  const canWrite = useHasRole('Admin', 'Editor');
+
+  const [showDelete, setShowDelete] = useState(false);
+  const [showEdit, setShowEdit] = useState(false);
+
+  // Edit state
+  const [editName, setEditName] = useState('');
+  const [editProfilePattern, setEditProfilePattern] = useState('');
+  const [editCredentialRef, setEditCredentialRef] = useState('');
+  const [editIdleShutdown, setEditIdleShutdown] = useState('');
+  const [editExecuteEnabled, setEditExecuteEnabled] = useState(false);
+  const [editExtraEgress, setEditExtraEgress] = useState('');
+  const [editLoginConfigSteps, setEditLoginConfigSteps] = useState<unknown[]>([]);
+  const [editLoginConfigExtra, setEditLoginConfigExtra] = useState<Record<string, unknown>>({});
+  const [editKeepaliveConfig, setEditKeepaliveConfig] = useState('');
+  const [editExportPolicy, setEditExportPolicy] = useState('');
+  const [editBrowserPolicy, setEditBrowserPolicy] = useState('');
+  const [editNotificationConfig, setEditNotificationConfig] = useState('');
+  const [editErrors, setEditErrors] = useState<Record<string, string>>({});
+
+  const { data: tpl, isLoading } = useQuery({
+    queryKey: ['template', id],
+    queryFn: () => templatesApi.get(id!),
+    enabled: !!id,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: () => templatesApi.remove(id!),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['templates'] });
+      navigate('/templates');
+    },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: (payload: Parameters<typeof templatesApi.update>[1]) =>
+      templatesApi.update(id!, payload),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['template', id] });
+      qc.invalidateQueries({ queryKey: ['templates'] });
+      setShowEdit(false);
+    },
+  });
+
+  if (isLoading || !tpl) {
+    return <p style={{ color: 'var(--muted-fg)', fontSize: 13 }}>Loading…</p>;
+  }
+
+  function openEdit() {
+    setEditName(tpl!.name);
+    setEditProfilePattern(tpl!.profile_name_pattern ?? '');
+    setEditCredentialRef(tpl!.credential_ref_default ?? '');
+    setEditIdleShutdown(tpl!.idle_shutdown_seconds != null ? String(tpl!.idle_shutdown_seconds) : '');
+    setEditExecuteEnabled(tpl!.execute_enabled);
+    setEditExtraEgress(tpl!.extra_egress_allowlist?.join('\n') ?? '');
+    if (tpl!.login_config && typeof tpl!.login_config === 'object') {
+      const { steps, ...rest } = tpl!.login_config as Record<string, unknown>;
+      setEditLoginConfigSteps(Array.isArray(steps) ? steps : []);
+      setEditLoginConfigExtra(rest);
+    } else {
+      setEditLoginConfigSteps([]);
+      setEditLoginConfigExtra({});
+    }
+    setEditKeepaliveConfig(tpl!.keepalive_config ? JSON.stringify(tpl!.keepalive_config, null, 2) : '');
+    setEditExportPolicy(tpl!.export_policy ? JSON.stringify(tpl!.export_policy, null, 2) : '');
+    setEditBrowserPolicy(tpl!.browser_policy ? JSON.stringify(tpl!.browser_policy, null, 2) : '');
+    setEditNotificationConfig(tpl!.notification_config ? JSON.stringify(tpl!.notification_config, null, 2) : '');
+    setEditErrors({});
+    setShowEdit(true);
+  }
+
+  function handleEditSubmit() {
+    const errors: Record<string, string> = {};
+    if (!editName.trim()) errors.name = 'Name is required.';
+    if (!editProfilePattern.trim()) errors.profile_name_pattern = 'Profile name pattern is required.';
+    if (editIdleShutdown && (isNaN(Number(editIdleShutdown)) || Number(editIdleShutdown) < 60)) {
+      errors.idle_shutdown_seconds = 'Must be a number ≥ 60.';
+    }
+
+    const jsonFields: [string, string][] = [
+      ['keepalive_config', editKeepaliveConfig],
+      ['export_policy', editExportPolicy],
+      ['browser_policy', editBrowserPolicy],
+      ['notification_config', editNotificationConfig],
+    ];
+    for (const [key, raw] of jsonFields) {
+      if (raw.trim() && tryParseJson(raw) === undefined) errors[key] = 'Invalid JSON.';
+    }
+
+    if (Object.keys(errors).length) { setEditErrors(errors); return; }
+
+    updateMutation.mutate({
+      name: editName.trim(),
+      profile_name_pattern: editProfilePattern.trim() || null,
+      credential_ref_default: editCredentialRef.trim() || null,
+      idle_shutdown_seconds: editIdleShutdown ? Number(editIdleShutdown) : null,
+      execute_enabled: editExecuteEnabled,
+      extra_egress_allowlist: editExtraEgress.split('\n').map((s) => s.trim()).filter(Boolean),
+      login_config: { ...editLoginConfigExtra, steps: editLoginConfigSteps },
+      keepalive_config: tryParseJson(editKeepaliveConfig),
+      export_policy: tryParseJson(editExportPolicy),
+      browser_policy: tryParseJson(editBrowserPolicy),
+      notification_config: tryParseJson(editNotificationConfig),
+    });
+  }
+
+  const configSections = [
+    { label: 'Login Config', value: tpl.login_config },
+    { label: 'Keepalive Config', value: tpl.keepalive_config },
+    { label: 'Export Policy', value: tpl.export_policy },
+    { label: 'Browser Policy', value: tpl.browser_policy },
+    { label: 'Notification Config', value: tpl.notification_config },
+  ];
+
+  return (
+    <div>
+      <ConfirmDialog
+        open={showDelete}
+        title="Delete Template"
+        description="This will permanently delete the template. Applications using it will not be affected."
+        confirmLabel="Delete"
+        destructive
+        onConfirm={async () => { await deleteMutation.mutateAsync(); setShowDelete(false); }}
+        onCancel={() => setShowDelete(false)}
+      />
+
+      {/* Edit dialog */}
+      {showEdit && (
+        <div
+          style={{
+            position: 'fixed', inset: 0, zIndex: 50,
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            background: 'rgba(0,0,0,0.5)',
+          }}
+          onClick={() => setShowEdit(false)}
+        >
+          <div
+            style={{
+              width: '100%', maxWidth: 900, maxHeight: '90vh', overflowY: 'auto',
+              background: 'var(--card)', borderRadius: 12, padding: '24px',
+            }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 style={{ fontSize: 16, fontWeight: 700, color: 'var(--fg)', margin: '0 0 20px' }}>
+              Edit Template
+            </h3>
+
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+              <div>
+                <label style={FORM_LABEL}>Name <span style={{ color: 'var(--error)' }}>*</span></label>
+                <input value={editName} onChange={(e) => setEditName(e.target.value)} style={FORM_INPUT} />
+                {editErrors.name && <p style={ERR}>{editErrors.name}</p>}
+              </div>
+
+              <div>
+                <label style={FORM_LABEL}>Profile Name Pattern <span style={{ color: 'var(--error)' }}>*</span></label>
+                <input
+                  value={editProfilePattern}
+                  onChange={(e) => setEditProfilePattern(e.target.value)}
+                  placeholder="my-app-*"
+                  style={{ ...FORM_INPUT, fontFamily: 'ui-monospace, Menlo, monospace' }}
+                />
+                {editErrors.profile_name_pattern && <p style={ERR}>{editErrors.profile_name_pattern}</p>}
+              </div>
+
+              <div>
+                <label style={FORM_LABEL}>Credential Ref Default</label>
+                <input
+                  value={editCredentialRef}
+                  onChange={(e) => setEditCredentialRef(e.target.value)}
+                  placeholder="k8s:secret/my-secret"
+                  style={{ ...FORM_INPUT, fontFamily: 'ui-monospace, Menlo, monospace' }}
+                />
+              </div>
+
+              <div>
+                <label style={FORM_LABEL}>Idle Shutdown Seconds</label>
+                <input
+                  type="number" min={60} step={1}
+                  value={editIdleShutdown}
+                  onChange={(e) => setEditIdleShutdown(e.target.value)}
+                  placeholder="3600"
+                  style={{ ...FORM_INPUT, width: 120 }}
+                />
+                {editErrors.idle_shutdown_seconds && <p style={ERR}>{editErrors.idle_shutdown_seconds}</p>}
+              </div>
+
+              <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                <input
+                  id="edit_execute_enabled"
+                  type="checkbox"
+                  checked={editExecuteEnabled}
+                  onChange={(e) => setEditExecuteEnabled(e.target.checked)}
+                  style={{ width: 16, height: 16, accentColor: 'var(--primary)', cursor: 'pointer' }}
+                />
+                <label htmlFor="edit_execute_enabled" style={{ fontSize: 13, color: 'var(--fg)', cursor: 'pointer' }}>
+                  Execute enabled
+                </label>
+              </div>
+
+              <div>
+                <label style={FORM_LABEL}>Extra Egress Allowlist</label>
+                <textarea
+                  value={editExtraEgress}
+                  onChange={(e) => setEditExtraEgress(e.target.value)}
+                  placeholder={'api.example.com\ncdn.example.com'}
+                  style={{ ...FORM_TEXTAREA, fontFamily: 'ui-monospace, Menlo, monospace', minHeight: 60 }}
+                />
+              </div>
+
+              <div>
+                <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--muted-fg)', marginBottom: 5 }}>
+                  Login Config <span style={{ color: 'var(--error)' }}>*</span>
+                </div>
+                <DslStepBuilder
+                  value={editLoginConfigSteps}
+                  onChange={setEditLoginConfigSteps}
+                />
+              </div>
+
+              {([
+                ['keepalive_config', 'Keepalive Config', editKeepaliveConfig, setEditKeepaliveConfig],
+                ['export_policy', 'Export Policy', editExportPolicy, setEditExportPolicy],
+                ['browser_policy', 'Browser Policy', editBrowserPolicy, setEditBrowserPolicy],
+                ['notification_config', 'Notification Config', editNotificationConfig, setEditNotificationConfig],
+              ] as [string, string, string, React.Dispatch<React.SetStateAction<string>>][]).map(
+                ([key, label, value, setter]) => (
+                  <div key={key}>
+                    <label style={FORM_LABEL}>{label}</label>
+                    <textarea
+                      value={value}
+                      onChange={(e) => setter(e.target.value)}
+                      rows={4}
+                      style={{ ...FORM_TEXTAREA, fontFamily: 'ui-monospace, Menlo, monospace' }}
+                    />
+                    {editErrors[key] && <p style={ERR}>{editErrors[key]}</p>}
+                  </div>
+                ),
+              )}
+            </div>
+
+            {updateMutation.isError && (
+              <p style={{ fontSize: 12, color: 'var(--error)', marginTop: 12 }}>
+                Failed to update template. Check your inputs and try again.
+              </p>
+            )}
+
+            <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 10, marginTop: 24 }}>
+              <button
+                onClick={() => setShowEdit(false)}
+                style={{
+                  height: 34, padding: '0 14px', borderRadius: 8,
+                  border: '1px solid var(--border-2)', background: 'var(--card)',
+                  color: 'var(--fg)', fontSize: 12.5, cursor: 'pointer',
+                }}
+              >
+                Cancel
+              </button>
+              <button
+                onClick={handleEditSubmit}
+                disabled={updateMutation.isPending}
+                style={{
+                  height: 34, padding: '0 14px', borderRadius: 8,
+                  background: 'var(--primary)', color: 'var(--primary-fg)',
+                  fontWeight: 600, fontSize: 12.5, border: 'none',
+                  cursor: updateMutation.isPending ? 'default' : 'pointer',
+                  opacity: updateMutation.isPending ? 0.6 : 1,
+                }}
+              >
+                {updateMutation.isPending ? 'Saving…' : 'Save'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Breadcrumb + header */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 8 }}>
+        <Link to="/templates" style={{ fontSize: 12.5, color: 'var(--muted-fg)', textDecoration: 'none' }}>
+          Templates
+        </Link>
+        <span style={{ color: 'var(--faint-fg)', fontSize: 12.5 }}>/</span>
+        <span style={{ fontSize: 12.5, color: 'var(--fg)' }}>{tpl.name}</span>
+      </div>
+
+      <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', marginBottom: 24 }}>
+        <div>
+          <h1 style={{ fontSize: 22, fontWeight: 800, letterSpacing: '-0.02em', margin: 0, color: 'var(--fg)' }}>
+            {tpl.name}
+          </h1>
+          <p style={{
+            fontFamily: 'ui-monospace, Menlo, monospace',
+            fontSize: 12, color: 'var(--faint-fg)', marginTop: 4, marginBottom: 0,
+          }}>
+            {tpl.id}
+          </p>
+        </div>
+        <div style={{ display: 'flex', gap: 8 }}>
+          {canWrite && (
+            <button
+              onClick={openEdit}
+              style={{
+                height: 34, padding: '0 14px', borderRadius: 8,
+                border: '1px solid var(--border-2)', background: 'var(--card)',
+                color: 'var(--fg)', fontSize: 12.5, cursor: 'pointer',
+              }}
+            >
+              Edit
+            </button>
+          )}
+          {canWrite && (
+            <button
+              onClick={() => setShowDelete(true)}
+              style={{
+                height: 34, padding: '0 14px', borderRadius: 8,
+                border: `1px solid color-mix(in srgb, var(--error) 40%, transparent)`,
+                background: 'var(--card)',
+                color: 'var(--error)', fontSize: 12.5, cursor: 'pointer',
+              }}
+            >
+              Delete
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Details card */}
+      <div style={{ ...CARD, marginBottom: 16 }}>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '20px 32px' }}>
+          {[
+            { label: 'Name', value: tpl.name, mono: false },
+            { label: 'Profile Name Pattern', value: tpl.profile_name_pattern ?? '—', mono: true },
+            { label: 'Credential Ref Default', value: tpl.credential_ref_default ?? '—', mono: true },
+            { label: 'Idle Shutdown', value: tpl.idle_shutdown_seconds != null ? `${tpl.idle_shutdown_seconds}s` : '—', mono: false },
+            { label: 'Execute Enabled', value: tpl.execute_enabled ? 'Yes' : 'No', mono: false },
+            { label: 'Tenant ID', value: tpl.tenant_id ?? '—', mono: true },
+          ].map(({ label, value, mono }) => (
+            <div key={label}>
+              <div style={LABEL_STYLE}>{label}</div>
+              <div style={mono ? FIELD_MONO : FIELD_TEXT}>{value}</div>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Config sections */}
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+        {configSections.map(({ label, value }) => (
+          <div key={label} style={CARD}>
+            <div style={{ fontSize: 12, fontWeight: 600, color: 'var(--fg)', marginBottom: 12 }}>{label}</div>
+            <pre style={PRE_STYLE}>
+              {value ? JSON.stringify(value, null, 2) : 'null'}
+            </pre>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin-ui/src/routes/template-new.tsx
+++ b/apps/admin-ui/src/routes/template-new.tsx
@@ -1,0 +1,376 @@
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { templatesApi } from '@/api/templates';
+import { DslStepBuilder } from '@/components/templates/dsl-step-builder';
+
+const LABEL: React.CSSProperties = {
+  fontSize: 12,
+  fontWeight: 500,
+  color: 'var(--muted-fg)',
+  display: 'block',
+  marginBottom: 5,
+};
+
+const INPUT: React.CSSProperties = {
+  width: '100%',
+  height: 36,
+  padding: '0 11px',
+  borderRadius: 8,
+  border: '1px solid var(--border-2)',
+  background: 'var(--bg)',
+  color: 'var(--fg)',
+  fontSize: 13,
+  outline: 'none',
+  boxSizing: 'border-box',
+};
+
+const TEXTAREA: React.CSSProperties = {
+  width: '100%',
+  minHeight: 80,
+  padding: '8px 11px',
+  borderRadius: 8,
+  border: '1px solid var(--border-2)',
+  background: 'var(--bg)',
+  color: 'var(--fg)',
+  fontSize: 13,
+  outline: 'none',
+  boxSizing: 'border-box',
+  resize: 'vertical',
+};
+
+const TEXTAREA_MONO: React.CSSProperties = {
+  ...TEXTAREA,
+  fontFamily: 'ui-monospace, Menlo, monospace',
+};
+
+const REQUIRED_MARK = <span style={{ color: 'var(--error)' }}> *</span>;
+const HELPER: React.CSSProperties = { fontSize: 11, color: 'var(--muted-fg)', marginTop: 4 };
+const ERR: React.CSSProperties = { fontSize: 11, color: 'var(--error)', marginTop: 4 };
+
+const DEFAULT_KEEPALIVE_CONFIG = JSON.stringify({ health_checks: [] }, null, 2);
+const DEFAULT_EXPORT_POLICY = JSON.stringify({ artifact_types: ['cookies'] }, null, 2);
+
+function tryParseJson(raw: string): unknown {
+  if (!raw.trim()) return null;
+  try { return JSON.parse(raw); } catch { return undefined; }
+}
+
+export function TemplateNewPage() {
+  const navigate = useNavigate();
+  const qc = useQueryClient();
+
+  const [name, setName] = useState('');
+  const [profileNamePattern, setProfileNamePattern] = useState('');
+  const [credentialRefDefault, setCredentialRefDefault] = useState('');
+  const [idleShutdownSeconds, setIdleShutdownSeconds] = useState('');
+  const [executeEnabled, setExecuteEnabled] = useState(false);
+  const [tenantId, setTenantId] = useState('');
+  const [extraEgressRaw, setExtraEgressRaw] = useState('');
+  const [loginConfigSteps, setLoginConfigSteps] = useState<unknown[]>([]);
+  const [loginConfigExtra] = useState<Record<string, unknown>>({});
+  const [keepaliveConfigRaw, setKeepaliveConfigRaw] = useState(DEFAULT_KEEPALIVE_CONFIG);
+  const [exportPolicyRaw, setExportPolicyRaw] = useState(DEFAULT_EXPORT_POLICY);
+  const [browserPolicyRaw, setBrowserPolicyRaw] = useState('');
+  const [notificationConfigRaw, setNotificationConfigRaw] = useState('');
+  const [showBrowserPolicy, setShowBrowserPolicy] = useState(false);
+  const [showNotificationConfig, setShowNotificationConfig] = useState(false);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+
+  const createMutation = useMutation({
+    mutationFn: templatesApi.create,
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['templates'] });
+      navigate('/templates');
+    },
+  });
+
+  function validate(): boolean {
+    const next: Record<string, string> = {};
+
+    if (!name.trim()) next.name = 'Name is required.';
+    if (!profileNamePattern.trim()) next.profile_name_pattern = 'Profile name pattern is required.';
+
+    if (idleShutdownSeconds !== '') {
+      const n = Number(idleShutdownSeconds);
+      if (isNaN(n) || n < 60) next.idle_shutdown_seconds = 'Must be a number ≥ 60.';
+    }
+
+    const requiredJsonFields: [string, string][] = [
+      ['keepalive_config', keepaliveConfigRaw],
+      ['export_policy', exportPolicyRaw],
+    ];
+    for (const [key, raw] of requiredJsonFields) {
+      if (!raw.trim()) {
+        next[key] = 'This field is required.';
+      } else if (tryParseJson(raw) === undefined) {
+        next[key] = 'Invalid JSON.';
+      }
+    }
+
+    const optionalJsonFields: [string, string][] = [
+      ['browser_policy', browserPolicyRaw],
+      ['notification_config', notificationConfigRaw],
+    ];
+    for (const [key, raw] of optionalJsonFields) {
+      if (raw.trim() && tryParseJson(raw) === undefined) next[key] = 'Invalid JSON.';
+    }
+
+    setErrors(next);
+    return Object.keys(next).length === 0;
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!validate()) return;
+
+    const extraEgress = extraEgressRaw.split('\n').map((s) => s.trim()).filter(Boolean);
+
+    createMutation.mutate({
+      name: name.trim(),
+      profile_name_pattern: profileNamePattern.trim(),
+      credential_ref_default: credentialRefDefault.trim() || null,
+      idle_shutdown_seconds: idleShutdownSeconds !== '' ? Number(idleShutdownSeconds) : null,
+      execute_enabled: executeEnabled,
+      ...(tenantId.trim() ? { tenant_id: tenantId.trim() } : {}),
+      ...(extraEgress.length > 0 ? { extra_egress_allowlist: extraEgress } : {}),
+      login_config: { ...loginConfigExtra, steps: loginConfigSteps },
+      keepalive_config: tryParseJson(keepaliveConfigRaw) ?? { health_checks: [] },
+      export_policy: tryParseJson(exportPolicyRaw) ?? { artifact_types: ['cookies'] },
+      ...(browserPolicyRaw.trim() ? { browser_policy: tryParseJson(browserPolicyRaw) } : {}),
+      ...(notificationConfigRaw.trim() ? { notification_config: tryParseJson(notificationConfigRaw) } : {}),
+    });
+  }
+
+  return (
+    <div style={{ maxWidth: 600 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 8 }}>
+        <Link to="/templates" style={{ fontSize: 12.5, color: 'var(--muted-fg)', textDecoration: 'none' }}>
+          Templates
+        </Link>
+        <span style={{ color: 'var(--faint-fg)', fontSize: 12.5 }}>/</span>
+        <span style={{ fontSize: 12.5, color: 'var(--fg)' }}>New</span>
+      </div>
+
+      <h1 style={{ fontSize: 24, fontWeight: 800, letterSpacing: '-0.02em', margin: '0 0 24px', color: 'var(--fg)' }}>
+        New Template
+      </h1>
+
+      <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
+
+        {/* Name */}
+        <div>
+          <label style={LABEL}>Name{REQUIRED_MARK}</label>
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="my-template"
+            style={INPUT}
+          />
+          {errors.name && <p style={ERR}>{errors.name}</p>}
+        </div>
+
+        {/* Profile Name Pattern */}
+        <div>
+          <label style={LABEL}>Profile Name Pattern{REQUIRED_MARK}</label>
+          <input
+            value={profileNamePattern}
+            onChange={(e) => setProfileNamePattern(e.target.value)}
+            placeholder="my-app-*"
+            style={{ ...INPUT, fontFamily: 'ui-monospace, Menlo, monospace' }}
+          />
+          <p style={HELPER}>Pattern matched against profile names when resolving templates.</p>
+          {errors.profile_name_pattern && <p style={ERR}>{errors.profile_name_pattern}</p>}
+        </div>
+
+        {/* Login Config */}
+        <div>
+          <div style={{ fontSize: 12, fontWeight: 500, color: 'var(--muted-fg)', marginBottom: 5 }}>
+            Login Config <span style={{ color: 'var(--error)' }}>*</span>
+          </div>
+          <DslStepBuilder
+            value={loginConfigSteps}
+            onChange={setLoginConfigSteps}
+          />
+        </div>
+
+        {/* Keepalive Config */}
+        <div>
+          <label style={LABEL}>Keepalive Config{REQUIRED_MARK}</label>
+          <textarea
+            value={keepaliveConfigRaw}
+            onChange={(e) => setKeepaliveConfigRaw(e.target.value)}
+            rows={5}
+            style={TEXTAREA_MONO}
+          />
+          {errors.keepalive_config && <p style={ERR}>{errors.keepalive_config}</p>}
+        </div>
+
+        {/* Export Policy */}
+        <div>
+          <label style={LABEL}>Export Policy{REQUIRED_MARK}</label>
+          <textarea
+            value={exportPolicyRaw}
+            onChange={(e) => setExportPolicyRaw(e.target.value)}
+            rows={4}
+            style={TEXTAREA_MONO}
+          />
+          {errors.export_policy && <p style={ERR}>{errors.export_policy}</p>}
+        </div>
+
+        {/* Credential Ref Default */}
+        <div>
+          <label style={LABEL}>Credential Ref Default</label>
+          <input
+            value={credentialRefDefault}
+            onChange={(e) => setCredentialRefDefault(e.target.value)}
+            placeholder="k8s:secret/my-secret"
+            style={{ ...INPUT, fontFamily: 'ui-monospace, Menlo, monospace' }}
+          />
+        </div>
+
+        {/* Idle Shutdown Seconds */}
+        <div>
+          <label style={LABEL}>Idle Shutdown Seconds</label>
+          <input
+            type="number"
+            min={60}
+            step={1}
+            value={idleShutdownSeconds}
+            onChange={(e) => setIdleShutdownSeconds(e.target.value)}
+            placeholder="3600"
+            style={{ ...INPUT, width: 120 }}
+          />
+          <p style={HELPER}>Minimum 60. Leave blank to disable idle shutdown.</p>
+          {errors.idle_shutdown_seconds && <p style={ERR}>{errors.idle_shutdown_seconds}</p>}
+        </div>
+
+        {/* Execute Enabled */}
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+          <input
+            id="execute_enabled"
+            type="checkbox"
+            checked={executeEnabled}
+            onChange={(e) => setExecuteEnabled(e.target.checked)}
+            style={{ width: 16, height: 16, accentColor: 'var(--primary)', cursor: 'pointer' }}
+          />
+          <label htmlFor="execute_enabled" style={{ fontSize: 13, color: 'var(--fg)', cursor: 'pointer' }}>
+            Execute enabled
+          </label>
+        </div>
+
+        {/* Extra Egress Allowlist */}
+        <div>
+          <label style={LABEL}>Extra Egress Allowlist</label>
+          <textarea
+            value={extraEgressRaw}
+            onChange={(e) => setExtraEgressRaw(e.target.value)}
+            placeholder={'api.example.com\ncdn.example.com'}
+            style={{ ...TEXTAREA_MONO, minHeight: 60 }}
+          />
+          <p style={HELPER}>One hostname per line.</p>
+        </div>
+
+        {/* Tenant ID */}
+        <div>
+          <label style={LABEL}>Tenant ID</label>
+          <input
+            value={tenantId}
+            onChange={(e) => setTenantId(e.target.value)}
+            placeholder="optional"
+            style={INPUT}
+          />
+        </div>
+
+        {/* Browser Policy (collapsible) */}
+        <div>
+          <button
+            type="button"
+            onClick={() => setShowBrowserPolicy((v) => !v)}
+            style={{
+              background: 'none', border: 'none', padding: 0, cursor: 'pointer',
+              fontSize: 12, fontWeight: 500, color: 'var(--muted-fg)',
+              display: 'flex', alignItems: 'center', gap: 6,
+            }}
+          >
+            <span style={{ fontSize: 10 }}>{showBrowserPolicy ? '▾' : '▸'}</span>
+            Browser Policy
+          </button>
+          {showBrowserPolicy && (
+            <div style={{ marginTop: 8 }}>
+              <textarea
+                value={browserPolicyRaw}
+                onChange={(e) => setBrowserPolicyRaw(e.target.value)}
+                rows={5}
+                placeholder='{"streaming_mode": "vnc"}'
+                style={TEXTAREA_MONO}
+              />
+              {errors.browser_policy && <p style={ERR}>{errors.browser_policy}</p>}
+            </div>
+          )}
+        </div>
+
+        {/* Notification Config (collapsible) */}
+        <div>
+          <button
+            type="button"
+            onClick={() => setShowNotificationConfig((v) => !v)}
+            style={{
+              background: 'none', border: 'none', padding: 0, cursor: 'pointer',
+              fontSize: 12, fontWeight: 500, color: 'var(--muted-fg)',
+              display: 'flex', alignItems: 'center', gap: 6,
+            }}
+          >
+            <span style={{ fontSize: 10 }}>{showNotificationConfig ? '▾' : '▸'}</span>
+            Notification Config
+          </button>
+          {showNotificationConfig && (
+            <div style={{ marginTop: 8 }}>
+              <textarea
+                value={notificationConfigRaw}
+                onChange={(e) => setNotificationConfigRaw(e.target.value)}
+                rows={5}
+                placeholder="{}"
+                style={TEXTAREA_MONO}
+              />
+              {errors.notification_config && <p style={ERR}>{errors.notification_config}</p>}
+            </div>
+          )}
+        </div>
+
+        {createMutation.isError && (
+          <p style={{ fontSize: 12, color: 'var(--error)' }}>
+            Failed to create template. Check your inputs and try again.
+          </p>
+        )}
+
+        <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 10, paddingTop: 8 }}>
+          <Link
+            to="/templates"
+            style={{
+              display: 'inline-flex', alignItems: 'center',
+              height: 34, padding: '0 14px', borderRadius: 8,
+              border: '1px solid var(--border-2)', background: 'var(--card)',
+              color: 'var(--fg)', fontSize: 12.5, textDecoration: 'none',
+            }}
+          >
+            Cancel
+          </Link>
+          <button
+            type="submit"
+            disabled={createMutation.isPending}
+            style={{
+              height: 34, padding: '0 14px', borderRadius: 8,
+              background: 'var(--primary)', color: 'var(--primary-fg)',
+              fontWeight: 600, fontSize: 12.5, border: 'none',
+              cursor: createMutation.isPending ? 'default' : 'pointer',
+              opacity: createMutation.isPending ? 0.6 : 1,
+            }}
+          >
+            {createMutation.isPending ? 'Creating…' : 'Create Template'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/apps/admin-ui/src/routes/templates.tsx
+++ b/apps/admin-ui/src/routes/templates.tsx
@@ -1,0 +1,147 @@
+import { useState } from 'react';
+import { Link } from 'react-router';
+import { useQuery } from '@tanstack/react-query';
+import { templatesApi } from '@/api/templates';
+import { StatusBadge } from '@/components/shared/status-badge';
+import { useHasRole } from '@/hooks/use-role';
+
+const TH: React.CSSProperties = {
+  padding: '11px 14px',
+  fontSize: 11,
+  textTransform: 'uppercase',
+  letterSpacing: '0.06em',
+  fontWeight: 500,
+  color: 'var(--faint-fg)',
+  textAlign: 'left',
+};
+
+const TD: React.CSSProperties = { padding: '11px 14px', fontSize: 13, color: 'var(--fg)' };
+const TD_MONO: React.CSSProperties = {
+  padding: '11px 14px',
+  fontFamily: 'ui-monospace, Menlo, monospace',
+  fontSize: 12,
+  color: 'var(--muted-fg)',
+};
+
+export function TemplatesPage() {
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+  const canWrite = useHasRole('Admin', 'Editor');
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['templates'],
+    queryFn: () => templatesApi.list(),
+  });
+
+  const templates = data ?? [];
+
+  return (
+    <div>
+      <div style={{ display: 'flex', alignItems: 'flex-start', justifyContent: 'space-between', marginBottom: 24 }}>
+        <div>
+          <h1 style={{ fontSize: 24, fontWeight: 800, letterSpacing: '-0.02em', margin: 0, color: 'var(--fg)' }}>
+            App Templates
+          </h1>
+          <p style={{ color: 'var(--muted-fg)', fontSize: 12.5, marginTop: 3, marginBottom: 0 }}>
+            Reusable application configurations
+          </p>
+        </div>
+        {canWrite && (
+          <Link
+            to="/templates/new"
+            style={{
+              display: 'inline-flex', alignItems: 'center',
+              height: 34, padding: '0 14px', borderRadius: 8,
+              background: 'var(--primary)', color: 'var(--primary-fg)',
+              fontWeight: 600, fontSize: 12.5, textDecoration: 'none',
+            }}
+          >
+            + New Template
+          </Link>
+        )}
+      </div>
+
+      {isLoading && (
+        <p style={{ color: 'var(--muted-fg)', fontSize: 13 }}>Loading…</p>
+      )}
+
+      {!isLoading && templates.length === 0 && (
+        <div style={{
+          border: '1px dashed var(--border-2)', borderRadius: 12,
+          padding: '48px 24px', textAlign: 'center',
+        }}>
+          <p style={{ fontSize: 15, fontWeight: 600, color: 'var(--fg)', margin: '0 0 6px' }}>
+            No templates
+          </p>
+          <p style={{ fontSize: 13, color: 'var(--muted-fg)', margin: 0 }}>
+            Templates define reusable application configurations.
+          </p>
+          {canWrite && (
+            <Link
+              to="/templates/new"
+              style={{
+                display: 'inline-flex', alignItems: 'center', marginTop: 16,
+                height: 34, padding: '0 14px', borderRadius: 8,
+                background: 'var(--primary)', color: 'var(--primary-fg)',
+                fontWeight: 600, fontSize: 12.5, textDecoration: 'none',
+              }}
+            >
+              + New Template
+            </Link>
+          )}
+        </div>
+      )}
+
+      {templates.length > 0 && (
+        <div style={{ background: 'var(--card)', border: '1px solid var(--border)', borderRadius: 12, overflow: 'hidden' }}>
+          <div style={{ overflowX: 'auto' }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse', minWidth: 720 }}>
+              <thead>
+                <tr style={{ background: 'var(--card-2)' }}>
+                  <th style={TH}>NAME</th>
+                  <th style={TH}>PROFILE PATTERN</th>
+                  <th style={TH}>IDLE SHUTDOWN</th>
+                  <th style={TH}>EXECUTE</th>
+                  <th style={TH}>CREATED</th>
+                </tr>
+              </thead>
+              <tbody>
+                {templates.map((tpl, i) => (
+                  <tr
+                    key={tpl.id}
+                    onMouseEnter={() => setHoveredId(tpl.id)}
+                    onMouseLeave={() => setHoveredId(null)}
+                    style={{
+                      borderBottom: i < templates.length - 1 ? '1px solid var(--border)' : 'none',
+                      background: hoveredId === tpl.id
+                        ? 'color-mix(in srgb, var(--fg) 4%, transparent)'
+                        : undefined,
+                    }}
+                  >
+                    <td style={{ ...TD, fontWeight: 500 }}>
+                      <Link
+                        to={`/templates/${tpl.id}`}
+                        style={{ color: 'var(--fg)', textDecoration: 'none' }}
+                      >
+                        {tpl.name}
+                      </Link>
+                    </td>
+                    <td style={TD_MONO}>{tpl.profile_name_pattern ?? '—'}</td>
+                    <td style={TD}>
+                      {tpl.idle_shutdown_seconds != null ? `${tpl.idle_shutdown_seconds}s` : '—'}
+                    </td>
+                    <td style={TD}>
+                      <StatusBadge value={tpl.execute_enabled ? 'ENABLED' : 'DISABLED'} />
+                    </td>
+                    <td style={{ ...TD, color: 'var(--muted-fg)' }}>
+                      {new Date(tpl.created_at).toLocaleString()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/admin-ui/src/routes/tenants.tsx
+++ b/apps/admin-ui/src/routes/tenants.tsx
@@ -1,0 +1,506 @@
+import { useState, useEffect } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { tenantsApi, type Tenant } from '@/api/tenants';
+import { useHasRole } from '@/hooks/use-role';
+import { ConfirmDialog } from '@/components/shared/confirm-dialog';
+import { EmptyState } from '@/components/shared/empty-state';
+
+const PAGE_SIZE = 20;
+
+function LockIcon() {
+  return (
+    <svg
+      width="48"
+      height="48"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={{ color: 'var(--faint-fg)', marginBottom: 12 }}
+    >
+      <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+      <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+    </svg>
+  );
+}
+
+const INPUT_STYLE: React.CSSProperties = {
+  width: '100%',
+  height: 36,
+  padding: '0 11px',
+  borderRadius: 8,
+  border: '1px solid var(--border-2)',
+  background: 'var(--bg)',
+  color: 'var(--fg)',
+  fontSize: 13,
+  boxSizing: 'border-box',
+  outline: 'none',
+};
+
+const LABEL_STYLE: React.CSSProperties = {
+  fontSize: 12,
+  fontWeight: 500,
+  color: 'var(--muted-fg)',
+  marginBottom: 5,
+  display: 'block',
+};
+
+interface TenantDialogProps {
+  open: boolean;
+  editing: Tenant | null;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+function TenantDialog({ open, editing, onClose, onSaved }: TenantDialogProps) {
+  const [name, setName] = useState('');
+  const [id, setId] = useState('');
+  const [maxSessions, setMaxSessions] = useState('10');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (open) {
+      setName(editing?.name ?? '');
+      setId(editing?.id ?? '');
+      setMaxSessions(String(editing?.max_sessions ?? 10));
+      setError('');
+    }
+  }, [open, editing?.id]);
+
+  const mutation = useMutation({
+    mutationFn: () =>
+      editing
+        ? tenantsApi.update(editing.id, { max_sessions: Number(maxSessions) })
+        : tenantsApi.create({
+            name,
+            ...(id.trim() ? { id: id.trim() } : {}),
+            max_sessions: Number(maxSessions),
+          }),
+    onSuccess: () => {
+      onSaved();
+      onClose();
+    },
+    onError: (err: Error) => setError(err.message),
+  });
+
+  if (!open) return null;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!editing && !name.trim()) return;
+    mutation.mutate();
+  };
+
+  const isDisabled = mutation.isPending || (!editing && !name.trim());
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 50,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'rgba(0,0,0,0.6)',
+      }}
+      onClick={onClose}
+    >
+      <div
+        style={{
+          background: 'var(--elev)',
+          border: '1px solid var(--border-2)',
+          borderRadius: 12,
+          padding: 24,
+          width: 480,
+          maxHeight: '85vh',
+          overflowY: 'auto',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 style={{ fontSize: 18, fontWeight: 700, marginBottom: 18 }}>
+          {editing ? 'Edit Tenant' : 'New Tenant'}
+        </h3>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label style={LABEL_STYLE}>
+              Name{!editing && <span style={{ color: '#dc2626', marginLeft: 2 }}>*</span>}
+            </label>
+            {editing ? (
+              <div
+                style={{
+                  ...INPUT_STYLE,
+                  display: 'flex',
+                  alignItems: 'center',
+                  opacity: 0.55,
+                  cursor: 'default',
+                  userSelect: 'none',
+                }}
+              >
+                {editing.name}
+              </div>
+            ) : (
+              <input
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="acme-corp"
+                required
+                style={INPUT_STYLE}
+              />
+            )}
+          </div>
+
+          {!editing && (
+            <div>
+              <label style={LABEL_STYLE}>
+                ID{' '}
+                <span style={{ fontSize: 11, color: 'var(--faint-fg)', fontWeight: 400 }}>
+                  (optional, auto-generated)
+                </span>
+              </label>
+              <input
+                value={id}
+                onChange={(e) => setId(e.target.value)}
+                placeholder="acme-corp"
+                style={INPUT_STYLE}
+              />
+            </div>
+          )}
+
+          <div>
+            <label style={LABEL_STYLE}>
+              Max Sessions<span style={{ color: '#dc2626', marginLeft: 2 }}>*</span>
+            </label>
+            <input
+              type="number"
+              min={1}
+              max={1000}
+              value={maxSessions}
+              onChange={(e) => setMaxSessions(e.target.value)}
+              style={{ ...INPUT_STYLE, fontVariantNumeric: 'tabular-nums' }}
+            />
+          </div>
+
+          {error && (
+            <p style={{ fontSize: 12, color: '#dc2626' }}>{error}</p>
+          )}
+
+          <div className="flex justify-end gap-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              style={{
+                background: 'var(--card)',
+                border: '1px solid var(--border)',
+                color: 'var(--fg)',
+                borderRadius: 8,
+                padding: '0 16px',
+                height: 36,
+                fontSize: 13,
+                cursor: 'pointer',
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isDisabled}
+              style={{
+                background: 'var(--primary)',
+                color: 'var(--primary-fg)',
+                border: 'none',
+                borderRadius: 8,
+                padding: '0 16px',
+                height: 36,
+                fontSize: 13,
+                fontWeight: 500,
+                cursor: isDisabled ? 'not-allowed' : 'pointer',
+                opacity: isDisabled ? 0.5 : 1,
+              }}
+            >
+              {mutation.isPending
+                ? editing
+                  ? 'Saving...'
+                  : 'Creating...'
+                : editing
+                ? 'Save Changes'
+                : 'Create'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export function TenantsPage() {
+  const isAdmin = useHasRole('Admin');
+  const qc = useQueryClient();
+  const [page, setPage] = useState(0);
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editing, setEditing] = useState<Tenant | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<Tenant | null>(null);
+  const [hoveredRow, setHoveredRow] = useState<string | null>(null);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['tenants', { limit: PAGE_SIZE, offset: page * PAGE_SIZE }],
+    queryFn: () => tenantsApi.list({ limit: PAGE_SIZE, offset: page * PAGE_SIZE }),
+    enabled: isAdmin,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => tenantsApi.remove(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['tenants'] });
+      setDeleteTarget(null);
+    },
+  });
+
+  if (!isAdmin) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24 text-center">
+        <LockIcon />
+        <p style={{ fontSize: 15, fontWeight: 500, color: 'var(--fg)' }}>
+          You don't have permission to view this page.
+        </p>
+      </div>
+    );
+  }
+
+  const tenants = data?.data ?? [];
+  const total = data?.total ?? 0;
+
+  const thStyle: React.CSSProperties = {
+    padding: '11px 14px',
+    fontSize: 11,
+    textTransform: 'uppercase',
+    letterSpacing: '0.06em',
+    fontWeight: 500,
+    color: 'var(--faint-fg)',
+    textAlign: 'left',
+    background: 'var(--card-2)',
+  };
+
+  const tdStyle: React.CSSProperties = {
+    padding: '11px 14px',
+    fontSize: 13,
+  };
+
+  const openCreate = () => {
+    setEditing(null);
+    setDialogOpen(true);
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 style={{ fontSize: 22, fontWeight: 700, color: 'var(--fg)' }}>Tenants</h1>
+          <p style={{ fontSize: 13, color: 'var(--muted-fg)', marginTop: 2 }}>
+            Multi-tenant management
+          </p>
+        </div>
+        <button
+          onClick={openCreate}
+          style={{
+            background: 'var(--primary)',
+            color: 'var(--primary-fg)',
+            border: 'none',
+            borderRadius: 8,
+            padding: '0 16px',
+            height: 36,
+            fontSize: 13,
+            fontWeight: 500,
+            cursor: 'pointer',
+          }}
+        >
+          + New Tenant
+        </button>
+      </div>
+
+      {isLoading && (
+        <p style={{ color: 'var(--muted-fg)', fontSize: 13 }}>Loading...</p>
+      )}
+
+      {!isLoading && tenants.length === 0 && (
+        <EmptyState
+          title="No tenants"
+          description="Create a tenant to get started."
+          action={
+            <button
+              onClick={openCreate}
+              style={{
+                background: 'var(--primary)',
+                color: 'var(--primary-fg)',
+                border: 'none',
+                borderRadius: 8,
+                padding: '0 16px',
+                height: 36,
+                fontSize: 13,
+                fontWeight: 500,
+                cursor: 'pointer',
+              }}
+            >
+              + New Tenant
+            </button>
+          }
+        />
+      )}
+
+      {tenants.length > 0 && (
+        <>
+          <div
+            className="overflow-x-auto"
+            style={{
+              background: 'var(--card)',
+              border: '1px solid var(--border)',
+              borderRadius: 12,
+              overflow: 'hidden',
+            }}
+          >
+            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+              <thead>
+                <tr>
+                  <th style={thStyle}>ID</th>
+                  <th style={thStyle}>Name</th>
+                  <th style={{ ...thStyle, fontVariantNumeric: 'tabular-nums' }}>Max Sessions</th>
+                  <th style={thStyle}>Created</th>
+                  <th style={{ ...thStyle, textAlign: 'right' }}>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {tenants.map((t) => (
+                  <tr
+                    key={t.id}
+                    onMouseEnter={() => setHoveredRow(t.id)}
+                    onMouseLeave={() => setHoveredRow(null)}
+                    style={{
+                      borderTop: '1px solid var(--border)',
+                      background:
+                        hoveredRow === t.id
+                          ? 'color-mix(in srgb, var(--fg) 4%, transparent)'
+                          : undefined,
+                    }}
+                  >
+                    <td style={{ ...tdStyle, fontFamily: 'monospace', fontSize: 12 }}>{t.id}</td>
+                    <td style={{ ...tdStyle, fontWeight: 500 }}>{t.name}</td>
+                    <td style={{ ...tdStyle, fontVariantNumeric: 'tabular-nums' }}>
+                      {t.max_sessions}
+                    </td>
+                    <td style={{ ...tdStyle, color: 'var(--muted-fg)' }}>
+                      {new Date(t.created_at).toLocaleDateString()}
+                    </td>
+                    <td style={{ ...tdStyle, textAlign: 'right' }}>
+                      <div className="flex items-center justify-end gap-3">
+                        <button
+                          onClick={() => {
+                            setEditing(t);
+                            setDialogOpen(true);
+                          }}
+                          style={{
+                            fontSize: 12,
+                            color: 'var(--primary)',
+                            background: 'none',
+                            border: 'none',
+                            cursor: 'pointer',
+                            textDecoration: 'underline',
+                            padding: 0,
+                          }}
+                        >
+                          Edit
+                        </button>
+                        <button
+                          onClick={() => setDeleteTarget(t)}
+                          style={{
+                            fontSize: 12,
+                            color: '#dc2626',
+                            background: 'none',
+                            border: 'none',
+                            cursor: 'pointer',
+                            textDecoration: 'underline',
+                            padding: 0,
+                          }}
+                        >
+                          Delete
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {total > PAGE_SIZE && (
+            <div
+              className="mt-4 flex items-center justify-between"
+              style={{ fontSize: 13, color: 'var(--muted-fg)' }}
+            >
+              <span>
+                Showing {page * PAGE_SIZE + 1}–{Math.min((page + 1) * PAGE_SIZE, total)} of {total}
+              </span>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => setPage((p) => Math.max(0, p - 1))}
+                  disabled={page === 0}
+                  style={{
+                    background: 'var(--card)',
+                    border: '1px solid var(--border)',
+                    color: 'var(--fg)',
+                    borderRadius: 6,
+                    padding: '4px 12px',
+                    fontSize: 13,
+                    cursor: page === 0 ? 'not-allowed' : 'pointer',
+                    opacity: page === 0 ? 0.5 : 1,
+                  }}
+                >
+                  Prev
+                </button>
+                <button
+                  onClick={() => setPage((p) => p + 1)}
+                  disabled={(page + 1) * PAGE_SIZE >= total}
+                  style={{
+                    background: 'var(--card)',
+                    border: '1px solid var(--border)',
+                    color: 'var(--fg)',
+                    borderRadius: 6,
+                    padding: '4px 12px',
+                    fontSize: 13,
+                    cursor: (page + 1) * PAGE_SIZE >= total ? 'not-allowed' : 'pointer',
+                    opacity: (page + 1) * PAGE_SIZE >= total ? 0.5 : 1,
+                  }}
+                >
+                  Next
+                </button>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+
+      <TenantDialog
+        open={dialogOpen}
+        editing={editing}
+        onClose={() => {
+          setDialogOpen(false);
+          setEditing(null);
+        }}
+        onSaved={() => qc.invalidateQueries({ queryKey: ['tenants'] })}
+      />
+
+      <ConfirmDialog
+        open={!!deleteTarget}
+        title={`Delete tenant "${deleteTarget?.name}"`}
+        description="This will permanently delete the tenant and all associated data."
+        confirmLabel="Delete Tenant"
+        destructive
+        requireInput={deleteTarget?.name}
+        onConfirm={() => deleteMutation.mutate(deleteTarget!.id)}
+        onCancel={() => setDeleteTarget(null)}
+      />
+    </div>
+  );
+}

--- a/apps/admin-ui/src/routes/users.tsx
+++ b/apps/admin-ui/src/routes/users.tsx
@@ -1,0 +1,513 @@
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { usersApi, type User } from '@/api/users';
+import { useHasRole } from '@/hooks/use-role';
+import { useAuthStore } from '@/stores/auth';
+import { ConfirmDialog } from '@/components/shared/confirm-dialog';
+import { EmptyState } from '@/components/shared/empty-state';
+
+const PAGE_SIZE = 20;
+
+const ROLES = ['Admin', 'Editor', 'Operator', 'Viewer'] as const;
+
+function LockIcon() {
+  return (
+    <svg
+      width="48"
+      height="48"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      style={{ color: 'var(--faint-fg)', marginBottom: 12 }}
+    >
+      <rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+      <path d="M7 11V7a5 5 0 0 1 10 0v4" />
+    </svg>
+  );
+}
+
+const BADGE_BASE: React.CSSProperties = {
+  display: 'inline-block',
+  padding: '2px 8px',
+  borderRadius: 9999,
+  fontSize: 11,
+  fontWeight: 500,
+};
+
+function RoleBadge({ role }: { role: string }) {
+  switch (role) {
+    case 'Admin':
+      return (
+        <span style={{ ...BADGE_BASE, background: 'var(--primary)', color: 'var(--primary-fg)' }}>
+          {role}
+        </span>
+      );
+    case 'Editor':
+      return (
+        <span style={{ ...BADGE_BASE, background: '#ede9fe', color: '#5b21b6' }}>{role}</span>
+      );
+    case 'Operator':
+      return (
+        <span style={{ ...BADGE_BASE, background: '#dbeafe', color: '#1d4ed8' }}>{role}</span>
+      );
+    case 'Viewer':
+    default:
+      return (
+        <span style={{ ...BADGE_BASE, background: 'var(--card-2)', color: 'var(--muted-fg)' }}>
+          {role}
+        </span>
+      );
+  }
+}
+
+function StatusBadge({ status }: { status: string }) {
+  if (status === 'active') {
+    return (
+      <span style={{ ...BADGE_BASE, background: '#dcfce7', color: '#15803d' }}>{status}</span>
+    );
+  }
+  return (
+    <span style={{ ...BADGE_BASE, background: 'var(--card-2)', color: 'var(--muted-fg)' }}>
+      {status}
+    </span>
+  );
+}
+
+const INPUT_STYLE: React.CSSProperties = {
+  width: '100%',
+  height: 36,
+  padding: '0 11px',
+  borderRadius: 8,
+  border: '1px solid var(--border-2)',
+  background: 'var(--bg)',
+  color: 'var(--fg)',
+  fontSize: 13,
+  boxSizing: 'border-box',
+  outline: 'none',
+};
+
+const LABEL_STYLE: React.CSSProperties = {
+  fontSize: 12,
+  fontWeight: 500,
+  color: 'var(--muted-fg)',
+  marginBottom: 5,
+  display: 'block',
+};
+
+interface CreateDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onCreated: () => void;
+}
+
+function CreateUserDialog({ open, onClose, onCreated }: CreateDialogProps) {
+  const currentTenantId = useAuthStore((s) => s.user?.tenant_id ?? '');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [role, setRole] = useState<string>('Operator');
+  const [tenantId, setTenantId] = useState(currentTenantId);
+  const [error, setError] = useState('');
+
+  const mutation = useMutation({
+    mutationFn: () => usersApi.create({ email, password, role, tenant_id: tenantId }),
+    onSuccess: () => {
+      onCreated();
+      onClose();
+      setEmail('');
+      setPassword('');
+      setRole('Operator');
+      setError('');
+    },
+    onError: (err: Error) => setError(err.message),
+  });
+
+  if (!open) return null;
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!email.trim() || !password || !tenantId.trim()) return;
+    mutation.mutate();
+  };
+
+  const isDisabled =
+    mutation.isPending || !email.trim() || !password || !tenantId.trim();
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 50,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        background: 'rgba(0,0,0,0.6)',
+      }}
+      onClick={onClose}
+    >
+      <div
+        style={{
+          background: 'var(--elev)',
+          border: '1px solid var(--border-2)',
+          borderRadius: 12,
+          padding: 24,
+          width: 480,
+          maxHeight: '85vh',
+          overflowY: 'auto',
+        }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h3 style={{ fontSize: 18, fontWeight: 700, marginBottom: 18 }}>New User</h3>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label style={LABEL_STYLE}>
+              Email<span style={{ color: '#dc2626', marginLeft: 2 }}>*</span>
+            </label>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="user@example.com"
+              required
+              style={INPUT_STYLE}
+            />
+          </div>
+
+          <div>
+            <label style={LABEL_STYLE}>
+              Password<span style={{ color: '#dc2626', marginLeft: 2 }}>*</span>
+            </label>
+            <input
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              style={INPUT_STYLE}
+            />
+            <p style={{ fontSize: 11, color: 'var(--faint-fg)', marginTop: 4 }}>
+              Min 12 chars, must include uppercase, lowercase, digit, and special character
+            </p>
+          </div>
+
+          <div>
+            <label style={LABEL_STYLE}>
+              Role<span style={{ color: '#dc2626', marginLeft: 2 }}>*</span>
+            </label>
+            <select
+              value={role}
+              onChange={(e) => setRole(e.target.value)}
+              style={INPUT_STYLE}
+            >
+              {ROLES.map((r) => (
+                <option key={r} value={r}>
+                  {r}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div>
+            <label style={LABEL_STYLE}>
+              Tenant ID<span style={{ color: '#dc2626', marginLeft: 2 }}>*</span>
+            </label>
+            <input
+              value={tenantId}
+              onChange={(e) => setTenantId(e.target.value)}
+              placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+              required
+              style={INPUT_STYLE}
+            />
+          </div>
+
+          {error && <p style={{ fontSize: 12, color: '#dc2626' }}>{error}</p>}
+
+          <div className="flex justify-end gap-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              style={{
+                background: 'var(--card)',
+                border: '1px solid var(--border)',
+                color: 'var(--fg)',
+                borderRadius: 8,
+                padding: '0 16px',
+                height: 36,
+                fontSize: 13,
+                cursor: 'pointer',
+              }}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isDisabled}
+              style={{
+                background: 'var(--primary)',
+                color: 'var(--primary-fg)',
+                border: 'none',
+                borderRadius: 8,
+                padding: '0 16px',
+                height: 36,
+                fontSize: 13,
+                fontWeight: 500,
+                cursor: isDisabled ? 'not-allowed' : 'pointer',
+                opacity: isDisabled ? 0.5 : 1,
+              }}
+            >
+              {mutation.isPending ? 'Creating...' : 'Create'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+export function UsersPage() {
+  const isAdmin = useHasRole('Admin');
+  const qc = useQueryClient();
+  const [page, setPage] = useState(0);
+  const [createOpen, setCreateOpen] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<User | null>(null);
+  const [hoveredRow, setHoveredRow] = useState<string | null>(null);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['users', { limit: PAGE_SIZE, offset: page * PAGE_SIZE }],
+    queryFn: () => usersApi.list({ limit: PAGE_SIZE, offset: page * PAGE_SIZE }),
+    enabled: isAdmin,
+  });
+
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => usersApi.remove(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['users'] });
+      setDeleteTarget(null);
+    },
+  });
+
+  if (!isAdmin) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24 text-center">
+        <LockIcon />
+        <p style={{ fontSize: 15, fontWeight: 500, color: 'var(--fg)' }}>
+          You don't have permission to view this page.
+        </p>
+      </div>
+    );
+  }
+
+  const users = data?.data ?? [];
+  const total = data?.total ?? 0;
+
+  const thStyle: React.CSSProperties = {
+    padding: '11px 14px',
+    fontSize: 11,
+    textTransform: 'uppercase',
+    letterSpacing: '0.06em',
+    fontWeight: 500,
+    color: 'var(--faint-fg)',
+    textAlign: 'left',
+    background: 'var(--card-2)',
+  };
+
+  const tdStyle: React.CSSProperties = {
+    padding: '11px 14px',
+    fontSize: 13,
+  };
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 style={{ fontSize: 22, fontWeight: 700, color: 'var(--fg)' }}>Users</h1>
+          <p style={{ fontSize: 13, color: 'var(--muted-fg)', marginTop: 2 }}>
+            User account management
+          </p>
+        </div>
+        <button
+          onClick={() => setCreateOpen(true)}
+          style={{
+            background: 'var(--primary)',
+            color: 'var(--primary-fg)',
+            border: 'none',
+            borderRadius: 8,
+            padding: '0 16px',
+            height: 36,
+            fontSize: 13,
+            fontWeight: 500,
+            cursor: 'pointer',
+          }}
+        >
+          + New User
+        </button>
+      </div>
+
+      {isLoading && (
+        <p style={{ color: 'var(--muted-fg)', fontSize: 13 }}>Loading...</p>
+      )}
+
+      {!isLoading && users.length === 0 && (
+        <EmptyState
+          title="No users"
+          description="Create a user to get started."
+          action={
+            <button
+              onClick={() => setCreateOpen(true)}
+              style={{
+                background: 'var(--primary)',
+                color: 'var(--primary-fg)',
+                border: 'none',
+                borderRadius: 8,
+                padding: '0 16px',
+                height: 36,
+                fontSize: 13,
+                fontWeight: 500,
+                cursor: 'pointer',
+              }}
+            >
+              + New User
+            </button>
+          }
+        />
+      )}
+
+      {users.length > 0 && (
+        <>
+          <div
+            className="overflow-x-auto"
+            style={{
+              background: 'var(--card)',
+              border: '1px solid var(--border)',
+              borderRadius: 12,
+              overflow: 'hidden',
+            }}
+          >
+            <table style={{ width: '100%', borderCollapse: 'collapse' }}>
+              <thead>
+                <tr>
+                  <th style={thStyle}>Email</th>
+                  <th style={thStyle}>Role</th>
+                  <th style={thStyle}>Tenant</th>
+                  <th style={thStyle}>Status</th>
+                  <th style={thStyle}>Created</th>
+                  <th style={{ ...thStyle, textAlign: 'right' }}>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {users.map((u) => (
+                  <tr
+                    key={u.id}
+                    onMouseEnter={() => setHoveredRow(u.id)}
+                    onMouseLeave={() => setHoveredRow(null)}
+                    style={{
+                      borderTop: '1px solid var(--border)',
+                      background:
+                        hoveredRow === u.id
+                          ? 'color-mix(in srgb, var(--fg) 4%, transparent)'
+                          : undefined,
+                    }}
+                  >
+                    <td style={tdStyle}>{u.email}</td>
+                    <td style={tdStyle}>
+                      <RoleBadge role={u.role} />
+                    </td>
+                    <td style={{ ...tdStyle, fontFamily: 'monospace', fontSize: 12 }}>
+                      {u.tenant_id}
+                    </td>
+                    <td style={tdStyle}>
+                      <StatusBadge status={u.status} />
+                    </td>
+                    <td style={{ ...tdStyle, color: 'var(--muted-fg)' }}>
+                      {new Date(u.created_at).toLocaleDateString()}
+                    </td>
+                    <td style={{ ...tdStyle, textAlign: 'right' }}>
+                      <button
+                        onClick={() => setDeleteTarget(u)}
+                        style={{
+                          fontSize: 12,
+                          color: '#dc2626',
+                          background: 'none',
+                          border: 'none',
+                          cursor: 'pointer',
+                          textDecoration: 'underline',
+                          padding: 0,
+                        }}
+                      >
+                        Delete
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {total > PAGE_SIZE && (
+            <div
+              className="mt-4 flex items-center justify-between"
+              style={{ fontSize: 13, color: 'var(--muted-fg)' }}
+            >
+              <span>
+                Showing {page * PAGE_SIZE + 1}–{Math.min((page + 1) * PAGE_SIZE, total)} of {total}
+              </span>
+              <div className="flex gap-2">
+                <button
+                  onClick={() => setPage((p) => Math.max(0, p - 1))}
+                  disabled={page === 0}
+                  style={{
+                    background: 'var(--card)',
+                    border: '1px solid var(--border)',
+                    color: 'var(--fg)',
+                    borderRadius: 6,
+                    padding: '4px 12px',
+                    fontSize: 13,
+                    cursor: page === 0 ? 'not-allowed' : 'pointer',
+                    opacity: page === 0 ? 0.5 : 1,
+                  }}
+                >
+                  Prev
+                </button>
+                <button
+                  onClick={() => setPage((p) => p + 1)}
+                  disabled={(page + 1) * PAGE_SIZE >= total}
+                  style={{
+                    background: 'var(--card)',
+                    border: '1px solid var(--border)',
+                    color: 'var(--fg)',
+                    borderRadius: 6,
+                    padding: '4px 12px',
+                    fontSize: 13,
+                    cursor: (page + 1) * PAGE_SIZE >= total ? 'not-allowed' : 'pointer',
+                    opacity: (page + 1) * PAGE_SIZE >= total ? 0.5 : 1,
+                  }}
+                >
+                  Next
+                </button>
+              </div>
+            </div>
+          )}
+        </>
+      )}
+
+      <CreateUserDialog
+        open={createOpen}
+        onClose={() => setCreateOpen(false)}
+        onCreated={() => qc.invalidateQueries({ queryKey: ['users'] })}
+      />
+
+      <ConfirmDialog
+        open={!!deleteTarget}
+        title={`Delete user "${deleteTarget?.email}"`}
+        description="This will permanently remove the user. They will no longer be able to sign in."
+        confirmLabel="Delete User"
+        destructive
+        onConfirm={() => deleteMutation.mutate(deleteTarget!.id)}
+        onCancel={() => setDeleteTarget(null)}
+      />
+    </div>
+  );
+}

--- a/apps/admin-ui/src/stores/auth.spec.ts
+++ b/apps/admin-ui/src/stores/auth.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+const mockLocalStorage = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => { store[key] = value; },
+    removeItem: (key: string) => { delete store[key]; },
+    clear: () => { store = {}; },
+  };
+})();
+
+Object.defineProperty(window, 'localStorage', { value: mockLocalStorage, configurable: true });
+
+describe('useAuthStore', () => {
+  beforeEach(() => {
+    mockLocalStorage.clear();
+    vi.resetModules();
+  });
+
+  it('starts with null when no stored token', async () => {
+    const { useAuthStore } = await import('./auth');
+    const state = useAuthStore.getState();
+    expect(state.token).toBeNull();
+    expect(state.user).toBeNull();
+  });
+
+  it('setToken stores token and decodes user', async () => {
+    const { useAuthStore } = await import('./auth');
+    const payload = { sub: 'federated:user-1', tenant_id: 't-1', role: 'Admin', email: 'admin@test.com' };
+    const fakeToken = `header.${btoa(JSON.stringify(payload))}.signature`;
+    useAuthStore.getState().setToken(fakeToken);
+
+    const state = useAuthStore.getState();
+    expect(state.token).toBe(fakeToken);
+    expect(state.user?.sub).toBe('federated:user-1');
+    expect(state.user?.role).toBe('Admin');
+    expect(state.user?.email).toBe('admin@test.com');
+    expect(mockLocalStorage.getItem('tabby_token')).toBe(fakeToken);
+  });
+
+  it('logout clears token and user', async () => {
+    const { useAuthStore } = await import('./auth');
+    const payload = { sub: 'user-1', tenant_id: 't-1', role: 'Admin' };
+    const fakeToken = `header.${btoa(JSON.stringify(payload))}.signature`;
+    useAuthStore.getState().setToken(fakeToken);
+    useAuthStore.getState().logout();
+
+    const state = useAuthStore.getState();
+    expect(state.token).toBeNull();
+    expect(state.user).toBeNull();
+    expect(mockLocalStorage.getItem('tabby_token')).toBeNull();
+  });
+});
+
+describe('displayName', () => {
+  it('returns email when available', async () => {
+    const { displayName } = await import('./auth');
+    expect(displayName({ sub: 'federated:u1', tenant_id: 't1', role: 'Admin', email: 'admin@test.com' }))
+      .toBe('admin@test.com');
+  });
+
+  it('strips federated prefix from sub when no email', async () => {
+    const { displayName } = await import('./auth');
+    expect(displayName({ sub: 'federated:abc-123', tenant_id: 't1', role: 'Admin' }))
+      .toBe('abc-123');
+  });
+
+  it('returns empty for null user', async () => {
+    const { displayName } = await import('./auth');
+    expect(displayName(null)).toBe('');
+  });
+});

--- a/apps/admin-ui/src/stores/auth.ts
+++ b/apps/admin-ui/src/stores/auth.ts
@@ -1,0 +1,59 @@
+import { create } from 'zustand';
+
+export interface User {
+  sub: string;
+  tenant_id: string;
+  role: string;
+  token_type?: string;
+  owner_user_id?: string;
+  email?: string;
+  name?: string;
+  idp_id?: string;
+  exp?: number;
+}
+
+interface AuthState {
+  token: string | null;
+  user: User | null;
+  setToken: (token: string) => void;
+  logout: () => void;
+}
+
+function decodeJwt(token: string): User | null {
+  try {
+    const payload = token.split('.')[1];
+    if (!payload) return null;
+    return JSON.parse(atob(payload)) as User;
+  } catch {
+    return null;
+  }
+}
+
+export const useAuthStore = create<AuthState>((set) => {
+  const stored = localStorage.getItem('tabby_token');
+  const initial = stored ? { token: stored, user: decodeJwt(stored) } : { token: null, user: null };
+
+  return {
+    ...initial,
+    setToken: (token: string) => {
+      localStorage.setItem('tabby_token', token);
+      set({ token, user: decodeJwt(token) });
+    },
+    logout: () => {
+      localStorage.removeItem('tabby_token');
+      set({ token: null, user: null });
+    },
+  };
+});
+
+export function displayName(user: User | null): string {
+  if (!user) return '';
+  if (user.email) return user.email;
+  if (user.name) return user.name;
+  return user.sub.replace(/^(federated:|svc:)/, '');
+}
+
+export function userInitial(user: User | null): string {
+  const name = displayName(user);
+  return name.charAt(0).toUpperCase() || '?';
+}

--- a/apps/admin-ui/src/stores/auth.ts
+++ b/apps/admin-ui/src/stores/auth.ts
@@ -23,7 +23,8 @@ function decodeJwt(token: string): User | null {
   try {
     const payload = token.split('.')[1];
     if (!payload) return null;
-    return JSON.parse(atob(payload)) as User;
+    const base64 = payload.replace(/-/g, '+').replace(/_/g, '/');
+    return JSON.parse(atob(base64)) as User;
   } catch {
     return null;
   }

--- a/apps/admin-ui/src/stores/ui.ts
+++ b/apps/admin-ui/src/stores/ui.ts
@@ -1,0 +1,39 @@
+import { create } from 'zustand';
+
+interface UiState {
+  sidebarCollapsed: boolean;
+  theme: 'light' | 'dark';
+  toggleSidebar: () => void;
+  setTheme: (theme: 'light' | 'dark') => void;
+  toggleTheme: () => void;
+}
+
+function getInitialTheme(): 'light' | 'dark' {
+  const saved = localStorage.getItem('tabby_theme');
+  if (saved === 'dark' || saved === 'light') return saved;
+  return 'dark';
+}
+
+function applyTheme(theme: 'light' | 'dark') {
+  document.documentElement.classList.toggle('light', theme === 'light');
+}
+
+const initialTheme = getInitialTheme();
+applyTheme(initialTheme);
+
+export const useUiStore = create<UiState>((set) => ({
+  sidebarCollapsed: false,
+  theme: initialTheme,
+  toggleSidebar: () => set((s) => ({ sidebarCollapsed: !s.sidebarCollapsed })),
+  setTheme: (theme) => {
+    localStorage.setItem('tabby_theme', theme);
+    applyTheme(theme);
+    set({ theme });
+  },
+  toggleTheme: () => set((s) => {
+    const next = s.theme === 'dark' ? 'light' : 'dark';
+    localStorage.setItem('tabby_theme', next);
+    applyTheme(next);
+    return { theme: next };
+  }),
+}));

--- a/apps/admin-ui/src/test-setup.ts
+++ b/apps/admin-ui/src/test-setup.ts
@@ -1,0 +1,20 @@
+import '@testing-library/jest-dom';
+
+Object.defineProperty(window, '__env', {
+  value: { API_URL: 'http://localhost:8000' },
+  writable: true,
+});
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});

--- a/apps/admin-ui/src/types/novnc.d.ts
+++ b/apps/admin-ui/src/types/novnc.d.ts
@@ -1,0 +1,17 @@
+declare module '@novnc/novnc/lib/rfb.js' {
+  interface RFBOptions {
+    wsProtocols?: string[];
+    credentials?: { password?: string };
+  }
+
+  export default class RFB {
+    constructor(target: HTMLElement, url: string, options?: RFBOptions);
+    scaleViewport: boolean;
+    resizeSession: boolean;
+    showDotCursor: boolean;
+    addEventListener(event: string, handler: (e: any) => void): void;
+    disconnect(): void;
+    clipboardPasteFrom(text: string): void;
+    sendKey(keysym: number, code: string | null, down?: boolean): void;
+  }
+}

--- a/apps/admin-ui/tsconfig.json
+++ b/apps/admin-ui/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "baseUrl": "."
+  },
+  "include": ["src"]
+}

--- a/apps/admin-ui/vite.config.ts
+++ b/apps/admin-ui/vite.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tailwindcss from '@tailwindcss/vite';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  server: {
+    port: 3000,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:8000',
+        changeOrigin: true,
+        rewrite: (p) => p.replace(/^\/api/, ''),
+      },
+    },
+  },
+  build: {
+    outDir: 'dist',
+    sourcemap: true,
+  },
+});

--- a/apps/admin-ui/vitest.config.ts
+++ b/apps/admin-ui/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import path from 'path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './src/test-setup.ts',
+  },
+});

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { MiddlewareConsumer, Module, NestModule } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ThrottlerModule } from '@nestjs/throttler';
 import { ScheduleModule } from '@nestjs/schedule';
@@ -15,8 +15,10 @@ import { StreamingModule } from './modules/streaming/streaming.module';
 import { ObservabilityModule } from './modules/observability/observability.module';
 import { NatsAclModule } from './modules/nats/nats-acl.module';
 import { BootstrapModule } from './modules/auth/bootstrap.module';
-import { APP_GUARD } from '@nestjs/core';
+import { APP_FILTER, APP_GUARD } from '@nestjs/core';
 import { UserThrottlerGuard } from './common/guards/user-throttler.guard';
+import { GlobalExceptionFilter } from './common/filters/http-exception.filter';
+import { CorrelationIdMiddleware } from './common/middleware/correlation-id.middleware';
 import { EventsModule } from './modules/events/events.module';
 import { AgentModule } from './modules/agent/agent.module';
 import { LifecycleModule } from './modules/lifecycle/lifecycle.module';
@@ -68,9 +70,17 @@ import { RecordingProvisionModule } from './modules/recording/recording-provisio
   ],
   providers: [
     {
+      provide: APP_FILTER,
+      useClass: GlobalExceptionFilter,
+    },
+    {
       provide: APP_GUARD,
       useClass: UserThrottlerGuard,
     },
   ],
 })
-export class AppModule {}
+export class AppModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(CorrelationIdMiddleware).forRoutes('*');
+  }
+}

--- a/apps/api/src/common/exceptions/domain.exceptions.ts
+++ b/apps/api/src/common/exceptions/domain.exceptions.ts
@@ -1,0 +1,53 @@
+import { HttpException, HttpStatus } from '@nestjs/common';
+
+export class TabbyDomainException extends HttpException {
+  public readonly domainCode: string;
+
+  constructor(
+    domainCode: string,
+    message: string,
+    statusCode: number,
+    details?: Record<string, unknown>,
+  ) {
+    super({ message, code: domainCode, ...(details ? { details } : {}) }, statusCode);
+    this.domainCode = domainCode;
+  }
+}
+
+export class BatonConflictException extends TabbyDomainException {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('BATON_CONFLICT', message, HttpStatus.CONFLICT, details);
+  }
+}
+
+export class SessionStateException extends TabbyDomainException {
+  constructor(message: string, currentState: string, expectedStates: string[]) {
+    super('SESSION_STATE_INVALID', message, HttpStatus.BAD_REQUEST, {
+      current_state: currentState,
+      expected_states: expectedStates,
+    });
+  }
+}
+
+export class NoHealthySessionException extends TabbyDomainException {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('NO_HEALTHY_SESSION', message, HttpStatus.NOT_FOUND, details);
+  }
+}
+
+export class ProfileNotFoundException extends TabbyDomainException {
+  constructor(message: string, details?: Record<string, unknown>) {
+    super('PROFILE_NOT_FOUND', message, HttpStatus.NOT_FOUND, details);
+  }
+}
+
+export class CredentialDecryptException extends TabbyDomainException {
+  constructor(details?: Record<string, unknown>) {
+    super(
+      'CREDENTIAL_DECRYPT_FAILED',
+      'Failed to decrypt credential bundle',
+      HttpStatus.INTERNAL_SERVER_ERROR,
+      details,
+    );
+  }
+}

--- a/apps/api/src/common/filters/http-exception.filter.spec.ts
+++ b/apps/api/src/common/filters/http-exception.filter.spec.ts
@@ -1,0 +1,257 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { HttpException, HttpStatus, BadRequestException, NotFoundException, ForbiddenException, InternalServerErrorException } from '@nestjs/common';
+import { GlobalExceptionFilter } from './http-exception.filter';
+import { TabbyDomainException, BatonConflictException, NoHealthySessionException, CredentialDecryptException } from '../exceptions/domain.exceptions';
+import * as Sentry from '@sentry/node';
+
+jest.mock('@sentry/node', () => ({
+  withScope: jest.fn((cb) => cb({
+    setTag: jest.fn(),
+    setExtra: jest.fn(),
+  })),
+  captureException: jest.fn(),
+}));
+
+describe('GlobalExceptionFilter', () => {
+  let filter: GlobalExceptionFilter;
+
+  const mockRequest = (overrides: Record<string, any> = {}) => ({
+    method: 'GET',
+    url: '/test',
+    path: '/test',
+    headers: { accept: 'application/json' },
+    correlationId: 'test-corr-id',
+    user: { tenant_id: 'tenant-1' },
+    ...overrides,
+  });
+
+  const mockResponse = () => {
+    const res: any = {
+      headersSent: false,
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+      send: jest.fn().mockReturnThis(),
+    };
+    return res;
+  };
+
+  const mockHost = (req: any, res: any) => ({
+    switchToHttp: () => ({
+      getRequest: () => req,
+      getResponse: () => res,
+    }),
+  } as any);
+
+  beforeEach(async () => {
+    filter = new GlobalExceptionFilter();
+    jest.clearAllMocks();
+  });
+
+  it('returns { error: { code, message } } for NotFoundException', () => {
+    const req = mockRequest();
+    const res = mockResponse();
+    const exception = new NotFoundException('App not found');
+
+    filter.catch(exception, mockHost(req, res));
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({
+      error: { code: 'NOT_FOUND', message: 'App not found' },
+    });
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it('returns { error: { code, message } } for ForbiddenException', () => {
+    const req = mockRequest();
+    const res = mockResponse();
+    const exception = new ForbiddenException('Access denied');
+
+    filter.catch(exception, mockHost(req, res));
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({
+      error: { code: 'FORBIDDEN', message: 'Access denied' },
+    });
+    expect(Sentry.captureException).not.toHaveBeenCalled();
+  });
+
+  it('handles validation errors with array messages', () => {
+    const req = mockRequest();
+    const res = mockResponse();
+    const exception = new BadRequestException({
+      message: ['email must be an email', 'password should not be empty'],
+      error: 'Bad Request',
+      statusCode: 400,
+    });
+
+    filter.catch(exception, mockHost(req, res));
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: 'email must be an email',
+        details: {
+          validation_errors: ['email must be an email', 'password should not be empty'],
+        },
+      },
+    });
+  });
+
+  it('captures 5xx to Sentry with correlation ID and tenant', () => {
+    const req = mockRequest();
+    const res = mockResponse();
+    const exception = new InternalServerErrorException('Something broke');
+
+    filter.catch(exception, mockHost(req, res));
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(Sentry.withScope).toHaveBeenCalled();
+    expect(Sentry.captureException).toHaveBeenCalled();
+
+    const body = res.json.mock.calls[0][0];
+    expect(body.error.code).toBe('INTERNAL_ERROR');
+    expect(body.request_id).toBe('test-corr-id');
+  });
+
+  it('does not include request_id in 4xx responses', () => {
+    const req = mockRequest();
+    const res = mockResponse();
+    const exception = new NotFoundException('Not found');
+
+    filter.catch(exception, mockHost(req, res));
+
+    const body = res.json.mock.calls[0][0];
+    expect(body.request_id).toBeUndefined();
+  });
+
+  it('captures non-HttpException as 500', () => {
+    const req = mockRequest();
+    const res = mockResponse();
+    const exception = new Error('Unexpected crash');
+
+    filter.catch(exception, mockHost(req, res));
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        error: { code: 'INTERNAL_ERROR', message: 'Internal server error' },
+        request_id: 'test-corr-id',
+      }),
+    );
+    expect(Sentry.captureException).toHaveBeenCalled();
+  });
+
+  it('handles TabbyDomainException with domainCode', () => {
+    const req = mockRequest();
+    const res = mockResponse();
+    const exception = new BatonConflictException('Baton is held by another user', {
+      baton_state: 'HUMAN_CONTROL',
+    });
+
+    filter.catch(exception, mockHost(req, res));
+
+    expect(res.status).toHaveBeenCalledWith(409);
+    expect(res.json).toHaveBeenCalledWith({
+      error: {
+        code: 'BATON_CONFLICT',
+        message: 'Baton is held by another user',
+        details: { baton_state: 'HUMAN_CONTROL' },
+      },
+    });
+  });
+
+  it('handles NoHealthySessionException', () => {
+    const req = mockRequest();
+    const res = mockResponse();
+    const exception = new NoHealthySessionException('No healthy session available', {
+      profile_id: 'prof-1',
+    });
+
+    filter.catch(exception, mockHost(req, res));
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({
+      error: {
+        code: 'NO_HEALTHY_SESSION',
+        message: 'No healthy session available',
+        details: { profile_id: 'prof-1' },
+      },
+    });
+  });
+
+  it('captures CredentialDecryptException to Sentry (5xx)', () => {
+    const req = mockRequest();
+    const res = mockResponse();
+    const exception = new CredentialDecryptException({ artifact_id: 'art-1' });
+
+    filter.catch(exception, mockHost(req, res));
+
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(Sentry.captureException).toHaveBeenCalled();
+    const body = res.json.mock.calls[0][0];
+    expect(body.error.code).toBe('CREDENTIAL_DECRYPT_FAILED');
+    expect(body.request_id).toBe('test-corr-id');
+  });
+
+  it('does not double-send if headers already sent', () => {
+    const req = mockRequest();
+    const res = mockResponse();
+    res.headersSent = true;
+    const exception = new NotFoundException('Not found');
+
+    filter.catch(exception, mockHost(req, res));
+
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it('renders HTML for streaming routes when Accept is text/html', () => {
+    const req = mockRequest({
+      path: '/vnc/some-session-id',
+      headers: { accept: 'text/html' },
+    });
+    const res = mockResponse();
+    const exception = new ForbiddenException('Access denied');
+
+    filter.catch(exception, mockHost(req, res));
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.send).toHaveBeenCalled();
+    const html = res.send.mock.calls[0][0];
+    expect(html).toContain('<!doctype html>');
+    expect(html).toContain('Access denied');
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it('returns JSON for streaming routes when Accept is application/json', () => {
+    const req = mockRequest({
+      path: '/vnc/some-session-id',
+      headers: { accept: 'application/json' },
+    });
+    const res = mockResponse();
+    const exception = new NotFoundException('Session not found');
+
+    filter.catch(exception, mockHost(req, res));
+
+    expect(res.json).toHaveBeenCalled();
+    expect(res.send).not.toHaveBeenCalled();
+  });
+
+  it('preserves extra fields from ConflictException object body', () => {
+    const req = mockRequest();
+    const res = mockResponse();
+    const exception = new HttpException(
+      { message: 'HITL pause active', retry_after_seconds: 180 },
+      HttpStatus.CONFLICT,
+    );
+
+    filter.catch(exception, mockHost(req, res));
+
+    expect(res.status).toHaveBeenCalledWith(409);
+    const body = res.json.mock.calls[0][0];
+    expect(body.error.code).toBe('CONFLICT');
+    expect(body.error.message).toBe('HITL pause active');
+    expect(body.error.details).toEqual({ retry_after_seconds: 180 });
+  });
+});

--- a/apps/api/src/common/filters/http-exception.filter.ts
+++ b/apps/api/src/common/filters/http-exception.filter.ts
@@ -2,6 +2,8 @@ import { ExceptionFilter, Catch, ArgumentsHost, HttpException, HttpStatus, Logge
 import { Response, Request } from 'express';
 import * as Sentry from '@sentry/node';
 
+const STREAMING_PATH_RE = /^\/(vnc|cdp)\//;
+
 @Catch()
 export class GlobalExceptionFilter implements ExceptionFilter {
   private readonly logger = new Logger(GlobalExceptionFilter.name);
@@ -10,6 +12,8 @@ export class GlobalExceptionFilter implements ExceptionFilter {
     const ctx = host.switchToHttp();
     const response = ctx.getResponse<Response>();
     const request = ctx.getRequest<Request>();
+
+    if (response.headersSent) return;
 
     let status = HttpStatus.INTERNAL_SERVER_ERROR;
     let code = 'INTERNAL_ERROR';
@@ -22,40 +26,84 @@ export class GlobalExceptionFilter implements ExceptionFilter {
 
       if (typeof body === 'object' && body !== null) {
         const obj = body as Record<string, unknown>;
-        message = (obj.message as string) || exception.message;
-        if (Array.isArray(obj.message)) {
+
+        if ((exception as any).domainCode) {
+          code = (exception as any).domainCode;
+          message = (obj.message as string) || exception.message;
+          if (obj.details) details = obj.details as Record<string, unknown>;
+        } else if (Array.isArray(obj.message)) {
+          code = 'VALIDATION_ERROR';
           message = obj.message[0];
           details = { validation_errors: obj.message };
+        } else {
+          message = (obj.message as string) || exception.message;
+          const { message: _m, statusCode: _s, error: _e, ...rest } = obj;
+          if (Object.keys(rest).length > 0) details = rest;
         }
       } else {
         message = String(body);
       }
 
-      switch (status) {
-        case 400: code = 'VALIDATION_ERROR'; break;
-        case 401: code = 'UNAUTHORIZED'; break;
-        case 403: code = 'FORBIDDEN'; break;
-        case 404: code = 'NOT_FOUND'; break;
-        case 409: code = 'CONFLICT'; break;
-        case 429: code = 'RATE_LIMITED'; break;
-        default: code = 'INTERNAL_ERROR';
+      if (!(exception as any).domainCode) {
+        switch (status) {
+          case 400: code = 'VALIDATION_ERROR'; break;
+          case 401: code = 'UNAUTHORIZED'; break;
+          case 403: code = 'FORBIDDEN'; break;
+          case 404: code = 'NOT_FOUND'; break;
+          case 409: code = 'CONFLICT'; break;
+          case 429: code = 'RATE_LIMITED'; break;
+          case 502: code = 'BAD_GATEWAY'; break;
+          case 504: code = 'GATEWAY_TIMEOUT'; break;
+          default: if (status >= 500) code = 'INTERNAL_ERROR';
+        }
       }
     }
 
-    // Send 5xx errors to Sentry for alerting
+    const correlationId: string | undefined = (request as any).correlationId;
+
     if (status >= 500) {
       Sentry.withScope((scope) => {
         scope.setTag('http.method', request.method);
         scope.setTag('http.url', request.url);
         scope.setTag('http.status_code', String(status));
-        scope.setExtra('body', request.body);
+        if (correlationId) scope.setTag('correlation_id', correlationId);
+        const user = (request as any).user;
+        if (user?.tenant_id) scope.setTag('tenant_id', user.tenant_id);
         Sentry.captureException(exception instanceof Error ? exception : new Error(message));
       });
-      this.logger.error(`${request.method} ${request.url} → ${status}: ${message}`, exception instanceof Error ? exception.stack : undefined);
+      this.logger.error(
+        `${request.method} ${request.url} → ${status}: ${message}` +
+        (correlationId ? ` [${correlationId}]` : ''),
+        exception instanceof Error ? exception.stack : undefined,
+      );
     }
 
-    response.status(status).json({
+    if (status >= 400 && STREAMING_PATH_RE.test(request.path)) {
+      const accept = request.headers.accept || '';
+      if (accept.includes('text/html') && !accept.includes('application/json')) {
+        response.status(status).send(renderHtmlError(status, message));
+        return;
+      }
+    }
+
+    const body: Record<string, unknown> = {
       error: { code, message, ...(details ? { details } : {}) },
-    });
+    };
+    if (status >= 500 && correlationId) {
+      body.request_id = correlationId;
+    }
+
+    response.status(status).json(body);
   }
+}
+
+function renderHtmlError(status: number, message: string): string {
+  const safe = message.replace(/[<>&"']/g, c =>
+    ({ '<': '&lt;', '>': '&gt;', '&': '&amp;', '"': '&quot;', "'": '&#39;' })[c]!,
+  );
+  return `<!doctype html>
+<html lang="en"><head><meta charset="utf-8"><title>Error ${status}</title>
+<style>body{font-family:system-ui,sans-serif;display:flex;justify-content:center;align-items:center;min-height:100vh;margin:0;background:#0f172a;color:#e2e8f0}
+.box{text-align:center;max-width:400px;padding:2rem}.code{font-size:3rem;font-weight:700;color:#f87171}.msg{margin-top:1rem;color:#94a3b8}</style>
+</head><body><div class="box"><div class="code">${status}</div><div class="msg">${safe}</div></div></body></html>`;
 }

--- a/apps/api/src/common/helpers/role-resolver.helper.ts
+++ b/apps/api/src/common/helpers/role-resolver.helper.ts
@@ -7,8 +7,10 @@ export function resolveRoleFromIdp(
 ): string {
   // 1. Check source JWT role claim mapping
   if (idp.role_claim) {
-    const sourceRoles: string[] = Array.isArray(verifiedPayload[idp.role_claim])
-      ? (verifiedPayload[idp.role_claim] as string[])
+    const raw = verifiedPayload[idp.role_claim];
+    const sourceRoles: string[] = Array.isArray(raw)
+      ? raw.map((r: unknown) => typeof r === 'object' && r !== null && 'key' in r ? String((r as Record<string, unknown>).key) : String(r))
+      : typeof raw === 'string' ? [raw]
       : [];
     if (idp.admin_role_values?.some(v => sourceRoles.includes(v))) {
       return 'Admin';

--- a/apps/api/src/common/middleware/correlation-id.middleware.spec.ts
+++ b/apps/api/src/common/middleware/correlation-id.middleware.spec.ts
@@ -1,0 +1,34 @@
+import { CorrelationIdMiddleware } from './correlation-id.middleware';
+
+describe('CorrelationIdMiddleware', () => {
+  let middleware: CorrelationIdMiddleware;
+
+  beforeEach(() => {
+    middleware = new CorrelationIdMiddleware();
+  });
+
+  it('uses incoming X-Request-ID header', () => {
+    const req: any = { headers: { 'x-request-id': 'incoming-123' } };
+    const res: any = { setHeader: jest.fn() };
+    const next = jest.fn();
+
+    middleware.use(req, res, next);
+
+    expect(req.correlationId).toBe('incoming-123');
+    expect(res.setHeader).toHaveBeenCalledWith('X-Request-ID', 'incoming-123');
+    expect(next).toHaveBeenCalled();
+  });
+
+  it('generates UUID when no X-Request-ID header', () => {
+    const req: any = { headers: {} };
+    const res: any = { setHeader: jest.fn() };
+    const next = jest.fn();
+
+    middleware.use(req, res, next);
+
+    expect(req.correlationId).toBeDefined();
+    expect(req.correlationId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    expect(res.setHeader).toHaveBeenCalledWith('X-Request-ID', req.correlationId);
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/apps/api/src/common/middleware/correlation-id.middleware.ts
+++ b/apps/api/src/common/middleware/correlation-id.middleware.ts
@@ -1,0 +1,13 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import { randomUUID } from 'crypto';
+
+@Injectable()
+export class CorrelationIdMiddleware implements NestMiddleware {
+  use(req: Request, _res: Response, next: NextFunction) {
+    const id = req.headers['x-request-id'] as string || randomUUID();
+    (req as any).correlationId = id;
+    _res.setHeader('X-Request-ID', id);
+    next();
+  }
+}

--- a/apps/api/src/common/types/express.d.ts
+++ b/apps/api/src/common/types/express.d.ts
@@ -1,0 +1,5 @@
+declare namespace Express {
+  interface Request {
+    correlationId: string;
+  }
+}

--- a/apps/api/src/modules/app-templates/app-templates.controller.ts
+++ b/apps/api/src/modules/app-templates/app-templates.controller.ts
@@ -79,6 +79,9 @@ class UpdateAppTemplateDto {
   @IsOptional() @IsBoolean() execute_enabled?: boolean;
   @ApiProperty({ required: false })
   @IsOptional() @IsInt() @Min(60) idle_shutdown_seconds?: number;
+  @ApiProperty({ required: false, description: 'Extra egress domains propagated to linked apps' })
+  @IsOptional() @IsArray() @IsString({ each: true })
+  extra_egress_allowlist?: string[];
 }
 
 @ApiTags('App Templates')

--- a/apps/api/src/modules/app-templates/app-templates.service.spec.ts
+++ b/apps/api/src/modules/app-templates/app-templates.service.spec.ts
@@ -144,6 +144,7 @@ describe('AppTemplatesService — propagation', () => {
         export_policy: template.export_policy,
         notification_config: template.notification_config,
         execute_enabled: template.execute_enabled,
+        extra_egress_allowlist: template.extra_egress_allowlist,
       };
 
       expect(appRepo.update).toHaveBeenCalledWith('app-1', expectedPayload);

--- a/apps/api/src/modules/app-templates/app-templates.service.ts
+++ b/apps/api/src/modules/app-templates/app-templates.service.ts
@@ -162,6 +162,7 @@ export class AppTemplatesService {
       const apps = await this.appRepo.find({
         where: { template_id: template.id },
         select: ['id'],
+        order: { id: 'ASC' },
         take: CHUNK_SIZE,
         skip: offset,
       });

--- a/apps/api/src/modules/app-templates/app-templates.service.ts
+++ b/apps/api/src/modules/app-templates/app-templates.service.ts
@@ -92,6 +92,7 @@ export class AppTemplatesService {
   private static readonly PROPAGATED_FIELDS = [
     'browser_policy', 'login_config', 'keepalive_config',
     'export_policy', 'notification_config', 'execute_enabled',
+    'extra_egress_allowlist',
   ] as const;
 
   /** Bump minor version, reset patch. e.g. "1.0.0" → "1.1.0", "2.5.3" → "2.6.0" */
@@ -114,6 +115,7 @@ export class AppTemplatesService {
       credential_ref_default: template.credential_ref_default,
       execute_enabled: template.execute_enabled,
       idle_shutdown_seconds: template.idle_shutdown_seconds,
+      extra_egress_allowlist: template.extra_egress_allowlist,
     };
     return createHash('sha256')
       .update(AppTemplatesService.stableStringify(fields))

--- a/apps/api/src/modules/apps/apps.controller.ts
+++ b/apps/api/src/modules/apps/apps.controller.ts
@@ -55,7 +55,7 @@ export class AppsController {
   }
 
   @Get(':id')
-  @Roles('Admin', 'Operator', 'Viewer')
+  @Roles('Admin', 'Editor', 'Operator', 'Viewer')
   @ApiOperation({ summary: 'Get application details' })
   @ApiParam({ name: 'id', description: 'Application UUID' })
   @ApiResponse({ status: 200 })

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -587,7 +587,7 @@ export class AuthController implements OnModuleDestroy {
 
     // Fetch user info
     const claims = await this.oauthProvider.fetchUserInfo(idp, tokens.access_token);
-    this.logger.log(`OAuth userinfo claims keys: ${Object.keys(claims).join(', ')} | roles raw: ${JSON.stringify(claims['roles'])} | type: ${typeof claims['roles']}`);
+    this.logger.debug(`OAuth userinfo keys: ${Object.keys(claims).join(', ')} | roles type: ${typeof claims['roles']}, isArray: ${Array.isArray(claims['roles'])}`);
     const { userId, email, name, tenantIdClaimValue } = this.oauthProvider.extractIdentity(idp, claims);
 
     if (!userId) throw new UnauthorizedException('Could not extract user identity from userinfo');

--- a/apps/api/src/modules/auth/auth.controller.ts
+++ b/apps/api/src/modules/auth/auth.controller.ts
@@ -154,6 +154,7 @@ class TokenExchangeDto {
 
 /** Module-level constant — avoids repeating the env-read inline everywhere. */
 const PUBLIC_BASE_URL = process.env.PUBLIC_BASE_URL || 'http://localhost:18080';
+const ADMIN_UI_BASE_URL = process.env.ADMIN_UI_BASE_URL || '';
 
 // OAuth state payload stored in Redis under oauth:state:{hex} (5-min TTL)
 interface OAuthStatePayload {
@@ -586,6 +587,7 @@ export class AuthController implements OnModuleDestroy {
 
     // Fetch user info
     const claims = await this.oauthProvider.fetchUserInfo(idp, tokens.access_token);
+    this.logger.log(`OAuth userinfo claims keys: ${Object.keys(claims).join(', ')} | roles raw: ${JSON.stringify(claims['roles'])} | type: ${typeof claims['roles']}`);
     const { userId, email, name, tenantIdClaimValue } = this.oauthProvider.extractIdentity(idp, claims);
 
     if (!userId) throw new UnauthorizedException('Could not extract user identity from userinfo');
@@ -702,13 +704,14 @@ export class AuthController implements OnModuleDestroy {
       postLoginRedirectUri = `${postLoginRedirectUri}${sep}token=${encodeURIComponent(stored.streamToken)}`;
     }
 
-    // Only allow relative paths or same-origin URLs (prevent open redirect + JWT leak)
+    // Only allow relative paths, same-origin, or admin-UI origin (prevent open redirect + JWT leak)
     const isRelative = postLoginRedirectUri.startsWith('/');
     if (!isRelative) {
       try {
         const parsed = new URL(postLoginRedirectUri);
-        const allowed = new URL(PUBLIC_BASE_URL);
-        if (parsed.origin !== allowed.origin) {
+        const allowedOrigins = [new URL(PUBLIC_BASE_URL).origin];
+        if (ADMIN_UI_BASE_URL) allowedOrigins.push(new URL(ADMIN_UI_BASE_URL).origin);
+        if (!allowedOrigins.includes(parsed.origin)) {
           throw new UnauthorizedException('post_login must be a relative path or same-origin URL');
         }
       } catch (e) {

--- a/apps/api/src/modules/credentials/credentials.service.ts
+++ b/apps/api/src/modules/credentials/credentials.service.ts
@@ -1,4 +1,9 @@
 import { ForbiddenException, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import {
+  NoHealthySessionException,
+  ProfileNotFoundException,
+  CredentialDecryptException,
+} from '../../common/exceptions/domain.exceptions';
 import { InjectRepository } from '@nestjs/typeorm';
 import { In, IsNull, MoreThan, Repository } from 'typeorm';
 import {
@@ -129,7 +134,7 @@ export class CredentialsService {
     try {
       session = await this.findHealthySession(tenantId, profile.app_id, ownerUserId);
     } catch (e) {
-      if (e instanceof NotFoundException && profile.app_id) {
+      if (e instanceof NoHealthySessionException && profile.app_id) {
         // No healthy session — check if app was idle-shutdown (desired_session_count=0)
         // If so, scale it back up so the controller creates a new session
         const app = await this.appRepo.findOne({ where: { id: profile.app_id } });
@@ -270,7 +275,7 @@ export class CredentialsService {
           throw err;
         }
       }
-      throw new NotFoundException(`No active profile found for "${profileId}"`);
+      throw new ProfileNotFoundException(`No active profile found for "${profileId}"`, { profile_id: profileId });
     }
 
     // Prefer ACTIVE over CANARY
@@ -372,7 +377,7 @@ export class CredentialsService {
 
     const session = await this.sessionRepo.findOne({ where });
     if (!session) {
-      throw new NotFoundException('No healthy session available');
+      throw new NoHealthySessionException('No healthy session available', { tenant_id: tenantId, app_id: appId });
     }
     return session;
   }
@@ -448,8 +453,8 @@ export class CredentialsService {
     try {
       decryptedJson = this.decryptBundle(encryptedBuf, nonceBuf);
     } catch (err) {
-      this.logger.warn(`Failed to decrypt artifact ${bundle.id}: ${(err as Error).message} (nonce type=${typeof bundle.nonce}, isBuffer=${Buffer.isBuffer(bundle.nonce)}, len=${nonceBuf.length})`);
-      return null;
+      this.logger.error(`Failed to decrypt artifact ${bundle.id}: ${(err as Error).message} (nonce type=${typeof bundle.nonce}, isBuffer=${Buffer.isBuffer(bundle.nonce)}, len=${nonceBuf.length})`);
+      throw new CredentialDecryptException({ artifact_id: bundle.id });
     } finally {
       // Zero the encrypted buffer
       encryptedBuf.fill(0);

--- a/apps/api/src/modules/events/events.gateway.ts
+++ b/apps/api/src/modules/events/events.gateway.ts
@@ -8,6 +8,7 @@ import {
 import { IncomingMessage } from 'http';
 import { NatsConnection, StringCodec, Subscription } from 'nats';
 import { requireEnv, connectNats } from '@browser-hitl/shared';
+import * as Sentry from '@sentry/node';
 import { AuthService } from '../auth/auth.service';
 import { AuditService } from '../audit/audit.service';
 import { ObservabilityService } from '../observability/observability.service';
@@ -148,6 +149,7 @@ export class EventsGateway
         }
       } catch (error) {
         this.logger.error(`Error processing NATS message on ${sub.getSubject()}: ${error}`);
+        Sentry.captureException(error instanceof Error ? error : new Error(String(error)));
       }
     }
   }

--- a/apps/api/src/modules/hitl/hitl.service.ts
+++ b/apps/api/src/modules/hitl/hitl.service.ts
@@ -3,10 +3,11 @@ import {
   NotFoundException,
   ConflictException,
   BadRequestException,
-  UnauthorizedException,
+  InternalServerErrorException,
   Logger,
   OnModuleDestroy,
 } from '@nestjs/common';
+import { BatonConflictException } from '../../common/exceptions/domain.exceptions';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, DataSource } from 'typeorm';
 import { SessionEntity, SessionBatonEntity, InterventionEntity } from '../../entities';
@@ -123,12 +124,15 @@ export class HitlService implements OnModuleDestroy {
       await this.applyBatonTimeoutState(manager, baton);
 
       if (baton.baton_state === 'HUMAN_CONTROL' && baton.owner_user_id !== actorId) {
-        throw new ConflictException('Baton is held by another user');
+        throw new BatonConflictException('Baton is held by another user', {
+          baton_state: baton.baton_state,
+        });
       }
       const takeoverReady = baton.baton_state === 'HUMAN_REQUESTED' || baton.baton_state === 'HUMAN_RELEASED';
       if (!takeoverReady && baton.owner_user_id !== actorId) {
-        throw new ConflictException(
+        throw new BatonConflictException(
           `Baton must be HUMAN_REQUESTED or HUMAN_RELEASED for takeover. Current state: ${baton.baton_state}`,
+          { baton_state: baton.baton_state },
         );
       }
 
@@ -189,11 +193,15 @@ export class HitlService implements OnModuleDestroy {
       await this.applyBatonTimeoutState(manager, baton);
 
       if (baton.baton_state !== 'HUMAN_CONTROL') {
-        throw new ConflictException('Baton is not in HUMAN_CONTROL state');
+        throw new BatonConflictException('Baton is not in HUMAN_CONTROL state', {
+          baton_state: baton.baton_state,
+        });
       }
 
       if (baton.owner_user_id !== actorId && actorRole !== 'Admin') {
-        throw new ConflictException('Only the baton holder can release it');
+        throw new BatonConflictException('Only the baton holder can release it', {
+          baton_state: baton.baton_state,
+        });
       }
 
       baton.baton_state = 'HUMAN_RELEASED';
@@ -414,7 +422,7 @@ export class HitlService implements OnModuleDestroy {
     try {
       return JSON.parse(raw) as T;
     } catch {
-      throw new UnauthorizedException('Corrupt idempotency cache entry');
+      throw new InternalServerErrorException('Corrupt idempotency cache entry');
     }
   }
 

--- a/apps/api/src/modules/streaming/streaming.controller.ts
+++ b/apps/api/src/modules/streaming/streaming.controller.ts
@@ -905,7 +905,7 @@ export class CdpStreamingController {
                 stUptime.textContent = Math.round((Date.now() - new Date(data.started_at).getTime()) / 60000) + 'm';
               }
               if (data.state === 'TERMINATED') { sessionTerminated = true; handleTerminated(); return; }
-              if (fromMcp && data.state === 'HEALTHY') { window.close(); }
+              if (!recordingMode && data.state === 'HEALTHY') { window.close(); }
               if (!fromMcp) return;
               var pending = data.pending_input_request;
               if (pending && pending.step_index != null) {
@@ -1787,7 +1787,7 @@ export class StreamingController {
                 stUptime.textContent = Math.round((Date.now() - new Date(data.started_at).getTime()) / 60000) + 'm';
               }
               if (data.state === 'TERMINATED') { sessionTerminated = true; handleTerminated(); return; }
-              if (fromMcp && data.state === 'HEALTHY') { window.close(); }
+              if (!recordingMode && data.state === 'HEALTHY') { window.close(); }
               if (!fromMcp) return;
               var pending = data.pending_input_request;
               if (pending && pending.step_index != null) {

--- a/apps/api/src/modules/streaming/streaming.controller.ts
+++ b/apps/api/src/modules/streaming/streaming.controller.ts
@@ -905,7 +905,7 @@ export class CdpStreamingController {
                 stUptime.textContent = Math.round((Date.now() - new Date(data.started_at).getTime()) / 60000) + 'm';
               }
               if (data.state === 'TERMINATED') { sessionTerminated = true; handleTerminated(); return; }
-              if (data.state === 'HEALTHY') { window.close(); }
+              if (fromMcp && data.state === 'HEALTHY') { window.close(); }
               if (!fromMcp) return;
               var pending = data.pending_input_request;
               if (pending && pending.step_index != null) {
@@ -1787,7 +1787,7 @@ export class StreamingController {
                 stUptime.textContent = Math.round((Date.now() - new Date(data.started_at).getTime()) / 60000) + 'm';
               }
               if (data.state === 'TERMINATED') { sessionTerminated = true; handleTerminated(); return; }
-              if (data.state === 'HEALTHY') { window.close(); }
+              if (fromMcp && data.state === 'HEALTHY') { window.close(); }
               if (!fromMcp) return;
               var pending = data.pending_input_request;
               if (pending && pending.step_index != null) {

--- a/apps/api/src/modules/streaming/streaming.controller.ts
+++ b/apps/api/src/modules/streaming/streaming.controller.ts
@@ -905,6 +905,7 @@ export class CdpStreamingController {
                 stUptime.textContent = Math.round((Date.now() - new Date(data.started_at).getTime()) / 60000) + 'm';
               }
               if (data.state === 'TERMINATED') { sessionTerminated = true; handleTerminated(); return; }
+              if (data.state === 'HEALTHY') { window.close(); }
               if (!fromMcp) return;
               var pending = data.pending_input_request;
               if (pending && pending.step_index != null) {
@@ -1786,6 +1787,7 @@ export class StreamingController {
                 stUptime.textContent = Math.round((Date.now() - new Date(data.started_at).getTime()) / 60000) + 'm';
               }
               if (data.state === 'TERMINATED') { sessionTerminated = true; handleTerminated(); return; }
+              if (data.state === 'HEALTHY') { window.close(); }
               if (!fromMcp) return;
               var pending = data.pending_input_request;
               if (pending && pending.step_index != null) {

--- a/apps/api/src/modules/tenants/tenants.service.ts
+++ b/apps/api/src/modules/tenants/tenants.service.ts
@@ -2,6 +2,7 @@ import { Injectable, ConflictException, NotFoundException, Logger } from '@nestj
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository, DataSource } from 'typeorm';
 import * as crypto from 'crypto';
+import * as Sentry from '@sentry/node';
 import { TenantEntity } from '../../entities';
 import { AuditService } from '../audit/audit.service';
 import { MinioProvisionerService } from './minio-provisioner.service';
@@ -46,7 +47,11 @@ export class TenantsService {
       this.logger.error(
         `Failed to provision MinIO bucket for tenant ${saved.id}: ${(err as Error).message}`,
       );
-      // Non-fatal: tenant is created, bucket can be provisioned later
+      Sentry.withScope((scope) => {
+        scope.setTag('tenant_id', saved.id);
+        scope.setTag('warn_context', 'minio_provision_failed');
+        Sentry.captureException(err instanceof Error ? err : new Error(String(err)));
+      });
     }
 
     await this.auditService.log({

--- a/charts/browser-hitl/templates/configmap.yaml
+++ b/charts/browser-hitl/templates/configmap.yaml
@@ -32,6 +32,9 @@ data:
   NATS_STREAM_MAX_AGE_HOURS: {{ .Values.config.natsStreamMaxAgeHours | default "8" | quote }}
   MINIO_ORPHAN_MAX_AGE_HOURS: {{ .Values.config.minioOrphanMaxAgeHours | default "2" | quote }}
   PUBLIC_BASE_URL: {{ .Values.config.publicBaseUrl | quote }}
+  {{- if .Values.config.adminUiBaseUrl }}
+  ADMIN_UI_BASE_URL: {{ .Values.config.adminUiBaseUrl | quote }}
+  {{- end }}
   STREAM_HOST: {{ .Values.config.streamHost | quote }}
   STREAM_PROTOCOL: {{ .Values.config.streamProtocol | quote }}
   SERVICE_AUTH_ALLOWED_TENANT_IDS: {{ .Values.config.serviceAuthAllowedTenantIds | quote }}

--- a/charts/browser-hitl/values-local.yaml
+++ b/charts/browser-hitl/values-local.yaml
@@ -289,6 +289,9 @@ egressProxy:
     # --- Automation Anywhere ---
     - ".automationanywhere.digital"
     - ".automationanywhere.com"
+    - ".goskope.com"
+    - ".okta.com"
+    - ".oktacdn.com"
     # --- Salesforce analytics (Pendo) ---
     - ".pendo.io"
     - ".pendo-static-5673999629942784.storage.googleapis.com"

--- a/charts/browser-hitl/values-local.yaml
+++ b/charts/browser-hitl/values-local.yaml
@@ -140,6 +140,7 @@ networkPolicies:
 # Local config overrides
 config:
   publicBaseUrl: "http://localhost:18080"
+  adminUiBaseUrl: "http://localhost:13000"
   streamHost: "localhost:18080"
   streamProtocol: "ws"
   serviceAuthAllowedTenantIds: "*"

--- a/docs/HIGH_LEVEL_ARCHITECTURE.md
+++ b/docs/HIGH_LEVEL_ARCHITECTURE.md
@@ -19,7 +19,7 @@ graph TB
         WORKER["Worker Pods<br/>Playwright + Chromium"]
         SLACK["Slack Bot"]
         TEAMS["Teams Bot"]
-        ADMIN["Admin UI<br/>Next.js"]
+        ADMIN["Admin UI<br/>React + Vite"]
     end
 
     subgraph Infrastructure

--- a/docs/HIGH_LEVEL_ARCHITECTURE.md
+++ b/docs/HIGH_LEVEL_ARCHITECTURE.md
@@ -1,0 +1,318 @@
+# Tabby — High-Level Architecture
+
+## System Context
+
+Tabby is a browser infrastructure service that provisions Chromium sessions, automates login flows, handles human-in-the-loop (HITL) intervention, and extracts credentials (cookies, tokens, headers) for AI agent consumption.
+
+```mermaid
+graph TB
+    subgraph Callers
+        PLAT["Adopt Platform<br/>(adoptwebui)"]
+        MCP["MCP Server<br/>(python-mcp)"]
+        NOUI["NoUI"]
+        A3["ProjectA3 Executor<br/>(via:tabby WDL steps)"]
+    end
+
+    subgraph Tabby
+        API["Tabby API<br/>NestJS · port 8000"]
+        CTRL["Controller<br/>Reconcile loop · 15s"]
+        WORKER["Worker Pods<br/>Playwright + Chromium"]
+        SLACK["Slack Bot"]
+        TEAMS["Teams Bot"]
+        ADMIN["Admin UI<br/>Next.js"]
+    end
+
+    subgraph Infrastructure
+        PG[(PostgreSQL)]
+        REDIS[(Redis)]
+        NATS[NATS JetStream]
+        MINIO[(MinIO)]
+    end
+
+    subgraph Human Access
+        VNC["VNC / noVNC Viewer"]
+        CDP["CDP Canvas Viewer"]
+    end
+
+    PLAT -->|"token exchange +<br/>credentials/request"| API
+    MCP -->|"via platform<br/>direct-signal"| PLAT
+    NOUI -->|"execute/browser +<br/>app templates"| API
+    A3 -->|"execute/fetch"| API
+
+    API --> PG
+    API --> REDIS
+    API --> MINIO
+    CTRL --> PG
+    CTRL --> NATS
+    CTRL -->|"K8s API<br/>create/destroy"| WORKER
+    SLACK --> NATS
+    TEAMS --> NATS
+    ADMIN --> API
+
+    WORKER --> VNC
+    WORKER --> CDP
+    WORKER -->|"artifacts<br/>(encrypted)"| MINIO
+```
+
+## Internal Components
+
+```mermaid
+graph LR
+    subgraph "apps/api"
+        AUTH[Auth Module<br/>JWT · OAuth · Token Exchange]
+        CRED[Credentials Module<br/>Decrypt · Deliver]
+        HITL[HITL Module<br/>Baton · Input · Stream]
+        EXEC[Execute Module<br/>fetch · browser commands]
+        STREAM[Streaming Module<br/>VNC/CDP viewer · WS proxy]
+        AGENT[Agent Module<br/>run-url · session-status]
+        TMPL[App Templates Module<br/>Auto-provisioning blueprints]
+        APPS[Apps Module<br/>Application CRUD]
+        PROF[Profiles Module<br/>Service profile lifecycle]
+        SESS[Sessions Module<br/>Session listing · scaling]
+        EVENTS[Events Gateway<br/>NATS → WebSocket relay]
+    end
+
+    subgraph "apps/controller"
+        RECON[Reconcile Service<br/>FOR UPDATE SKIP LOCKED]
+        SM[State Machine<br/>Session transitions · HITL]
+        POD[Pod Manager<br/>K8s pod/svc/netpol lifecycle]
+        NATS_PUB[NATS Publisher<br/>hitl.started · session.state]
+    end
+
+    subgraph "apps/worker"
+        DSL[Login DSL Runner<br/>16 step types]
+        HEALTH[Health Predicate<br/>url_check · dom_check]
+        EXTRACT[Artifact Extractor<br/>cookies · headers · custom JS]
+        INPUT[Input Relay<br/>Redis poll for human input]
+        CDPRELAY[CDP Relay Server<br/>port 9223]
+        EXECHDL[Execute Handlers<br/>fetch · browser commands]
+    end
+
+    subgraph "packages/shared"
+        TYPES[DSL Types · Enums<br/>State Machine · Constants<br/>Redis Keys · NATS Subjects<br/>Credential Envelope Types]
+    end
+```
+
+## Session State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> STARTING: Controller creates session + pod
+    STARTING --> HEALTHY: Health predicate PASS
+    STARTING --> LOGIN_NEEDED: Health predicate AUTH_FAIL
+    STARTING --> FAILED: TRANSIENT_FAIL (max retries)
+
+    LOGIN_NEEDED --> LOGIN_IN_PROGRESS: Controller creates intervention
+    LOGIN_IN_PROGRESS --> HEALTHY: Human resolves + health PASS
+    LOGIN_IN_PROGRESS --> LOGIN_NEEDED: New input request (sequential)
+    LOGIN_IN_PROGRESS --> FAILED: Timeout / max attempts
+
+    HEALTHY --> UNHEALTHY: Keepalive health check fails
+    HEALTHY --> TERMINATED: desired=0 / idle shutdown / max age
+
+    UNHEALTHY --> HEALTHY: Health recovers
+    UNHEALTHY --> LOGIN_NEEDED: AUTH_FAIL detected
+    UNHEALTHY --> FAILED: Max retries exceeded
+
+    FAILED --> TERMINATED: Cleanup
+    TERMINATED --> [*]
+```
+
+## Baton State Machine
+
+```mermaid
+stateDiagram-v2
+    AUTOMATION_CONTROL --> HUMAN_REQUESTED: Controller detects AUTH_FAIL
+    HUMAN_REQUESTED --> HUMAN_CONTROL: Human takes over (VNC/Slack)
+    HUMAN_CONTROL --> HUMAN_RELEASED: Human clicks resolve
+    HUMAN_RELEASED --> AUTOMATION_CONTROL: Worker resumes
+```
+
+## Credential Request Flow
+
+```mermaid
+sequenceDiagram
+    participant C as Caller
+    participant API as Tabby API
+    participant R as Redis
+    participant W as Worker
+    participant M as MinIO
+
+    C->>API: POST /credentials/request {profile_id}
+    API->>API: Resolve ACTIVE profile + HEALTHY session
+
+    alt Session HEALTHY
+        API->>M: Fetch encrypted artifact bundle
+        M-->>API: AES-256-GCM bundle
+        API->>API: Decrypt + buildCredentialSet
+        API-->>C: CredentialResponseEnvelope
+    else No session (auto-provision)
+        API->>API: Find matching App Template
+        API->>API: Clone → Application + Profile + Session
+        Note over API: Controller picks up session on next reconcile
+    else Session not HEALTHY
+        API-->>C: 404 (caller polls session-status)
+    end
+```
+
+## HITL Flow
+
+```mermaid
+sequenceDiagram
+    participant W as Worker
+    participant DB as Postgres
+    participant CTRL as Controller
+    participant NATS as NATS
+    participant SB as Slack Bot
+    participant H as Human
+    participant R as Redis
+
+    W->>DB: pending_input_request + AUTH_FAIL
+    CTRL->>DB: Detect AUTH_FAIL → transition LOGIN_NEEDED
+    CTRL->>DB: Create intervention + set baton HUMAN_REQUESTED
+    CTRL->>DB: Transition → LOGIN_IN_PROGRESS
+    CTRL->>NATS: hitl.started.{tenant}.{session}
+    NATS->>SB: Deliver event
+    SB->>H: Slack message with buttons
+
+    alt OTP / Password
+        H->>SB: Submit via Slack modal
+        SB->>R: SET human_input:{session}:{step}
+    else VNC Confirm
+        H->>API: POST /sessions/:id/input {confirm, resolved}
+        API->>R: SET human_input:{session}:{step}
+    end
+
+    W->>R: Poll human_input:{session}:{step}
+    R-->>W: Value received
+    W->>W: Continue DSL execution
+    W->>DB: Health check PASS
+    CTRL->>DB: Transition → HEALTHY
+    CTRL->>NATS: hitl.completed.{tenant}.{session}
+```
+
+## Platform Integration
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant FE as Platform Frontend
+    participant BE as Platform Backend
+    participant T as Tabby API
+    participant TW as Temporal Workflows
+    participant A3 as ProjectA3
+
+    U->>FE: Execute action
+    FE->>BE: POST /v1/conversations/{id}/message
+
+    Note over BE: tabby_resolution_service.py
+
+    BE->>BE: Check deployment rules (use_tabby?)
+    BE->>BE: Check feature flag ("tabby" enabled?)
+    BE->>T: POST /auth/token-exchange (Frontegg JWT)
+    T-->>BE: Tabby JWT (cached ~59 min)
+    BE->>T: POST /credentials/request
+
+    alt HEALTHY
+        T-->>BE: Credential envelope
+        BE->>BE: Extract values via credential_path
+        BE->>TW: Dispatch with resolved headers
+        TW->>A3: Execute WDL
+    else HITL needed
+        T-->>BE: 404 → poll session-status
+        BE-->>FE: tabby_hitl_required + VNC grant
+        FE-->>U: Show VNC viewer
+        U->>FE: Login + Mark as Resolved
+        FE->>BE: POST /tabby-resolve-hitl
+        BE->>T: POST /sessions/:id/input
+    end
+```
+
+## Deployment Architecture
+
+```mermaid
+graph TB
+    subgraph "Kubernetes Cluster"
+        subgraph "Static Pods (Helm-managed)"
+            API_POD["API Pod<br/>replicas: 1-4"]
+            CTRL_POD["Controller Pod<br/>replicas: 1-3"]
+            SLACK_POD["Slack Bot Pod"]
+            TEAMS_POD["Teams Bot Pod"]
+            ADMIN_POD["Admin UI Pod"]
+            PG_POD["PostgreSQL"]
+            REDIS_POD["Redis"]
+            NATS_POD["NATS"]
+            MINIO_POD["MinIO"]
+        end
+
+        subgraph "Dynamic Pods (Controller-managed)"
+            W1["Worker Pod<br/>Chromium + noVNC sidecar"]
+            W2["Worker Pod"]
+            WN["Worker Pod N"]
+        end
+    end
+
+    CTRL_POD -->|"K8s API"| W1
+    CTRL_POD -->|"K8s API"| W2
+    CTRL_POD -->|"K8s API"| WN
+```
+
+### Cloud vs On-Prem
+
+| Aspect | Cloud (TrueFoundry) | On-Prem (Helm) |
+|---|---|---|
+| Deployment | `tfy apply` (ArgoCD) | `helm upgrade` |
+| Chart | `adopt-tabby` subchart in `adoptapp` umbrella | Standalone `browser-hitl` chart |
+| Images | `ghcr.io/adoptai/tabby/*` | Customer registry |
+| Ingress | Istio VirtualService | Ingress / VirtualService |
+| Hosts | `tabby-api.*` + `tabby-admin.*` (two-host required) | Same |
+| IdP | Frontegg (shared) | Customer IdP (OIDC/SAML) |
+| Infra | Embedded PG/Redis/NATS/MinIO | External managed services supported |
+
+## Authentication
+
+```mermaid
+graph LR
+    subgraph "Token Types"
+        FED["Federated JWT<br/>Platform user via token-exchange"]
+        AGENT["Agent JWT<br/>Bot via client credentials"]
+        SVC["Service Token<br/>Internal service auth"]
+        HUMAN["Human JWT<br/>Direct login (admin)"]
+        VNC_TOK["VNC Cookie<br/>OAuth callback · 1h"]
+        STREAM["Stream Token<br/>Single-use · 10min"]
+    end
+
+    subgraph "Roles (5)"
+        ADMIN["Admin — full access"]
+        EDITOR["Editor — apps, templates, profiles"]
+        OPERATOR["Operator — sessions, VNC, HITL"]
+        VIEWER["Viewer — read-only"]
+        AGENT_R["Agent — scoped to allowed_profiles"]
+    end
+
+    FED --> EDITOR
+    FED --> OPERATOR
+    AGENT --> AGENT_R
+    HUMAN --> ADMIN
+    SVC --> OPERATOR
+```
+
+## Key Data Stores
+
+| Store | What it holds |
+|---|---|
+| **PostgreSQL** | Tenants, users, applications, sessions, profiles, interventions, artifacts, audit log, circuit breaker, IdP config, agent clients, app templates |
+| **Redis** | Human input relay, stream tokens, JWT blacklist, extract locks, OAuth state, short links, VNC auth, rate limits |
+| **NATS JetStream** | `hitl.started.*`, `hitl.completed.*`, `session.state.changed.*`, `auth.bundle.exported.*` |
+| **MinIO** | Encrypted credential artifact bundles (AES-256-GCM) |
+
+## Key Ports
+
+| Service | Port |
+|---|---|
+| API | 8000 |
+| Controller health | 8090 |
+| Worker health | 8091 |
+| Admin UI | 8000 |
+| noVNC sidecar | 6080 |
+| CDP relay | 9223 |

--- a/infra/docker/Dockerfile.admin-ui
+++ b/infra/docker/Dockerfile.admin-ui
@@ -1,12 +1,29 @@
-# Admin UI Dockerfile (Phase 2 placeholder runtime)
-FROM node:20-slim@sha256:f93745c153377ee2fbbdd6e24efcd03cd2e86d6ab1d8aa9916a3790c40313a55
-
+# Stage 1: Build
+FROM node:20-slim AS builder
+RUN corepack enable && corepack prepare pnpm@9 --activate
 WORKDIR /app
+COPY pnpm-lock.yaml pnpm-workspace.yaml package.json ./
+COPY apps/admin-ui/package.json apps/admin-ui/
+COPY packages/shared/package.json packages/shared/
+RUN pnpm install --frozen-lockfile --filter @browser-hitl/admin-ui...
+COPY packages/shared/ packages/shared/
+COPY apps/admin-ui/ apps/admin-ui/
+RUN cd apps/admin-ui && pnpm run build
 
-COPY apps/admin-ui/server.js ./server.js
-
+# Stage 2: Serve (non-root compatible)
+FROM nginx:1.27-alpine
+RUN mkdir -p /var/cache/nginx/client_temp \
+             /var/cache/nginx/proxy_temp \
+             /var/cache/nginx/fastcgi_temp \
+             /var/cache/nginx/uwsgi_temp \
+             /var/cache/nginx/scgi_temp \
+             /var/run \
+    && chown -R 1000:1000 /var/cache/nginx /var/log/nginx \
+    && sed -i 's|/run/nginx.pid|/tmp/nginx.pid|' /etc/nginx/nginx.conf \
+    && chmod -R g+w /usr/share/nginx/html
+COPY --from=builder --chown=1000:1000 /app/apps/admin-ui/dist /usr/share/nginx/html
+COPY --chown=1000:1000 infra/docker/nginx-admin-ui.conf /etc/nginx/conf.d/default.conf
+COPY --chown=1000:1000 infra/docker/entrypoint-admin-ui.sh /docker-entrypoint.d/40-inject-env.sh
+RUN chmod +x /docker-entrypoint.d/40-inject-env.sh
+USER 1000
 EXPOSE 8000
-
-USER node
-
-CMD ["node", "server.js"]

--- a/infra/docker/entrypoint-admin-ui.sh
+++ b/infra/docker/entrypoint-admin-ui.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+API_URL="${NEXT_PUBLIC_API_URL:-http://localhost:8000}"
+
+cat > /usr/share/nginx/html/env.js << ENVEOF
+window.__env = {
+  API_URL: "${API_URL}",
+};
+ENVEOF
+
+echo "[admin-ui] env.js written with API_URL=${API_URL}"

--- a/infra/docker/nginx-admin-ui.conf
+++ b/infra/docker/nginx-admin-ui.conf
@@ -1,0 +1,29 @@
+server {
+    listen 8000;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location /health {
+        access_log off;
+        return 200 '{"status":"ok"}';
+        add_header Content-Type application/json;
+    }
+
+    location /env.js {
+        add_header Cache-Control "no-store, no-cache, must-revalidate";
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+        add_header Cache-Control "no-store" always;
+    }
+
+    location /assets/ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml;
+}

--- a/packages/shared/src/enums.ts
+++ b/packages/shared/src/enums.ts
@@ -31,6 +31,7 @@ export enum HealthResultType {
 
 export enum UserRole {
   ADMIN = 'Admin',
+  EDITOR = 'Editor',
   OPERATOR = 'Operator',
   VIEWER = 'Viewer',
   AGENT = 'Agent',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,28 +38,112 @@ importers:
       '@browser-hitl/shared':
         specifier: workspace:*
         version: link:../../packages/shared
-      '@sentry/node':
-        specifier: ^10.51.0
-        version: 10.51.0
-      next:
-        specifier: ^15.5.16
-        version: 15.5.18(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@hookform/resolvers':
+        specifier: ^3.9.0
+        version: 3.10.0(react-hook-form@7.80.0(react@19.2.4))
+      '@novnc/novnc':
+        specifier: ^1.5.0
+        version: 1.5.0
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.0
+        version: 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-dropdown-menu':
+        specifier: ^2.1.0
+        version: 2.1.18(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-select':
+        specifier: ^2.1.0
+        version: 2.3.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-separator':
+        specifier: ^1.1.0
+        version: 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot':
+        specifier: ^1.1.0
+        version: 1.3.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.0
+        version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-toast':
+        specifier: ^1.2.0
+        version: 1.2.17(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-tooltip':
+        specifier: ^1.1.0
+        version: 1.2.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@tailwindcss/vite':
+        specifier: ^4.0.0
+        version: 4.3.2(vite@6.4.3(@types/node@25.2.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.2))
+      '@tanstack/react-query':
+        specifier: ^5.60.0
+        version: 5.101.1(react@19.2.4)
+      '@tanstack/react-table':
+        specifier: ^8.20.0
+        version: 8.21.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      axios:
+        specifier: '>=1.15.2'
+        version: 1.16.1
+      class-variance-authority:
+        specifier: ^0.7.0
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.0
+        version: 2.1.1
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.4.0
+      lucide-react:
+        specifier: ^0.460.0
+        version: 0.460.0(react@19.2.4)
       react:
         specifier: ^19.0.0
         version: 19.2.4
       react-dom:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
+      react-hook-form:
+        specifier: ^7.54.0
+        version: 7.80.0(react@19.2.4)
+      react-router:
+        specifier: ^7.0.0
+        version: 7.18.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      tailwind-merge:
+        specifier: ^2.6.0
+        version: 2.6.1
+      tailwindcss:
+        specifier: ^4.0.0
+        version: 4.3.1
+      zod:
+        specifier: ^3.23.0
+        version: 3.25.76
+      zustand:
+        specifier: ^5.0.0
+        version: 5.0.14(@types/react@19.2.14)(react@19.2.4)
     devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.6.0
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.1.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/react':
         specifier: ^19.0.0
         version: 19.2.14
       '@types/react-dom':
         specifier: ^19.0.0
         version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.0
+        version: 4.7.0(vite@6.4.3(@types/node@25.2.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.2))
+      jsdom:
+        specifier: ^25.0.0
+        version: 25.0.1
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
+      vite:
+        specifier: ^6.0.0
+        version: 6.4.3(@types/node@25.2.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.2)
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@25.2.3)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.46.0)
 
   apps/api:
     dependencies:
@@ -414,6 +498,9 @@ importers:
 
 packages:
 
+  '@adobe/css-tools@4.5.0':
+    resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
+
   '@angular-devkit/core@17.3.11':
     resolution: {integrity: sha512-vTNDYNsLIWpYk2I969LMQFH29GTsLzxNk/0cLw5q56ARF0v5sIWfHYwGTS88jdDqIpuuettcSczbxeA7EuAmqQ==}
     engines: {node: ^18.13.0 || >=20.9.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
@@ -431,6 +518,9 @@ packages:
   '@angular-devkit/schematics@17.3.11':
     resolution: {integrity: sha512-I5wviiIqiFwar9Pdk30Lujk8FczEEc18i22A5c6Z9lbmhPQdTroDnEQdsfXjy404wPe8H62s0I15o4pmMGfTYQ==}
     engines: {node: ^18.13.0 || >=20.9.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@azure/abort-controller@2.1.2':
     resolution: {integrity: sha512-nBrLsEWm4J2u5LpAPjxADTlq3trDgVZZXHNKabeXZtpq3d3AbN/KGO82R87rdDz5/lYB024rtEf10/q0urNgsA==}
@@ -527,6 +617,10 @@ packages:
 
   '@babel/helper-plugin-utils@7.28.6':
     resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-string-parser@7.27.1':
@@ -641,6 +735,22 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
 
+  '@babel/plugin-transform-react-jsx-self@7.29.7':
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7':
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
@@ -748,6 +858,34 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
+
   '@emnapi/core@1.8.1':
     resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
 
@@ -757,147 +895,324 @@ packages:
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
 
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
   '@fastify/otel@0.18.0':
     resolution: {integrity: sha512-3TASCATfw+ctICSb4ymrv7iCm0qJ0N9CarB+CZ7zIJ7KqNbwI5JjyDL1/sxoC0ccTO1Zyd1iQ+oqncPg5FJXaA==}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
 
-  '@img/colour@1.0.0':
-    resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
-    engines: {node: '>=18'}
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
 
-  '@img/sharp-darwin-arm64@0.34.5':
-    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [darwin]
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
 
-  '@img/sharp-darwin-x64@0.34.5':
-    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [darwin]
+  '@floating-ui/react-dom@2.1.8':
+    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
 
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
-    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
-    cpu: [arm64]
-    os: [darwin]
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
-  '@img/sharp-libvips-darwin-x64@1.2.4':
-    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@img/sharp-libvips-linux-arm64@1.2.4':
-    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@img/sharp-libvips-linux-arm@1.2.4':
-    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
-    cpu: [arm]
-    os: [linux]
-
-  '@img/sharp-libvips-linux-ppc64@1.2.4':
-    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@img/sharp-libvips-linux-riscv64@1.2.4':
-    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@img/sharp-libvips-linux-s390x@1.2.4':
-    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
-    cpu: [s390x]
-    os: [linux]
-
-  '@img/sharp-libvips-linux-x64@1.2.4':
-    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
-    cpu: [x64]
-    os: [linux]
-
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
-    cpu: [x64]
-    os: [linux]
-
-  '@img/sharp-linux-arm64@0.34.5':
-    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [linux]
-
-  '@img/sharp-linux-arm@0.34.5':
-    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm]
-    os: [linux]
-
-  '@img/sharp-linux-ppc64@0.34.5':
-    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@img/sharp-linux-riscv64@0.34.5':
-    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [riscv64]
-    os: [linux]
-
-  '@img/sharp-linux-s390x@0.34.5':
-    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [s390x]
-    os: [linux]
-
-  '@img/sharp-linux-x64@0.34.5':
-    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [linux]
-
-  '@img/sharp-linuxmusl-arm64@0.34.5':
-    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [linux]
-
-  '@img/sharp-linuxmusl-x64@0.34.5':
-    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [linux]
-
-  '@img/sharp-wasm32@0.34.5':
-    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [wasm32]
-
-  '@img/sharp-win32-arm64@0.34.5':
-    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [arm64]
-    os: [win32]
-
-  '@img/sharp-win32-ia32@0.34.5':
-    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [ia32]
-    os: [win32]
-
-  '@img/sharp-win32-x64@0.34.5':
-    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
-    cpu: [x64]
-    os: [win32]
+  '@hookform/resolvers@3.10.0':
+    resolution: {integrity: sha512-79Dv+3mDF7i+2ajj7SkypSKHhl1cbln1OGavqrsF7p6mbUv11xpqpacPsGDCTRvCSjEEIez2ef1NveSVL3b0Ag==}
+    peerDependencies:
+      react-hook-form: ^7.0.0
 
   '@ioredis/commands@1.5.0':
     resolution: {integrity: sha512-eUgLqrMf8nJkZxT24JvVRrQya1vZkQh8BBeYNwGDqa5I0VUi8ACx7uFvAaLxintokpTenkK6DASvo/bvNbBGow==}
@@ -1196,57 +1511,6 @@ packages:
       '@nestjs/platform-socket.io':
         optional: true
 
-  '@next/env@15.5.18':
-    resolution: {integrity: sha512-hAV85Ckd9QR6RvH04MEKwsfLTksvFpO47j9xwtoIuvuPnlwecpSi+uZTtm8HirVbtlI2Fnz//xpcSTjFdyJk+g==}
-
-  '@next/swc-darwin-arm64@15.5.18':
-    resolution: {integrity: sha512-w0WvQf1n+txiwns/9pwIQteCJpZTbxzO2SE0FLcwuD4v0WEh1JPOjdyxWL21XwJsdpx8cFRjyzxzCS/siP7HcQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@next/swc-darwin-x64@15.5.18':
-    resolution: {integrity: sha512-znn71QmDuxm+BOaglihMZfvyySMnNljkVIY5Z2TCssBmm+WqL6c19VhtH5ktFkHa8EZ2bnTUpcNcmNSQsg67og==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@next/swc-linux-arm64-gnu@15.5.18':
-    resolution: {integrity: sha512-yPPe5MNL+igZUa+OsqQJisqSfh6oarIuA1Q0BDxljGJhRQyZeP+WRHh7rs/jZUGMh5aY0YdIjXZG0VohkKkUdw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@next/swc-linux-arm64-musl@15.5.18':
-    resolution: {integrity: sha512-glaCczEWIrHsokFZ3pP08U4BpKxwIdnT+txdOM32OBgpL9Yw4aqx8NejmgtZQZOdstQ5f0L3CasIZudzCuD+nw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@next/swc-linux-x64-gnu@15.5.18':
-    resolution: {integrity: sha512-oUfg2EgJmU3R0OCOWiokGFUTvZiPfXtriXiuF3YNxRoROCdgvTedHIzYoeKH34gsZxS/V7mHbfq2hpAHwhH1/A==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-
-  '@next/swc-linux-x64-musl@15.5.18':
-    resolution: {integrity: sha512-JLxSP3KTd9iu/bvUMQxH7RJo9xKSHf55/6RPE4a6FTSZygGn7uvZbCej0AHXydwkggQGSD9UddSjwv6Xz5ESfA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-
-  '@next/swc-win32-arm64-msvc@15.5.18':
-    resolution: {integrity: sha512-ir1v7enP52K2HNz3tQQvwF+x7VNxBk1ciiZ18WBPvxf4C59IqdfmHPJYK3vH7rSxpuCVw/8C712wTXNAtEp+NA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@next/swc-win32-x64-msvc@15.5.18':
-    resolution: {integrity: sha512-LIu5me6QTANCd25E7I5uIEfvgQ06RK7tvHAbYo3zCb3VpxQEPvMcSpd87NwUABDT6MbGPdEGR5VRiK4PPTJhQg==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
   '@nodable/entities@2.1.0':
     resolution: {integrity: sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==}
 
@@ -1519,6 +1783,503 @@ packages:
     peerDependencies:
       '@opentelemetry/api': ^1.8
 
+  '@radix-ui/number@1.1.2':
+    resolution: {integrity: sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig==}
+
+  '@radix-ui/primitive@1.1.4':
+    resolution: {integrity: sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==}
+
+  '@radix-ui/react-arrow@1.1.10':
+    resolution: {integrity: sha512-j2VTDz1vgCsmuG0k5lBfOcM8n5JPFqZBcMryasFjHYMhwxYL5SRUV5lMSUpRdNtw3D/Sv8pzJtrlAgkssYSsQQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collection@1.1.10':
+    resolution: {integrity: sha512-IVVz4EvBcKjrzKgof714qDnz/SzQAkLA2Emh5edlHbgcE6fNd3Un6CJLlaYcnm8N4JmAtzQgse4dOKxcD2yc9g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-compose-refs@1.1.3':
+    resolution: {integrity: sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.4':
+    resolution: {integrity: sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.17':
+    resolution: {integrity: sha512-TDTYmpdq8dI2+Xgvgj9AJ8Ghqq+Eph/TRVEdaFQPDItIY+6QSkU7MJMeevw1568Yw/2Ijz8BTphPSP2XejKphw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-direction@1.1.2':
+    resolution: {integrity: sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.13':
+    resolution: {integrity: sha512-2v+zNAWWe0ySxgC0D0yeXMPQ23xZVgXZTerTz+JKlmdRj6gfTqmCcR29jb6d290DezXPGgruHWDX/vYUebtErg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dropdown-menu@2.1.18':
+    resolution: {integrity: sha512-PZGV82gFk0WltDRI//SsG28ZIjlo9ANTmoNYg0jLNzXXiDsAy5PkOOYQaVD1pPxY6t7gxffb1QMD6qaUvsBZdw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.4':
+    resolution: {integrity: sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.10':
+    resolution: {integrity: sha512-Fas/lXQqhVvqwAb64s5RFeHiHYElZ6SUQbZaNd6EkfhP/Al7wTIQ9WIR4QVX475tlu5yFCEdDcJH6/UwsZjMWw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.2':
+    resolution: {integrity: sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-menu@2.1.18':
+    resolution: {integrity: sha512-lj8Rxjtn6zJq1oSbE/uDtAwCbB9BnxgHD+8MwJMuTh6u1dPamYhW9iuELr/Z8d0D/UysFblYYHeBPwi7T4k0YQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popper@1.3.1':
+    resolution: {integrity: sha512-bhnq/0DEPTi2lsOD3J5rTL65qUKHbKbhqHsmN9TMiclSXpipi651ooUKPPp6G5lF/WiHBdn1s0Wuqsn+myVAvw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.12':
+    resolution: {integrity: sha512-m309havGzsjLHHaIX50G5PlvRs3xkgPCsGk/5PTvYm8D5q33yG0J7w/712PTOhid7NTaFETtnSXjngHQavvhVw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.6':
+    resolution: {integrity: sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.6':
+    resolution: {integrity: sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.13':
+    resolution: {integrity: sha512-9gkwneI0guf8JDmrFxPjJF6Ozzgioyw+/lonYNCwefS9ZHA05er0BVHiXr+LbWGHxUfczvMY6G1oiZZi1VzjRw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-select@2.3.1':
+    resolution: {integrity: sha512-w6eDvY78LE9ZUiNnXCA1QVK8RYN7k9galFv09kjVydJqBAgHd7Y9A6h0UJ/6DCZNGZMZrB2ohcSW1Bo9d8+wWA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-separator@1.1.10':
+    resolution: {integrity: sha512-Y6K6jLQCVfCnTL2MEtGxDLffkhNfEfHsEg3Wa8JU+IWdn3EWbLXd3OuOfQRN7p/W/cUce1WyTk3QeuAoDBzN9g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.3.0':
+    resolution: {integrity: sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.15':
+    resolution: {integrity: sha512-kxc9gI6/HfcU4nfMMVS3AmQK414kbU1IE6UCJmMmxjhO3cRPXOyYnmvyKD+ODt7q56nRq9l7Wovi6uaGwKgMlg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toast@1.2.17':
+    resolution: {integrity: sha512-uL4kyyWy000pPL43fGGCV5qT6ZchCWEQZOSlkYiPwPt8Hy1iW38RjeptIvz1/SZesrW6Vn58Ct3sV7tfEfiAbw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tooltip@1.2.10':
+    resolution: {integrity: sha512-NlNe8D0dWEpVfXFli90IO6X07Josx/b1iu98tDnx9Xv0HT4wLIL+m2VOheMHhK7qbp2HoTBqALEFzGyZs/levw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.2':
+    resolution: {integrity: sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.3':
+    resolution: {integrity: sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.3':
+    resolution: {integrity: sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.2':
+    resolution: {integrity: sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.2':
+    resolution: {integrity: sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-previous@1.1.2':
+    resolution: {integrity: sha512-IGBQPtRFdhN6MQ8dbegVmBq1LVZluya3F1jWY+puIcQC3MHctRwTDSBWCkL/3ZcnMJLTMJ++Z+ktmvg0F89iCw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-rect@1.1.2':
+    resolution: {integrity: sha512-d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.2':
+    resolution: {integrity: sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.2.6':
+    resolution: {integrity: sha512-jCE0WljWifTI4niIMCll06kGpsJTAPiZVU9H4WR1N6qW7At9ystHbN7dDB+we2xH535roFHj7qKS+RGj0FMDWQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/rect@1.1.2':
+    resolution: {integrity: sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==}
+
+  '@rolldown/pluginutils@1.0.0-beta.27':
+    resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
+
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    resolution: {integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    resolution: {integrity: sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
+    cpu: [x64]
+    os: [win32]
+
   '@scarf/scarf@1.4.0':
     resolution: {integrity: sha512-xxeapPiUXdZAE3che6f3xogoJPeZgig6omHEy1rIY5WVsB3H2BHNnZH+gHG6x91SCWyQCzWGsuL2Hh3ClO5/qQ==}
 
@@ -1619,8 +2380,137 @@ packages:
   '@sqltools/formatter@1.2.5':
     resolution: {integrity: sha512-Uy0+khmZqUrUGm5dmMqVlnvufZRSK0FbYzVgp0UMstm+F5+W2/jnEEQyc9vo1ZR/E5ZI/B1WjjoTqBqwJL6Krw==}
 
-  '@swc/helpers@0.5.15':
-    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+  '@tailwindcss/node@4.3.2':
+    resolution: {integrity: sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==}
+
+  '@tailwindcss/oxide-android-arm64@4.3.2':
+    resolution: {integrity: sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.2':
+    resolution: {integrity: sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.3.2':
+    resolution: {integrity: sha512-UIIzmefR6KO1sDU7MzRqAxC8iBpft/VhkGjTjnhoS6k7Z3rQ9wEgA1ODSiyH/tcSYssulNm4Ci3hOeK1jH7ccQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.2':
+    resolution: {integrity: sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.2':
+    resolution: {integrity: sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.2':
+    resolution: {integrity: sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.2':
+    resolution: {integrity: sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.2':
+    resolution: {integrity: sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.2':
+    resolution: {integrity: sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.2':
+    resolution: {integrity: sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.2':
+    resolution: {integrity: sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.2':
+    resolution: {integrity: sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.3.2':
+    resolution: {integrity: sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/vite@4.3.2':
+    resolution: {integrity: sha512-eHpMeX4JXfVNJDEcsouTeCBubJBTcTLigeaw/NTUW6PB5ATKKXdyonnXgTBX2VuRbjz1hjfz6C5XAhr52ImQXA==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@tanstack/query-core@5.101.1':
+    resolution: {integrity: sha512-Y6Y92dkXtNqx67m2pMSxUsA3zOCwv862JexZRP8/EPwvKXMPu9m8rv43spiXWzOUIggQ3SQApttALStzhA8B4g==}
+
+  '@tanstack/react-query@5.101.1':
+    resolution: {integrity: sha512-ZnONUuQKJe1bJMStXUL1s5uKN9FcfC28j5cK+iDZcdSHtUv1wtin1cGc/Oewhf2Oc4eKY7lggtpvT/AbMmhHew==}
+    peerDependencies:
+      react: ^18 || ^19
+
+  '@tanstack/react-table@8.21.3':
+    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
+  '@tanstack/table-core@8.21.3':
+    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
+    engines: {node: '>=12'}
+
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
 
   '@tokenizer/inflate@0.2.7':
     resolution: {integrity: sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==}
@@ -1643,6 +2533,9 @@ packages:
 
   '@tybys/wasm-util@0.9.0':
     resolution: {integrity: sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -1677,6 +2570,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
   '@types/express-serve-static-core@5.1.1':
     resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
@@ -1812,6 +2708,41 @@ packages:
   '@typespec/ts-http-runtime@0.3.3':
     resolution: {integrity: sha512-91fp6CAAJSRtH5ja95T1FHSKa8aPW9/Zw6cta81jlZTUw/+Vq8jM/AfF/14h2b71wwR84JUTW/3Y8QPhDAawFA==}
     engines: {node: '>=20.0.0'}
+
+  '@vitejs/plugin-react@4.7.0':
+    resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -1994,6 +2925,17 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  aria-hidden@1.2.6:
+    resolution: {integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==}
+    engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
   array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
 
@@ -2002,6 +2944,10 @@ packages:
 
   array-timsort@1.0.3:
     resolution: {integrity: sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
@@ -2208,6 +3154,10 @@ packages:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
 
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -2235,6 +3185,10 @@ packages:
   caniuse-lite@1.0.30001770:
     resolution: {integrity: sha512-x/2CLQ1jHENRbHg5PSId2sXq1CIO1CISvwWAj027ltMVG2UNgW+w9oH2+HzgEIRFembL8bUlXtfbBHR1fCg2xw==}
 
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -2249,6 +3203,10 @@ packages:
 
   chardet@0.7.0:
     resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
 
   chokidar@3.6.0:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
@@ -2277,6 +3235,9 @@ packages:
 
   class-validator@0.14.3:
     resolution: {integrity: sha512-rXXekcjofVN1LTOSw+u4u9WXVEUvNBVjORW154q/IdmYWy1nMbOU9aNtZB0t8m+FJQ9q91jlr2f9CwwUFdFMRA==}
+
+  class-variance-authority@0.7.1:
+    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
   cli-cursor@3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
@@ -2310,9 +3271,6 @@ packages:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
 
-  client-only@0.0.1:
-    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
-
   cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
@@ -2335,6 +3293,10 @@ packages:
   clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
     engines: {node: '>=0.8'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
 
   cluster-key-slot@1.1.2:
     resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
@@ -2432,6 +3394,10 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
 
@@ -2483,8 +3449,22 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
+
+  date-fns@4.4.0:
+    resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
 
   dayjs@1.11.19:
     resolution: {integrity: sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==}
@@ -2506,6 +3486,9 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   decode-uri-component@0.2.2:
     resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
     engines: {node: '>=0.10'}
@@ -2517,6 +3500,10 @@ packages:
     peerDependenciesMeta:
       babel-plugin-macros:
         optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
 
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
@@ -2561,6 +3548,10 @@ packages:
     resolution: {integrity: sha512-cW3gggJ28HZ/LExwxP2B++aiKxhJXMSIt9K48FOXQkm+vuG5gyatXnLsONRJdzO/7VfjDIiaOOa/bs4l464Lwg==}
     engines: {node: '>=4'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -2573,6 +3564,9 @@ packages:
     resolution: {integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==}
     engines: {node: '>=8'}
 
+  detect-node-es@1.1.0:
+    resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
   diff-sequences@29.6.3:
     resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -2580,6 +3574,12 @@ packages:
   diff@4.0.4:
     resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
     engines: {node: '>=0.3.1'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dom-serializer@2.0.0:
     resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
@@ -2650,12 +3650,20 @@ packages:
     resolution: {integrity: sha512-phv3E1Xl4tQOShqSte26C7Fl84EwUdZsyOuSSk9qtAGyyQs2s3jJzComh+Abf4g187lUUAvH+H26omrqia2aGg==}
     engines: {node: '>=10.13.0'}
 
+  enhanced-resolve@5.21.6:
+    resolution: {integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==}
+    engines: {node: '>=10.13.0'}
+
   enquirer@2.3.6:
     resolution: {integrity: sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==}
     engines: {node: '>=8.6'}
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
   env-paths@2.2.1:
@@ -2687,6 +3695,16 @@ packages:
   es-set-tostringtag@2.1.0:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -2724,6 +3742,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   etag@1.8.1:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
@@ -2748,6 +3769,10 @@ packages:
   exit@0.1.2:
     resolution: {integrity: sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==}
     engines: {node: '>= 0.8.0'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   expect@29.7.0:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
@@ -2789,6 +3814,15 @@ packages:
 
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
@@ -2929,6 +3963,10 @@ packages:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
 
+  get-nonce@1.0.1:
+    resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
+    engines: {node: '>=6'}
+
   get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
     engines: {node: '>=8.0.0'}
@@ -3014,6 +4052,10 @@ packages:
     resolution: {integrity: sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==}
     engines: {node: '>=14'}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -3049,6 +4091,10 @@ packages:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
 
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
@@ -3082,6 +4128,10 @@ packages:
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -3194,6 +4244,9 @@ packages:
   is-plain-obj@4.1.0:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
@@ -3405,6 +4458,10 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
 
@@ -3418,6 +4475,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@25.0.1:
+    resolution: {integrity: sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsep@1.4.0:
     resolution: {integrity: sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==}
@@ -3489,6 +4555,76 @@ packages:
 
   libphonenumber-js@1.12.37:
     resolution: {integrity: sha512-rDU6bkpuMs8YRt/UpkuYEAsYSoNuDEbrE41I3KNvmXREGH6DGBJ8Wbak4by29wNOQ27zk4g4HL82zf0OGhwRuw==}
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
@@ -3573,15 +4709,30 @@ packages:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
 
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
+  lucide-react@0.460.0:
+    resolution: {integrity: sha512-BVtq/DykVeIvRTJvRAgCsOwaGL8Un3Bxh8MbDxMhEWlZay3T4IpEKDEpwt5KZ0KJMHzgm6jrltxlT5eXOWXDHg==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
+
   luxon@3.5.0:
     resolution: {integrity: sha512-rh+Zjr6DNfUYR3bPwJEnuwDdqMbxZW7LOQfUN4B54+Cl+0o5zaU9RJ6bcidfDtC1cWCZXQ+nvX8bf6bAji37QQ==}
     engines: {node: '>=12'}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   magic-string@0.30.8:
     resolution: {integrity: sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==}
@@ -3664,6 +4815,10 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -3718,8 +4873,8 @@ packages:
     resolution: {integrity: sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw==}
     engines: {node: '>=20.17'}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+  nanoid@3.3.15:
+    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3740,27 +4895,6 @@ packages:
 
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
-
-  next@15.5.18:
-    resolution: {integrity: sha512-eKL8zUJkX9Y5lE+RX/2YJoItVdGlIscyVyboeD9wSpp0PaGqjoA4tTpT2qPqz9ax+5IzGESyLSeZ/RCwbSZ2uQ==}
-    engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
-    hasBin: true
-    peerDependencies:
-      '@opentelemetry/api': ^1.1.0
-      '@playwright/test': ^1.51.1
-      babel-plugin-react-compiler: '*'
-      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
-      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
-      sass: ^1.3.0
-    peerDependenciesMeta:
-      '@opentelemetry/api':
-        optional: true
-      '@playwright/test':
-        optional: true
-      babel-plugin-react-compiler:
-        optional: true
-      sass:
-        optional: true
 
   nkeys.js@1.1.0:
     resolution: {integrity: sha512-tB/a0shZL5UZWSwsoeyqfTszONTt4k2YS0tuQioMOD180+MbombYVgzDUYHlx+gejYK6rgf08n/2Df99WY0Sxg==}
@@ -3797,6 +4931,9 @@ packages:
   npm-run-path@4.0.1:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
+
+  nwsapi@2.2.24:
+    resolution: {integrity: sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==}
 
   nx@21.6.10:
     resolution: {integrity: sha512-iKSyAg0VGG1MEOnlyyseMOt4n9J7I955VC+0UPQbNQTLdIUW8ibIHubpQyjd8Qvq4CfrLxzm+iq1AmbZ5vEG4A==}
@@ -3909,6 +5046,9 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
 
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
@@ -3964,6 +5104,13 @@ packages:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
     engines: {node: '>=8'}
 
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
   pause@0.0.1:
     resolution: {integrity: sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg==}
 
@@ -4012,6 +5159,10 @@ packages:
     resolution: {integrity: sha512-xUXwsxNjwTQ8K3GnT4pCJm+xq3RUPQbmkYJTP5aFIfNIvbcc/4MUxgBaaRSZJ6yGJZiGSyYlM6MzwTsRk8SYCg==}
     engines: {node: '>=12'}
 
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
   pidtree@0.6.0:
     resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
     engines: {node: '>=0.10'}
@@ -4043,8 +5194,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -4062,6 +5213,10 @@ packages:
   postgres-interval@1.2.0:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
+
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
   pretty-format@29.7.0:
     resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
@@ -4125,8 +5280,61 @@ packages:
     peerDependencies:
       react: ^19.2.4
 
+  react-hook-form@7.80.0:
+    resolution: {integrity: sha512-4P+fk6oXsxY+6xSj7Euhc2sumQD8zQqCuVHoJwoyp9EchP+IUW9OESB7uHFJOKsIBQ4MQqYE84INJFqUCYNoOg==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-refresh@0.17.0:
+    resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
+    engines: {node: '>=0.10.0'}
+
+  react-remove-scroll-bar@2.3.8:
+    resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-router@7.18.0:
+    resolution: {integrity: sha512-pTTGt8J+ji1NOmYnjzT+bAJy/1zD+Jp4ziO6cL7T3ZLvXKtusO7BpFqlRXitqpcPVqllsIXFHRMt+2/k3Xn6HQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
@@ -4139,6 +5347,10 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
+
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
 
   redis-errors@1.2.0:
     resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
@@ -4206,9 +5418,20 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
+  rollup@4.62.2:
+    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
   router@2.2.0:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
+
+  rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
 
   rsa-pem-from-mod-exp@0.8.6:
     resolution: {integrity: sha512-c5ouQkOvGHF1qomUUDJGFcXsomeSO2gbEs6hVhMAtlkE1CuaZase/WzoaKFG/EZQuNmq6pw/EMCeEnDvOgCJYQ==}
@@ -4244,6 +5467,10 @@ packages:
   sax@1.4.4:
     resolution: {integrity: sha512-1n3r/tGXO6b6VXMdFT54SHzT9ytu9yr7TaELowdYpMqY/Ao7EnlQGmAQ1+RatX7Tkkdm6hONI2owqNx2aZj5Sw==}
     engines: {node: '>=11.0.0'}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -4284,6 +5511,9 @@ packages:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
     engines: {node: '>= 18'}
 
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
     engines: {node: '>= 0.4'}
@@ -4295,10 +5525,6 @@ packages:
     resolution: {integrity: sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==}
     engines: {node: '>= 0.10'}
     hasBin: true
-
-  sharp@0.34.5:
-    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -4323,6 +5549,9 @@ packages:
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
@@ -4391,12 +5620,18 @@ packages:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   standard-as-callback@2.1.0:
     resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
 
   stream-buffers@3.0.3:
     resolution: {integrity: sha512-pqMqwQCso0PBJt2PQmDO0cFj0lyqmiwOMiMSkVtRokl7e+ZTRYgDHKnuZNbqjiJXgsg4nuqtD/zxuo9KqTp0Yw==}
@@ -4466,6 +5701,10 @@ packages:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -4476,19 +5715,6 @@ packages:
   strtok3@10.3.4:
     resolution: {integrity: sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==}
     engines: {node: '>=18'}
-
-  styled-jsx@5.1.6:
-    resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
-    engines: {node: '>= 12.0.0'}
-    peerDependencies:
-      '@babel/core': '*'
-      babel-plugin-macros: '*'
-      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      babel-plugin-macros:
-        optional: true
 
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
@@ -4509,8 +5735,24 @@ packages:
     resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
     engines: {node: '>=0.10'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tailwind-merge@2.6.1:
+    resolution: {integrity: sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==}
+
+  tailwindcss@4.3.1:
+    resolution: {integrity: sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==}
+
+  tailwindcss@4.3.2:
+    resolution: {integrity: sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==}
+
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
+    engines: {node: '>=6'}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
 
   tar-fs@3.1.1:
@@ -4567,9 +5809,38 @@ packages:
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyexec@1.0.4:
     resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
     engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
 
   tmp@0.0.33:
     resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
@@ -4598,8 +5869,16 @@ packages:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
     engines: {node: '>=14.16'}
 
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -4792,6 +6071,26 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
+  use-callback-ref@1.3.3:
+    resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-sidecar@1.1.3:
+    resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -4840,6 +6139,111 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vite@6.4.3:
+    resolution: {integrity: sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      jiti: '>=1.21.0'
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
 
@@ -4855,6 +6259,10 @@ packages:
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
 
   webpack-node-externals@3.0.0:
     resolution: {integrity: sha512-LnL6Z3GGDPht/AigwRh2dvL9PQPFQ8skEpVrWZXLWBYmqcaojHNN0onvHzie6rq7EWKrrBfPYqNEzTJgiwEQDQ==}
@@ -4874,6 +6282,19 @@ packages:
       webpack-cli:
         optional: true
 
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
+
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
@@ -4884,6 +6305,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   wordwrap@1.0.0:
@@ -4952,6 +6378,10 @@ packages:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
   xml-naming@0.1.0:
     resolution: {integrity: sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==}
     engines: {node: '>=16.0.0'}
@@ -4963,6 +6393,9 @@ packages:
   xmlbuilder@11.0.1:
     resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
     engines: {node: '>=4.0'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -5003,7 +6436,27 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zustand@5.0.14:
+    resolution: {integrity: sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
 snapshots:
+
+  '@adobe/css-tools@4.5.0': {}
 
   '@angular-devkit/core@17.3.11(chokidar@3.6.0)':
     dependencies:
@@ -5036,6 +6489,14 @@ snapshots:
       rxjs: 7.8.1
     transitivePeerDependencies:
       - chokidar
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@azure/abort-controller@2.1.2':
     dependencies:
@@ -5198,6 +6659,8 @@ snapshots:
 
   '@babel/helper-plugin-utils@7.28.6': {}
 
+  '@babel/helper-plugin-utils@7.29.7': {}
+
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
@@ -5297,6 +6760,18 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/runtime@7.29.7': {}
 
   '@babel/template@7.28.6':
     dependencies:
@@ -5454,6 +6929,26 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
+
   '@emnapi/core@1.8.1':
     dependencies:
       '@emnapi/wasi-threads': 1.1.0
@@ -5467,6 +6962,153 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
+    optional: true
+
   '@fastify/otel@0.18.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -5477,102 +7119,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@img/colour@1.0.0':
-    optional: true
-
-  '@img/sharp-darwin-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-darwin-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-darwin-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-arm@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-ppc64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-riscv64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-s390x@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linux-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    optional: true
-
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    optional: true
-
-  '@img/sharp-linux-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-arm@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-ppc64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-ppc64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-riscv64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-riscv64': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-s390x@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.2.4
-    optional: true
-
-  '@img/sharp-linux-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-linuxmusl-arm64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
-    optional: true
-
-  '@img/sharp-linuxmusl-x64@0.34.5':
-    optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-    optional: true
-
-  '@img/sharp-wasm32@0.34.5':
+  '@floating-ui/core@1.7.5':
     dependencies:
-      '@emnapi/runtime': 1.8.1
-    optional: true
+      '@floating-ui/utils': 0.2.11
 
-  '@img/sharp-win32-arm64@0.34.5':
-    optional: true
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
 
-  '@img/sharp-win32-ia32@0.34.5':
-    optional: true
+  '@floating-ui/react-dom@2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
 
-  '@img/sharp-win32-x64@0.34.5':
-    optional: true
+  '@floating-ui/utils@0.2.11': {}
+
+  '@hookform/resolvers@3.10.0(react-hook-form@7.80.0(react@19.2.4))':
+    dependencies:
+      react-hook-form: 7.80.0(react@19.2.4)
 
   '@ioredis/commands@1.5.0': {}
 
@@ -6047,32 +7613,6 @@ snapshots:
       rxjs: 7.8.2
       tslib: 2.8.1
 
-  '@next/env@15.5.18': {}
-
-  '@next/swc-darwin-arm64@15.5.18':
-    optional: true
-
-  '@next/swc-darwin-x64@15.5.18':
-    optional: true
-
-  '@next/swc-linux-arm64-gnu@15.5.18':
-    optional: true
-
-  '@next/swc-linux-arm64-musl@15.5.18':
-    optional: true
-
-  '@next/swc-linux-x64-gnu@15.5.18':
-    optional: true
-
-  '@next/swc-linux-x64-musl@15.5.18':
-    optional: true
-
-  '@next/swc-win32-arm64-msvc@15.5.18':
-    optional: true
-
-  '@next/swc-win32-x64-msvc@15.5.18':
-    optional: true
-
   '@nodable/entities@2.1.0': {}
 
   '@novnc/novnc@1.5.0': {}
@@ -6381,6 +7921,456 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@radix-ui/number@1.1.2': {}
+
+  '@radix-ui/primitive@1.1.4': {}
+
+  '@radix-ui/react-arrow@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-collection@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-compose-refs@1.1.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-context@1.1.4(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-dialog@1.1.17(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-direction@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-dismissable-layer@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-escape-keydown': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-dropdown-menu@2.1.18(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-menu': 2.1.18(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-focus-guards@1.1.4(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-focus-scope@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-id@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-menu@2.1.18(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-collection': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-popper': 1.3.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-popper@1.3.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-arrow': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-rect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/rect': 1.1.2
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-portal@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-presence@1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-primitive@2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-roving-focus@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-collection': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-select@2.3.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/number': 1.1.2
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-collection': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-focus-scope': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-popper': 1.3.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      aria-hidden: 1.2.6
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-separator@1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-slot@1.3.0(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-tabs@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-roving-focus': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-toast@1.2.17(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-collection': 1.1.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-tooltip@1.2.10(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-context': 1.1.4(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-popper': 1.3.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-portal': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-visually-hidden': 1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/react-use-callback-ref@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-controllable-state@1.2.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.14)(react@19.2.4)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-effect-event@0.0.3(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-escape-keydown@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-layout-effect@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-previous@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-rect@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/rect': 1.1.2
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-use-size@1.1.2(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.14)(react@19.2.4)
+      react: 19.2.4
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  '@radix-ui/react-visually-hidden@1.2.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@radix-ui/rect@1.1.2': {}
+
+  '@rolldown/pluginutils@1.0.0-beta.27': {}
+
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    optional: true
+
   '@scarf/scarf@1.4.0': {}
 
   '@sentry/core@10.51.0': {}
@@ -6545,9 +8535,118 @@ snapshots:
 
   '@sqltools/formatter@1.2.5': {}
 
-  '@swc/helpers@0.5.15':
+  '@tailwindcss/node@4.3.2':
     dependencies:
-      tslib: 2.8.1
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.21.6
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.3.2
+
+  '@tailwindcss/oxide-android-arm64@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.2':
+    optional: true
+
+  '@tailwindcss/oxide@4.3.2':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.3.2
+      '@tailwindcss/oxide-darwin-arm64': 4.3.2
+      '@tailwindcss/oxide-darwin-x64': 4.3.2
+      '@tailwindcss/oxide-freebsd-x64': 4.3.2
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.2
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.2
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.2
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.2
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.2
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.2
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.2
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.2
+
+  '@tailwindcss/vite@4.3.2(vite@6.4.3(@types/node@25.2.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.2))':
+    dependencies:
+      '@tailwindcss/node': 4.3.2
+      '@tailwindcss/oxide': 4.3.2
+      tailwindcss: 4.3.2
+      vite: 6.4.3(@types/node@25.2.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.2)
+
+  '@tanstack/query-core@5.101.1': {}
+
+  '@tanstack/react-query@5.101.1(react@19.2.4)':
+    dependencies:
+      '@tanstack/query-core': 5.101.1
+      react: 19.2.4
+
+  '@tanstack/react-table@8.21.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tanstack/table-core': 8.21.3
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
+  '@tanstack/table-core@8.21.3': {}
+
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.5.0
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@tokenizer/inflate@0.2.7':
     dependencies:
@@ -6570,6 +8669,8 @@ snapshots:
   '@tybys/wasm-util@0.9.0':
     dependencies:
       tslib: 2.8.1
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -6620,6 +8721,8 @@ snapshots:
       '@types/json-schema': 7.0.15
 
   '@types/estree@1.0.8': {}
+
+  '@types/estree@1.0.9': {}
 
   '@types/express-serve-static-core@5.1.1':
     dependencies:
@@ -6791,6 +8894,58 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
+
+  '@vitejs/plugin-react@4.7.0(vite@6.4.3(@types/node@25.2.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.2))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 6.4.3(@types/node@25.2.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@25.2.3)(lightningcss@1.32.0)(terser@5.46.0))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@25.2.3)(lightningcss@1.32.0)(terser@5.46.0)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:
@@ -6995,11 +9150,23 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
+
   array-flatten@1.1.1: {}
 
   array-ify@1.0.0: {}
 
   array-timsort@1.0.3: {}
+
+  assertion-error@2.0.1: {}
 
   async@3.2.6: {}
 
@@ -7321,6 +9488,8 @@ snapshots:
 
   bytes@3.1.2: {}
 
+  cac@6.7.14: {}
+
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -7346,6 +9515,14 @@ snapshots:
 
   caniuse-lite@1.0.30001770: {}
 
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -7356,6 +9533,8 @@ snapshots:
   char-regex@1.0.2: {}
 
   chardet@0.7.0: {}
+
+  check-error@2.1.3: {}
 
   chokidar@3.6.0:
     dependencies:
@@ -7387,6 +9566,10 @@ snapshots:
       libphonenumber-js: 1.12.37
       validator: 13.15.26
 
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
+
   cli-cursor@3.1.0:
     dependencies:
       restore-cursor: 3.1.0
@@ -7414,8 +9597,6 @@ snapshots:
 
   cli-width@4.1.0: {}
 
-  client-only@0.0.1: {}
-
   cliui@8.0.1:
     dependencies:
       string-width: 4.2.3
@@ -7429,6 +9610,8 @@ snapshots:
       playwright-core: 1.58.2
 
   clone@1.0.4: {}
+
+  clsx@2.1.1: {}
 
   cluster-key-slot@1.1.2: {}
 
@@ -7508,6 +9691,8 @@ snapshots:
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
+
+  cookie@1.1.1: {}
 
   core-util-is@1.0.3: {}
 
@@ -7590,7 +9775,21 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css.escape@1.5.1: {}
+
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
   csstype@3.2.3: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+
+  date-fns@4.4.0: {}
 
   dayjs@1.11.19: {}
 
@@ -7602,9 +9801,13 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decimal.js@10.6.0: {}
+
   decode-uri-component@0.2.2: {}
 
   dedent@1.7.1: {}
+
+  deep-eql@5.0.2: {}
 
   deepmerge@4.3.1: {}
 
@@ -7637,16 +9840,23 @@ snapshots:
 
   dependency-graph@1.0.0: {}
 
+  dequal@2.0.3: {}
+
   destroy@1.2.0: {}
 
-  detect-libc@2.1.2:
-    optional: true
+  detect-libc@2.1.2: {}
 
   detect-newline@3.1.0: {}
+
+  detect-node-es@1.1.0: {}
 
   diff-sequences@29.6.3: {}
 
   diff@4.0.4: {}
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dom-serializer@2.0.0:
     dependencies:
@@ -7713,11 +9923,18 @@ snapshots:
       graceful-fs: 4.2.11
       tapable: 2.3.0
 
+  enhanced-resolve@5.21.6:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
+
   enquirer@2.3.6:
     dependencies:
       ansi-colors: 4.1.3
 
   entities@4.5.0: {}
+
+  entities@6.0.1: {}
 
   env-paths@2.2.1: {}
 
@@ -7744,6 +9961,61 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.2
 
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
+
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
@@ -7766,6 +10038,10 @@ snapshots:
   estraverse@4.3.0: {}
 
   estraverse@5.3.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
 
   etag@1.8.1: {}
 
@@ -7794,6 +10070,8 @@ snapshots:
       strip-final-newline: 2.0.0
 
   exit@0.1.2: {}
+
+  expect-type@1.4.0: {}
 
   expect@29.7.0:
     dependencies:
@@ -7904,6 +10182,10 @@ snapshots:
   fb-watchman@2.0.2:
     dependencies:
       bser: 2.1.1
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
 
   fflate@0.8.2: {}
 
@@ -8057,6 +10339,8 @@ snapshots:
       hasown: 2.0.2
       math-intrinsics: 1.1.0
 
+  get-nonce@1.0.1: {}
+
   get-package-type@0.1.0: {}
 
   get-proto@1.0.1:
@@ -8146,6 +10430,10 @@ snapshots:
 
   hpagent@1.2.0: {}
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-escaper@2.0.2: {}
 
   htmlparser2@9.1.0:
@@ -8192,6 +10480,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
@@ -8227,6 +10519,8 @@ snapshots:
   import-meta-resolve@4.2.0: {}
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   inflight@1.0.6:
     dependencies:
@@ -8349,6 +10643,8 @@ snapshots:
   is-obj@2.0.0: {}
 
   is-plain-obj@4.1.0: {}
+
+  is-potential-custom-element-name@1.0.1: {}
 
   is-promise@4.0.0: {}
 
@@ -8847,6 +11143,8 @@ snapshots:
 
   jiti@2.6.1: {}
 
+  jiti@2.7.0: {}
+
   jose@6.1.3: {}
 
   js-tokens@4.0.0: {}
@@ -8859,6 +11157,34 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@25.0.1:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.5
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.24
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.19.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsep@1.4.0: {}
 
@@ -8944,6 +11270,55 @@ snapshots:
 
   libphonenumber-js@1.12.37: {}
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
   lines-and-columns@1.2.4: {}
 
   lines-and-columns@2.0.3: {}
@@ -9020,13 +11395,25 @@ snapshots:
       strip-ansi: 7.1.2
       wrap-ansi: 9.0.2
 
+  loupe@3.2.1: {}
+
   lru-cache@10.4.3: {}
 
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
 
+  lucide-react@0.460.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+
   luxon@3.5.0: {}
+
+  lz-string@1.5.0: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   magic-string@0.30.8:
     dependencies:
@@ -9084,6 +11471,8 @@ snapshots:
   mimic-fn@2.1.0: {}
 
   mimic-function@5.0.1: {}
+
+  min-indent@1.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -9145,7 +11534,7 @@ snapshots:
 
   nano-spawn@2.0.0: {}
 
-  nanoid@3.3.11: {}
+  nanoid@3.3.15: {}
 
   nats@2.29.3:
     dependencies:
@@ -9158,30 +11547,6 @@ snapshots:
   negotiator@1.0.0: {}
 
   neo-async@2.6.2: {}
-
-  next@15.5.18(@opentelemetry/api@1.9.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
-    dependencies:
-      '@next/env': 15.5.18
-      '@swc/helpers': 0.5.15
-      caniuse-lite: 1.0.30001770
-      postcss: 8.4.31
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-      styled-jsx: 5.1.6(react@19.2.4)
-    optionalDependencies:
-      '@next/swc-darwin-arm64': 15.5.18
-      '@next/swc-darwin-x64': 15.5.18
-      '@next/swc-linux-arm64-gnu': 15.5.18
-      '@next/swc-linux-arm64-musl': 15.5.18
-      '@next/swc-linux-x64-gnu': 15.5.18
-      '@next/swc-linux-x64-musl': 15.5.18
-      '@next/swc-win32-arm64-msvc': 15.5.18
-      '@next/swc-win32-x64-msvc': 15.5.18
-      '@opentelemetry/api': 1.9.1
-      sharp: 0.34.5
-    transitivePeerDependencies:
-      - '@babel/core'
-      - babel-plugin-macros
 
   nkeys.js@1.1.0:
     dependencies:
@@ -9208,6 +11573,8 @@ snapshots:
   npm-run-path@4.0.1:
     dependencies:
       path-key: 3.1.1
+
+  nwsapi@2.2.24: {}
 
   nx@21.6.10:
     dependencies:
@@ -9373,6 +11740,10 @@ snapshots:
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
 
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   parseurl@1.3.3: {}
 
   passport-jwt@4.0.1:
@@ -9414,6 +11785,10 @@ snapshots:
   path-to-regexp@8.3.0: {}
 
   path-type@4.0.0: {}
+
+  pathe@1.1.2: {}
+
+  pathval@2.0.1: {}
 
   pause@0.0.1: {}
 
@@ -9458,6 +11833,8 @@ snapshots:
 
   picomatch@4.0.1: {}
 
+  picomatch@4.0.4: {}
+
   pidtree@0.6.0: {}
 
   pirates@4.0.7: {}
@@ -9478,9 +11855,9 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.4.31:
+  postcss@8.5.15:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.15
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -9493,6 +11870,12 @@ snapshots:
   postgres-interval@1.2.0:
     dependencies:
       xtend: 4.0.2
+
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
 
   pretty-format@29.7.0:
     dependencies:
@@ -9568,7 +11951,50 @@ snapshots:
       react: 19.2.4
       scheduler: 0.27.0
 
+  react-hook-form@7.80.0(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+
+  react-is@17.0.2: {}
+
   react-is@18.3.1: {}
+
+  react-refresh@0.17.0: {}
+
+  react-remove-scroll-bar@2.3.8(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-remove-scroll@2.7.2(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.14)(react@19.2.4)
+      react-style-singleton: 2.2.3(@types/react@19.2.14)(react@19.2.4)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.14)(react@19.2.4)
+      use-sidecar: 1.1.3(@types/react@19.2.14)(react@19.2.4)
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  react-router@7.18.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+    dependencies:
+      cookie: 1.1.1
+      react: 19.2.4
+      set-cookie-parser: 2.7.2
+    optionalDependencies:
+      react-dom: 19.2.4(react@19.2.4)
+
+  react-style-singleton@2.2.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
 
   react@19.2.4: {}
 
@@ -9581,6 +12007,11 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
 
   redis-errors@1.2.0: {}
 
@@ -9635,6 +12066,37 @@ snapshots:
 
   rfdc@1.4.1: {}
 
+  rollup@4.62.2:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.62.2
+      '@rollup/rollup-android-arm64': 4.62.2
+      '@rollup/rollup-darwin-arm64': 4.62.2
+      '@rollup/rollup-darwin-x64': 4.62.2
+      '@rollup/rollup-freebsd-arm64': 4.62.2
+      '@rollup/rollup-freebsd-x64': 4.62.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.2
+      '@rollup/rollup-linux-arm64-gnu': 4.62.2
+      '@rollup/rollup-linux-arm64-musl': 4.62.2
+      '@rollup/rollup-linux-loong64-gnu': 4.62.2
+      '@rollup/rollup-linux-loong64-musl': 4.62.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.2
+      '@rollup/rollup-linux-ppc64-musl': 4.62.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.2
+      '@rollup/rollup-linux-riscv64-musl': 4.62.2
+      '@rollup/rollup-linux-s390x-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-musl': 4.62.2
+      '@rollup/rollup-openbsd-x64': 4.62.2
+      '@rollup/rollup-openharmony-arm64': 4.62.2
+      '@rollup/rollup-win32-arm64-msvc': 4.62.2
+      '@rollup/rollup-win32-ia32-msvc': 4.62.2
+      '@rollup/rollup-win32-x64-gnu': 4.62.2
+      '@rollup/rollup-win32-x64-msvc': 4.62.2
+      fsevents: 2.3.3
+
   router@2.2.0:
     dependencies:
       debug: 4.4.3
@@ -9644,6 +12106,10 @@ snapshots:
       path-to-regexp: 8.3.0
     transitivePeerDependencies:
       - supports-color
+
+  rrweb-cssom@0.7.1: {}
+
+  rrweb-cssom@0.8.0: {}
 
   rsa-pem-from-mod-exp@0.8.6: {}
 
@@ -9672,6 +12138,10 @@ snapshots:
   safer-buffer@2.1.2: {}
 
   sax@1.4.4: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -9748,6 +12218,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  set-cookie-parser@2.7.2: {}
+
   set-function-length@1.2.2:
     dependencies:
       define-data-property: 1.1.4
@@ -9764,38 +12236,6 @@ snapshots:
       inherits: 2.0.4
       safe-buffer: 5.2.1
       to-buffer: 1.2.2
-
-  sharp@0.34.5:
-    dependencies:
-      '@img/colour': 1.0.0
-      detect-libc: 2.1.2
-      semver: 7.7.4
-    optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.34.5
-      '@img/sharp-darwin-x64': 0.34.5
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
-      '@img/sharp-libvips-darwin-x64': 1.2.4
-      '@img/sharp-libvips-linux-arm': 1.2.4
-      '@img/sharp-libvips-linux-arm64': 1.2.4
-      '@img/sharp-libvips-linux-ppc64': 1.2.4
-      '@img/sharp-libvips-linux-riscv64': 1.2.4
-      '@img/sharp-libvips-linux-s390x': 1.2.4
-      '@img/sharp-libvips-linux-x64': 1.2.4
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-      '@img/sharp-linux-arm': 0.34.5
-      '@img/sharp-linux-arm64': 0.34.5
-      '@img/sharp-linux-ppc64': 0.34.5
-      '@img/sharp-linux-riscv64': 0.34.5
-      '@img/sharp-linux-s390x': 0.34.5
-      '@img/sharp-linux-x64': 0.34.5
-      '@img/sharp-linuxmusl-arm64': 0.34.5
-      '@img/sharp-linuxmusl-x64': 0.34.5
-      '@img/sharp-wasm32': 0.34.5
-      '@img/sharp-win32-arm64': 0.34.5
-      '@img/sharp-win32-ia32': 0.34.5
-      '@img/sharp-win32-x64': 0.34.5
-    optional: true
 
   shebang-command@2.0.0:
     dependencies:
@@ -9830,6 +12270,8 @@ snapshots:
       side-channel-list: 1.0.0
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
+
+  siginfo@2.0.0: {}
 
   signal-exit@3.0.7: {}
 
@@ -9887,9 +12329,13 @@ snapshots:
     dependencies:
       escape-string-regexp: 2.0.0
 
+  stackback@0.0.2: {}
+
   standard-as-callback@2.1.0: {}
 
   statuses@2.0.2: {}
+
+  std-env@3.10.0: {}
 
   stream-buffers@3.0.3: {}
 
@@ -9960,6 +12406,10 @@ snapshots:
 
   strip-final-newline@2.0.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-json-comments@3.1.1: {}
 
   strnum@2.3.0: {}
@@ -9967,11 +12417,6 @@ snapshots:
   strtok3@10.3.4:
     dependencies:
       '@tokenizer/token': 0.3.0
-
-  styled-jsx@5.1.6(react@19.2.4):
-    dependencies:
-      client-only: 0.0.1
-      react: 19.2.4
 
   supports-color@7.2.0:
     dependencies:
@@ -9989,7 +12434,17 @@ snapshots:
 
   symbol-observable@4.0.0: {}
 
+  symbol-tree@3.2.4: {}
+
+  tailwind-merge@2.6.1: {}
+
+  tailwindcss@4.3.1: {}
+
+  tailwindcss@4.3.2: {}
+
   tapable@2.3.0: {}
+
+  tapable@2.3.3: {}
 
   tar-fs@3.1.1:
     dependencies:
@@ -10074,7 +12529,28 @@ snapshots:
 
   through@2.3.8: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
   tinyexec@1.0.4: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
+
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
 
   tmp@0.0.33:
     dependencies:
@@ -10102,7 +12578,15 @@ snapshots:
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
 
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
   tr46@0.0.3: {}
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   tree-kill@1.2.2: {}
 
@@ -10264,6 +12748,21 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
+  use-callback-ref@1.3.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
+  use-sidecar@1.1.3(@types/react@19.2.14)(react@19.2.4):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.2.4
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.14
+
   util-deprecate@1.0.2: {}
 
   util@0.12.5:
@@ -10298,6 +12797,91 @@ snapshots:
 
   vary@1.1.2: {}
 
+  vite-node@2.1.9(@types/node@25.2.3)(lightningcss@1.32.0)(terser@5.46.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@25.2.3)(lightningcss@1.32.0)(terser@5.46.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@25.2.3)(lightningcss@1.32.0)(terser@5.46.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.15
+      rollup: 4.62.2
+    optionalDependencies:
+      '@types/node': 25.2.3
+      fsevents: 2.3.3
+      lightningcss: 1.32.0
+      terser: 5.46.0
+
+  vite@6.4.3(@types/node@25.2.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(yaml@2.8.2):
+    dependencies:
+      esbuild: 0.25.12
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rollup: 4.62.2
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 25.2.3
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      terser: 5.46.0
+      yaml: 2.8.2
+
+  vitest@2.1.9(@types/node@25.2.3)(jsdom@25.0.1)(lightningcss@1.32.0)(terser@5.46.0):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@25.2.3)(lightningcss@1.32.0)(terser@5.46.0))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@25.2.3)(lightningcss@1.32.0)(terser@5.46.0)
+      vite-node: 2.1.9(@types/node@25.2.3)(lightningcss@1.32.0)(terser@5.46.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.2.3
+      jsdom: 25.0.1
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   walker@1.0.8:
     dependencies:
       makeerror: 1.0.12
@@ -10318,6 +12902,8 @@ snapshots:
       '@zxing/text-encoding': 0.9.0
 
   webidl-conversions@3.0.1: {}
+
+  webidl-conversions@7.0.0: {}
 
   webpack-node-externals@3.0.0: {}
 
@@ -10353,6 +12939,17 @@ snapshots:
       - esbuild
       - uglify-js
 
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
+
   whatwg-url@5.0.0:
     dependencies:
       tr46: 0.0.3
@@ -10371,6 +12968,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   wordwrap@1.0.0: {}
 
@@ -10415,6 +13017,8 @@ snapshots:
     dependencies:
       is-wsl: 3.1.1
 
+  xml-name-validator@5.0.0: {}
+
   xml-naming@0.1.0: {}
 
   xml2js@0.6.2:
@@ -10423,6 +13027,8 @@ snapshots:
       xmlbuilder: 11.0.1
 
   xmlbuilder@11.0.1: {}
+
+  xmlchars@2.2.0: {}
 
   xtend@4.0.2: {}
 
@@ -10451,3 +13057,8 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zod@3.25.76: {}
+
+  zustand@5.0.14(@types/react@19.2.14)(react@19.2.4):
+    optionalDependencies:
+      '@types/react': 19.2.14
+      react: 19.2.4


### PR DESCRIPTION
## Summary

- Complete Admin UI rebuilt with React 19 + Vite 6 + React Router v7, replacing the placeholder HTML stub
- Dark-first design system matching the `adminui-bonito` prototype
- Standardized API error handling with GlobalExceptionFilter, domain exceptions, and correlation IDs
- Fixed Frontegg role resolver, credential decrypt silent failure, and multiple RBAC gaps

## Changes

### Admin UI (new frontend)
- Role-aware sidebar navigation (Admin sees all, Editor sees apps/templates/profiles, Operator/Viewer restricted)
- Dashboard with 7 session health cards, live refresh, summary stats
- Sessions list with All/My Sessions filter toggle and pagination
- Application and template CRUD with integrated visual DSL step builder (16 step types, drag reorder, visual/JSON toggle)
- Profile management with promote/rollback and canary stats
- Admin pages: tenants, users, identity providers (with `provider_type` field), agent clients (with secret reveal)
- VNC/CDP viewer with collapsible HITL side panel, clipboard, restart confirmation
- Nginx static build (~20MB Docker image) with non-root container support and runtime env injection
- 24 unit/component tests

### API error handling
- Registered `GlobalExceptionFilter` — standardized `{ error: { code, message, details? } }` response shape
- Added `CorrelationIdMiddleware` (X-Request-ID)
- 5 domain exception classes (BatonConflict, SessionState, NoHealthySession, ProfileNotFound, CredentialDecrypt)
- Fixed Sentry routing (removed request.body leak, added tenant_id/correlation_id tags)
- Fixed credential decrypt returning empty 200 → now throws 500

### Bug fixes
- Fixed Frontegg role resolver: handles `roles` as array of objects with `.key` field (not just string arrays)
- Added `Editor` to `UserRole` enum in shared package
- Added `ADMIN_UI_BASE_URL` to OAuth redirect allowlist
- Fixed `GET /apps/:id` missing Editor in `@Roles` decorator
- Fixed IdP edit crash on null `admin_domains`/`admin_role_values`/`editor_role_values`

## Test plan
- [ ] Login as Admin (email/password) — verify all 9 sidebar items visible
- [ ] Login as Editor — verify only 5 sidebar items, admin pages show lock icon
- [ ] Dashboard shows session health cards with live refresh
- [ ] Sessions list loads with filter toggle
- [ ] Create application with step builder (add goto + fill + click steps)
- [ ] Create template with required fields (profile_name_pattern is required)
- [ ] Profiles page shows version list with ACTIVE/RETIRED badges
- [ ] Tenants/Users/IdPs/Agent Clients CRUD works as Admin
- [ ] OAuth login via Frontegg resolves to Editor role (not Admin)
- [ ] API returns `{ error: { code, message } }` for all errors
- [ ] `X-Request-ID` header present on all responses