### PR TITLE
feat: add is_active flag to app templates for deactivation

### DIFF
--- a/apps/api/src/data-source.ts
+++ b/apps/api/src/data-source.ts
@@ -31,6 +31,7 @@ import { AddExtraEgressAllowlist1708300000026 } from './migrations/1708300000026
 import { AddRoleMapping1708300000027 } from './migrations/1708300000027-AddRoleMapping';
 import { AddLastActivityAt1708300000028 } from './migrations/1708300000028-AddLastActivityAt';
 import { TraceContext1708300000029 } from './migrations/1708300000029-TraceContext';
+import { AddTemplateIsActive1708300000030 } from './migrations/1708300000030-AddTemplateIsActive';
 
 const poolSize = Number(process.env.DB_POOL_SIZE) || 20;
 
@@ -40,7 +41,7 @@ export const dataSourceOptions: DataSourceOptions = {
     testDefault: 'postgresql://postgres:postgres@localhost:5432/browser_hitl',
   }),
   entities: Object.values(entities),
-  migrations: [InitialSchema1708300000000, WorkerRLS1708300000001, AgentClients1708300000002, AuthRequests1708300000003, LoginQueue1708300000004, AccountLockout1708300000005, ArtifactCascadeDelete1708300000006, ServiceProfiles1708300000007, ProfileAppLink1708300000008, GenericHumanInput1708300000009, AddIdentityProviders1708300000010, AddOwnerUserIds1708300000011, AddAppTemplates1708300000012, AddIdleShutdown1708300000013, AddAppOwnerUserId1708300000014, MultiTenantCloud1708300000015, GenericOAuth1708300000016, NullablePasswordHash1708300000017, GlobalIdp1708300000018, AddRestartRequested1708300000019, AddTemplateLineage1708300000020, DropIdpSecrets1708300000021, AddExecuteEnabled1708300000022, ControllerScaling1708300000023, AddTemplateExecuteEnabled1708300000024, UnrestrictedProfiles1708300000025, AddExtraEgressAllowlist1708300000026, AddRoleMapping1708300000027, AddLastActivityAt1708300000028, TraceContext1708300000029],
+  migrations: [InitialSchema1708300000000, WorkerRLS1708300000001, AgentClients1708300000002, AuthRequests1708300000003, LoginQueue1708300000004, AccountLockout1708300000005, ArtifactCascadeDelete1708300000006, ServiceProfiles1708300000007, ProfileAppLink1708300000008, GenericHumanInput1708300000009, AddIdentityProviders1708300000010, AddOwnerUserIds1708300000011, AddAppTemplates1708300000012, AddIdleShutdown1708300000013, AddAppOwnerUserId1708300000014, MultiTenantCloud1708300000015, GenericOAuth1708300000016, NullablePasswordHash1708300000017, GlobalIdp1708300000018, AddRestartRequested1708300000019, AddTemplateLineage1708300000020, DropIdpSecrets1708300000021, AddExecuteEnabled1708300000022, ControllerScaling1708300000023, AddTemplateExecuteEnabled1708300000024, UnrestrictedProfiles1708300000025, AddExtraEgressAllowlist1708300000026, AddRoleMapping1708300000027, AddLastActivityAt1708300000028, TraceContext1708300000029, AddTemplateIsActive1708300000030],
   migrationsRun: true,
   synchronize: false,
   logging: process.env.NODE_ENV === 'development' ? ['error', 'warn', 'migration'] : ['error'],

--- a/apps/api/src/entities/app-template.entity.ts
+++ b/apps/api/src/entities/app-template.entity.ts
@@ -52,6 +52,17 @@ export class AppTemplateEntity {
   execute_enabled: boolean;
 
   /**
+   * Whether this template is active. Inactive templates are skipped by
+   * auto-provisioning (autoProvisionFromTemplate treats is_active=false like a
+   * missing template), so no new per-user apps are cloned from them. Existing
+   * provisioned apps/profiles/sessions are unaffected — this is a soft on/off
+   * switch, not a teardown. Not propagated to linked apps and not part of the
+   * content hash, so toggling it never version-bumps downstream profiles.
+   */
+  @Column({ type: 'boolean', default: true })
+  is_active: boolean;
+
+  /**
    * Extra egress domains cloned onto every app auto-provisioned from this
    * template. Mirrors applications.extra_egress_allowlist. NoUI populates this
    * from recorded HAR so per-user sessions inherit the full domain set.

--- a/apps/api/src/migrations/1708300000030-AddTemplateIsActive.ts
+++ b/apps/api/src/migrations/1708300000030-AddTemplateIsActive.ts
@@ -1,0 +1,15 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddTemplateIsActive1708300000030 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "app_templates" ADD COLUMN "is_active" boolean NOT NULL DEFAULT true`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "app_templates" DROP COLUMN "is_active"`,
+    );
+  }
+}

--- a/apps/api/src/modules/app-templates/app-templates.controller.ts
+++ b/apps/api/src/modules/app-templates/app-templates.controller.ts
@@ -56,6 +56,10 @@ class CreateAppTemplateDto {
   @ApiProperty({ required: false, description: 'Extra egress domains cloned onto every auto-provisioned app (suffix patterns like ".expedia.com" or exact hosts). Typically populated from recorded HAR.', example: ['.expedia.com', '.trvl-media.com'] })
   @IsOptional() @IsArray() @IsString({ each: true })
   extra_egress_allowlist?: string[];
+
+  @ApiProperty({ required: false, default: true, description: 'Whether this template is active. Inactive templates are skipped by auto-provisioning (no new per-user apps are cloned). Defaults to true.' })
+  @IsOptional() @IsBoolean()
+  is_active?: boolean;
 }
 
 class UpdateAppTemplateDto {
@@ -79,6 +83,8 @@ class UpdateAppTemplateDto {
   @IsOptional() @IsBoolean() execute_enabled?: boolean;
   @ApiProperty({ required: false })
   @IsOptional() @IsInt() @Min(60) idle_shutdown_seconds?: number;
+  @ApiProperty({ required: false, description: 'Toggle the template active/inactive. Inactive templates are skipped by auto-provisioning.' })
+  @IsOptional() @IsBoolean() is_active?: boolean;
 }
 
 @ApiTags('App Templates')

--- a/apps/api/src/modules/app-templates/app-templates.service.spec.ts
+++ b/apps/api/src/modules/app-templates/app-templates.service.spec.ts
@@ -20,6 +20,7 @@ function makeTemplate(overrides: Partial<AppTemplateEntity> = {}): AppTemplateEn
     notification_config: {},
     credential_ref_default: 'manual:',
     execute_enabled: false,
+    is_active: true,
     extra_egress_allowlist: [],
     idle_shutdown_seconds: null,
     created_at: new Date(),

--- a/apps/api/src/modules/credentials/credentials.service.ts
+++ b/apps/api/src/modules/credentials/credentials.service.ts
@@ -340,6 +340,11 @@ export class CredentialsService {
       return null;
     }
 
+    if (template.is_active === false) {
+      this.logger.warn(`App template "${template.name}" (profile_name_pattern="${profileId}") is inactive in tenant ${tenantId} — skipping auto-provision`);
+      return null;
+    }
+
     this.logger.log(`Auto-provisioning from template "${template.name}" for user ${ownerUserId}`);
 
     const actorId = `federated:${ownerUserId}`;


### PR DESCRIPTION
## What
Adds an `is_active` boolean to App Templates so a template can be **deactivated without deleting it**.

- Migration `1708300000030-AddTemplateIsActive` (registered in `data-source.ts`'s explicit migrations array) — `is_active BOOLEAN NOT NULL DEFAULT true`
- `is_active` column on `AppTemplateEntity`
- Accepted on the create/update DTOs; toggled via the **existing** `PATCH /admin/app-templates/:id` (Admin/Editor guarded) — no new route
- `autoProvisionFromTemplate` skips inactive templates → no new per-user apps are cloned; existing apps/sessions are untouched
- Excluded from `PROPAGATED_FIELDS` and `computeContentHash`, so toggling does not churn linked apps or bump profile versions

## Why
The adoptwebui Auth Manager needs a real Active/Inactive toggle for App Templates; previously the only "off switch" was a destructive delete.

## Risk
Low. New column defaults `true` (existing templates stay active). One guard clause added to the provisioning path.

## Validation
- `tsc --noEmit` clean; `jest app-templates` → 22 passed (includes propagation tests)
- Verified live on local Kind: migration applied, `PATCH {is_active:false}` flips the row, provisioning honors it

## Related
Frontend consumer: adoptai/adoptwebui#1552

🤖 Generated with [Claude Code](https://claude.com/claude-code)