### PR TITLE
feat: route Tabby sessions through a residential upstream proxy

### DIFF
--- a/apps/api/src/data-source.ts
+++ b/apps/api/src/data-source.ts
@@ -32,6 +32,7 @@ import { AddRoleMapping1708300000027 } from './migrations/1708300000027-AddRoleM
 import { AddLastActivityAt1708300000028 } from './migrations/1708300000028-AddLastActivityAt';
 import { TraceContext1708300000029 } from './migrations/1708300000029-TraceContext';
 import { AddTemplateIsActive1708300000030 } from './migrations/1708300000030-AddTemplateIsActive';
+import { AddResidentialProxyEnabled1708300000031 } from './migrations/1708300000031-AddResidentialProxyEnabled';
 
 const poolSize = Number(process.env.DB_POOL_SIZE) || 20;
 
@@ -41,7 +42,7 @@ export const dataSourceOptions: DataSourceOptions = {
     testDefault: 'postgresql://postgres:postgres@localhost:5432/browser_hitl',
   }),
   entities: Object.values(entities),
-  migrations: [InitialSchema1708300000000, WorkerRLS1708300000001, AgentClients1708300000002, AuthRequests1708300000003, LoginQueue1708300000004, AccountLockout1708300000005, ArtifactCascadeDelete1708300000006, ServiceProfiles1708300000007, ProfileAppLink1708300000008, GenericHumanInput1708300000009, AddIdentityProviders1708300000010, AddOwnerUserIds1708300000011, AddAppTemplates1708300000012, AddIdleShutdown1708300000013, AddAppOwnerUserId1708300000014, MultiTenantCloud1708300000015, GenericOAuth1708300000016, NullablePasswordHash1708300000017, GlobalIdp1708300000018, AddRestartRequested1708300000019, AddTemplateLineage1708300000020, DropIdpSecrets1708300000021, AddExecuteEnabled1708300000022, ControllerScaling1708300000023, AddTemplateExecuteEnabled1708300000024, UnrestrictedProfiles1708300000025, AddExtraEgressAllowlist1708300000026, AddRoleMapping1708300000027, AddLastActivityAt1708300000028, TraceContext1708300000029, AddTemplateIsActive1708300000030],
+  migrations: [InitialSchema1708300000000, WorkerRLS1708300000001, AgentClients1708300000002, AuthRequests1708300000003, LoginQueue1708300000004, AccountLockout1708300000005, ArtifactCascadeDelete1708300000006, ServiceProfiles1708300000007, ProfileAppLink1708300000008, GenericHumanInput1708300000009, AddIdentityProviders1708300000010, AddOwnerUserIds1708300000011, AddAppTemplates1708300000012, AddIdleShutdown1708300000013, AddAppOwnerUserId1708300000014, MultiTenantCloud1708300000015, GenericOAuth1708300000016, NullablePasswordHash1708300000017, GlobalIdp1708300000018, AddRestartRequested1708300000019, AddTemplateLineage1708300000020, DropIdpSecrets1708300000021, AddExecuteEnabled1708300000022, ControllerScaling1708300000023, AddTemplateExecuteEnabled1708300000024, UnrestrictedProfiles1708300000025, AddExtraEgressAllowlist1708300000026, AddRoleMapping1708300000027, AddLastActivityAt1708300000028, TraceContext1708300000029, AddTemplateIsActive1708300000030, AddResidentialProxyEnabled1708300000031],
   migrationsRun: true,
   synchronize: false,
   logging: process.env.NODE_ENV === 'development' ? ['error', 'warn', 'migration'] : ['error'],

--- a/apps/api/src/entities/app-template.entity.ts
+++ b/apps/api/src/entities/app-template.entity.ts
@@ -52,6 +52,17 @@ export class AppTemplateEntity {
   execute_enabled: boolean;
 
   /**
+   * Whether apps auto-provisioned from this template route their browser session
+   * egress through the residential proxy (Oxylabs) chained upstream of Tabby's
+   * egress proxy. App-level default for the app's execute sessions; a session may
+   * override via sessions.residential_proxy_enabled. Mirrors
+   * applications.residential_proxy_enabled. Whole-session scope; `.adopt.ai`/internal
+   * hosts always dial direct regardless of this flag.
+   */
+  @Column({ type: 'boolean', default: false })
+  residential_proxy_enabled: boolean;
+
+  /**
    * Whether this template is active. Inactive templates are skipped by
    * auto-provisioning (autoProvisionFromTemplate treats is_active=false like a
    * missing template), so no new per-user apps are cloned from them. Existing

--- a/apps/api/src/entities/application.entity.ts
+++ b/apps/api/src/entities/application.entity.ts
@@ -68,6 +68,15 @@ export class ApplicationEntity {
   @Column({ type: 'boolean', default: false })
   execute_enabled: boolean;
 
+  /**
+   * App-level default for routing this app's browser session egress through the
+   * residential proxy (Oxylabs, chained upstream of the egress proxy). A session
+   * may override via sessions.residential_proxy_enabled; precedence is
+   * session ?? app ?? false. Cloned from the source template.
+   */
+  @Column({ type: 'boolean', default: false })
+  residential_proxy_enabled: boolean;
+
   /** Timestamp of last reconcile pass by any controller replica (FOR UPDATE SKIP LOCKED) */
   @Column({ type: 'timestamptz', nullable: true })
   last_reconciled_at: Date | null;

--- a/apps/api/src/entities/session.entity.ts
+++ b/apps/api/src/entities/session.entity.ts
@@ -96,4 +96,12 @@ export class SessionEntity {
 
   @Column({ type: 'varchar', nullable: true })
   traceparent: string | null;
+
+  /**
+   * Per-session override for residential-proxy egress. null = inherit the
+   * app-level default (applications.residential_proxy_enabled). The controller
+   * resolves session ?? app ?? false and tells the egress proxy per session.
+   */
+  @Column({ type: 'boolean', nullable: true })
+  residential_proxy_enabled: boolean | null;
 }

--- a/apps/api/src/migrations/1708300000031-AddResidentialProxyEnabled.ts
+++ b/apps/api/src/migrations/1708300000031-AddResidentialProxyEnabled.ts
@@ -1,0 +1,28 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddResidentialProxyEnabled1708300000031 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "app_templates" ADD COLUMN "residential_proxy_enabled" boolean NOT NULL DEFAULT false`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "applications" ADD COLUMN "residential_proxy_enabled" boolean NOT NULL DEFAULT false`,
+    );
+    // Per-session override: null = inherit the app-level default. No default value.
+    await queryRunner.query(
+      `ALTER TABLE "sessions" ADD COLUMN "residential_proxy_enabled" boolean`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "sessions" DROP COLUMN "residential_proxy_enabled"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "applications" DROP COLUMN "residential_proxy_enabled"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "app_templates" DROP COLUMN "residential_proxy_enabled"`,
+    );
+  }
+}

--- a/apps/api/src/modules/app-templates/app-templates.controller.ts
+++ b/apps/api/src/modules/app-templates/app-templates.controller.ts
@@ -49,6 +49,10 @@ class CreateAppTemplateDto {
   @IsOptional() @IsBoolean()
   execute_enabled?: boolean;
 
+  @ApiProperty({ required: false, default: false, description: 'Whether apps auto-provisioned from this template route session egress through the residential proxy (Oxylabs). App-level default; a session may override.' })
+  @IsOptional() @IsBoolean()
+  residential_proxy_enabled?: boolean;
+
   @ApiProperty({ required: false, description: 'Auto-shutdown session after N seconds idle' })
   @IsOptional() @IsInt() @Min(60)
   idle_shutdown_seconds?: number;
@@ -81,6 +85,8 @@ class UpdateAppTemplateDto {
   @IsOptional() @IsString() credential_ref_default?: string;
   @ApiProperty({ required: false })
   @IsOptional() @IsBoolean() execute_enabled?: boolean;
+  @ApiProperty({ required: false })
+  @IsOptional() @IsBoolean() residential_proxy_enabled?: boolean;
   @ApiProperty({ required: false })
   @IsOptional() @IsInt() @Min(60) idle_shutdown_seconds?: number;
   @ApiProperty({ required: false, description: 'Toggle the template active/inactive. Inactive templates are skipped by auto-provisioning.' })

--- a/apps/api/src/modules/app-templates/app-templates.service.spec.ts
+++ b/apps/api/src/modules/app-templates/app-templates.service.spec.ts
@@ -20,6 +20,7 @@ function makeTemplate(overrides: Partial<AppTemplateEntity> = {}): AppTemplateEn
     notification_config: {},
     credential_ref_default: 'manual:',
     execute_enabled: false,
+    residential_proxy_enabled: false,
     is_active: true,
     extra_egress_allowlist: [],
     idle_shutdown_seconds: null,
@@ -145,6 +146,7 @@ describe('AppTemplatesService — propagation', () => {
         export_policy: template.export_policy,
         notification_config: template.notification_config,
         execute_enabled: template.execute_enabled,
+        residential_proxy_enabled: template.residential_proxy_enabled,
       };
 
       expect(appRepo.update).toHaveBeenCalledWith('app-1', expectedPayload);

--- a/apps/api/src/modules/app-templates/app-templates.service.ts
+++ b/apps/api/src/modules/app-templates/app-templates.service.ts
@@ -92,6 +92,7 @@ export class AppTemplatesService {
   private static readonly PROPAGATED_FIELDS = [
     'browser_policy', 'login_config', 'keepalive_config',
     'export_policy', 'notification_config', 'execute_enabled',
+    'residential_proxy_enabled',
   ] as const;
 
   /** Bump minor version, reset patch. e.g. "1.0.0" → "1.1.0", "2.5.3" → "2.6.0" */
@@ -113,6 +114,7 @@ export class AppTemplatesService {
       notification_config: template.notification_config,
       credential_ref_default: template.credential_ref_default,
       execute_enabled: template.execute_enabled,
+      residential_proxy_enabled: template.residential_proxy_enabled,
       idle_shutdown_seconds: template.idle_shutdown_seconds,
     };
     return createHash('sha256')

--- a/apps/api/src/modules/apps/apps.dto.ts
+++ b/apps/api/src/modules/apps/apps.dto.ts
@@ -7,7 +7,7 @@ import { Type } from 'class-transformer';
 export const APP_SELECTABLE_FIELDS = [
   'id', 'name', 'tenant_id', 'target_urls', 'extra_egress_allowlist', 'login_config', 'keepalive_config',
   'export_policy', 'notification_config', 'browser_policy', 'desired_session_count',
-  'execute_enabled', 'credential_last_validated_at', 'credential_rotation_reminder_days',
+  'execute_enabled', 'residential_proxy_enabled', 'credential_last_validated_at', 'credential_rotation_reminder_days',
   'created_at', 'updated_at',
 ] as const;
 
@@ -89,6 +89,11 @@ export class CreateAppDto {
   @IsBoolean()
   execute_enabled?: boolean;
 
+  @ApiProperty({ description: 'Whether this app routes browser session egress through the residential proxy (Oxylabs). App-level default; a session may override.', required: false, default: false })
+  @IsOptional()
+  @IsBoolean()
+  residential_proxy_enabled?: boolean;
+
   @ApiProperty({ description: 'Target tenant UUID. Admin only — defaults to caller tenant if omitted.', required: false })
   @IsOptional()
   @IsUUID()
@@ -144,4 +149,9 @@ export class UpdateAppDto {
   @IsOptional()
   @IsBoolean()
   execute_enabled?: boolean;
+
+  @ApiProperty({ description: 'Whether this app routes browser session egress through the residential proxy (Oxylabs). App-level default; a session may override.', required: false })
+  @IsOptional()
+  @IsBoolean()
+  residential_proxy_enabled?: boolean;
 }

--- a/apps/api/src/modules/apps/apps.service.ts
+++ b/apps/api/src/modules/apps/apps.service.ts
@@ -29,6 +29,7 @@ interface CreateAppInput {
   desired_session_count?: number;
   browser_policy?: Record<string, unknown>;
   execute_enabled?: boolean;
+  residential_proxy_enabled?: boolean;
 }
 
 @Injectable()
@@ -101,6 +102,7 @@ export class AppsService {
       desired_session_count: input.desired_session_count ?? 1,
       browser_policy: input.browser_policy ?? { downloads: false, clipboard: false, file_chooser: false },
       execute_enabled: input.execute_enabled ?? false,
+      residential_proxy_enabled: input.residential_proxy_enabled ?? false,
     });
     const saved = await this.appRepo.save(app);
 
@@ -186,6 +188,7 @@ export class AppsService {
       ...(input.desired_session_count !== undefined && { desired_session_count: input.desired_session_count }),
       ...(input.browser_policy !== undefined && { browser_policy: input.browser_policy }),
       ...(input.execute_enabled !== undefined && { execute_enabled: input.execute_enabled }),
+      ...(input.residential_proxy_enabled !== undefined && { residential_proxy_enabled: input.residential_proxy_enabled }),
     });
 
     const saved = await this.appRepo.save(app);

--- a/apps/api/src/modules/credentials/credentials.service.ts
+++ b/apps/api/src/modules/credentials/credentials.service.ts
@@ -368,6 +368,9 @@ export class CredentialsService {
       // controller never provisions the worker Service + JWT_SIGNING_KEY, so the
       // per-user connection could never run /execute/fetch | /execute/browser.
       execute_enabled: template.execute_enabled,
+      // Carry the template's residential-proxy default onto the cloned app so the
+      // controller resolves the per-session egress route (session ?? app ?? false).
+      residential_proxy_enabled: template.residential_proxy_enabled,
       desired_session_count: 0, // Start with 0, scale up after profile is created
     }, tenantId, actorId);
 

--- a/apps/api/src/modules/recording/recording-provision.controller.ts
+++ b/apps/api/src/modules/recording/recording-provision.controller.ts
@@ -30,6 +30,12 @@ interface CreateRecordingSessionBody {
    * `--from` a login recording.
    */
   source_session_id?: string;
+  /**
+   * Per-session override for residential-proxy egress. When set, this recording
+   * session routes (or does not route) through the residential proxy regardless
+   * of the recording-shell app default. Omit to inherit the app default.
+   */
+  residential_proxy?: boolean;
 }
 
 /**
@@ -147,7 +153,9 @@ export class RecordingProvisionController {
     if (ownerUserId) {
       await this.appRepo.update(app_id, { owner_user_id: ownerUserId });
     }
-    await this.sessionsService.scale(app_id, 1, tenantId, actorId);
+    await this.sessionsService.scale(app_id, 1, tenantId, actorId, undefined, {
+      residentialProxy: body?.residential_proxy,
+    });
 
     // 3. Wait for the controller to create the session row, then mint the URL.
     const session = await this.waitForSession(app_id, tenantId);

--- a/apps/api/src/modules/sessions/sessions.service.ts
+++ b/apps/api/src/modules/sessions/sessions.service.ts
@@ -68,6 +68,7 @@ export class SessionsService {
     tenantId: string | undefined,
     actorId: string,
     inboundTraceparent?: string,
+    options?: { residentialProxy?: boolean },
   ): Promise<{ desired_sessions: number; app_id: string }> {
     const where: any = tenantId ? { id: appId, tenant_id: tenantId } : { id: appId };
     const app = await this.appRepo.findOne({ where });
@@ -132,6 +133,8 @@ export class SessionsService {
           hitl_attempt_count: 0,
           owner_user_id: app.owner_user_id ?? null,
           traceparent,
+          // Per-session override; unset → null → inherit the app-level default.
+          residential_proxy_enabled: options?.residentialProxy ?? null,
         }));
         await this.batonRepo.save(this.batonRepo.create({
           session_id: created.id,

--- a/apps/controller/src/entities/application.entity.ts
+++ b/apps/controller/src/entities/application.entity.ts
@@ -63,6 +63,10 @@ export class ApplicationEntity {
   @Column({ type: 'boolean', default: false })
   execute_enabled: boolean;
 
+  /** App-level default: route this app's session egress through the residential proxy. Session may override; precedence session ?? app ?? false. */
+  @Column({ type: 'boolean', default: false })
+  residential_proxy_enabled: boolean;
+
   /** Timestamp of last reconcile pass by any controller replica (FOR UPDATE SKIP LOCKED) */
   @Column({ type: 'timestamptz', nullable: true })
   last_reconciled_at: Date | null;

--- a/apps/controller/src/entities/session.entity.ts
+++ b/apps/controller/src/entities/session.entity.ts
@@ -89,4 +89,8 @@ export class SessionEntity {
 
   @Column({ type: 'varchar', nullable: true })
   traceparent: string | null;
+
+  /** Per-session override for residential-proxy egress. null = inherit app default. */
+  @Column({ type: 'boolean', nullable: true })
+  residential_proxy_enabled: boolean | null;
 }

--- a/apps/controller/src/pod-manager.service.spec.ts
+++ b/apps/controller/src/pod-manager.service.spec.ts
@@ -56,7 +56,7 @@ describe('PodManagerService egress allowlist sync', () => {
     process.env.EGRESS_PROXY_ALLOWLIST_URL = 'http://egress-proxy:8095/allowlist';
 
     const service = new PodManagerService();
-    await service.syncEgressAllowlist('session-1', ['https://example.com/login'], ['.expedia.com'], true);
+    await service.syncEgressAllowlist('session-1', ['https://example.com/login'], ['.expedia.com'], true, true);
 
     const body = JSON.parse((fetchMock.mock.calls[0][1] as any).body);
     expect(body).toEqual({
@@ -64,6 +64,7 @@ describe('PodManagerService egress allowlist sync', () => {
       target_urls: ['https://example.com/login'],
       extra_allowlist: ['.expedia.com'],
       allow_all: true,
+      residential: true,
     });
   });
 
@@ -79,6 +80,7 @@ describe('PodManagerService egress allowlist sync', () => {
     const body = JSON.parse((fetchMock.mock.calls[0][1] as any).body);
     expect(body.extra_allowlist).toEqual([]);
     expect(body.allow_all).toBe(false);
+    expect(body.residential).toBe(false);
   });
 
   it('sends DELETE allowlist cleanup with encoded session id', async () => {

--- a/apps/controller/src/pod-manager.service.ts
+++ b/apps/controller/src/pod-manager.service.ts
@@ -206,6 +206,7 @@ export class PodManagerService {
     executeEnabled: boolean = false,
     extraAllowlist: string[] = [],
     allowAll: boolean = false,
+    residential: boolean = false,
   ): Promise<void> {
     const policyName = this.buildNetworkPolicyName(sessionId);
 
@@ -213,7 +214,7 @@ export class PodManagerService {
       const policy = this.buildNetworkPolicy(policyName, sessionId, streamingMode, executeEnabled);
       this.logger.log(`Creating NetworkPolicy ${policyName} for pod ${podName}`);
       await this.createPolicy(policy);
-      await this.syncEgressAllowlist(sessionId, targetUrls, extraAllowlist, allowAll);
+      await this.syncEgressAllowlist(sessionId, targetUrls, extraAllowlist, allowAll, residential);
       this.logger.log(`NetworkPolicy ${policyName} created`);
     } catch (error) {
       this.logger.error(`Failed to create NetworkPolicy ${policyName}: ${error}`);
@@ -245,6 +246,7 @@ export class PodManagerService {
     targetUrls: string[],
     extraAllowlist: string[] = [],
     allowAll: boolean = false,
+    residential: boolean = false,
   ): Promise<void> {
     const allowlistEndpoint = process.env.EGRESS_PROXY_ALLOWLIST_URL;
     if (!allowlistEndpoint) {
@@ -262,6 +264,7 @@ export class PodManagerService {
         target_urls: targetUrls,
         extra_allowlist: extraAllowlist,
         allow_all: allowAll,
+        residential,
       }),
     });
 

--- a/apps/controller/src/reconcile.service.ts
+++ b/apps/controller/src/reconcile.service.ts
@@ -223,7 +223,7 @@ export class ReconcileService implements OnModuleInit, OnModuleDestroy {
         continue;
       }
       try {
-        await this.podManager.syncEgressAllowlist(session.id, app.target_urls, extraAllowlist, allowAll);
+        await this.podManager.syncEgressAllowlist(session.id, app.target_urls, extraAllowlist, allowAll, this.resolveResidential(session, app));
       } catch (error) {
         this.logger.error(
           `Egress allowlist sync failed for session ${session.id}; terminating session fail-closed: ${error}`,
@@ -291,6 +291,15 @@ export class ReconcileService implements OnModuleInit, OnModuleDestroy {
     const extraAllowlist = Array.isArray(app.extra_egress_allowlist) ? app.extra_egress_allowlist : [];
     const allowAll = Boolean((app.browser_policy as Record<string, unknown> | undefined)?.recording_mode);
     return { extraAllowlist, allowAll };
+  }
+
+  /**
+   * Resolve whether a session's egress should chain through the residential proxy.
+   * Precedence: per-session override → app-level default → off. The egress proxy
+   * uses this to decide per session whether to tunnel via Oxylabs.
+   */
+  private resolveResidential(session: SessionEntity, app: ApplicationEntity): boolean {
+    return session.residential_proxy_enabled ?? app.residential_proxy_enabled ?? false;
   }
 
   private async createSession(app: ApplicationEntity): Promise<void> {
@@ -368,7 +377,7 @@ export class ReconcileService implements OnModuleInit, OnModuleDestroy {
 
       // Generate NetworkPolicy — open the 8091 ingress when the worker health
       // Service exists (execute or recording drain).
-      await this.podManager.createNetworkPolicy(savedSession.id, podName, app.target_urls, streamingMode, needsWorkerHealth, extraAllowlist, allowAll);
+      await this.podManager.createNetworkPolicy(savedSession.id, podName, app.target_urls, streamingMode, needsWorkerHealth, extraAllowlist, allowAll, this.resolveResidential(savedSession, app));
 
       this.logger.log(`Created session ${savedSession.id} with pod ${podName} (mode=${streamingMode})`);
     } catch (error) {

--- a/charts/browser-hitl/files/egress-proxy/server.js
+++ b/charts/browser-hitl/files/egress-proxy/server.js
@@ -18,6 +18,13 @@ const ALLOW_INSECURE_SESSION_ALLOWLIST = (process.env.EGRESS_PROXY_ALLOW_INSECUR
   .toLowerCase() === 'true';
 const DEFAULT_ALLOWLIST = parseAllowlist(process.env.EGRESS_PROXY_DEFAULT_ALLOWLIST || '');
 
+// Upstream residential proxy (e.g. Oxylabs), chained beneath this proxy for
+// sessions flagged residential. Full proxy URL incl. server-side credentials;
+// the username may contain a `{sessionId}` placeholder for the vendor's sticky
+// session-id option (same value → same exit IP). Parsed once; NEVER logged
+// (contains credentials). Absent/invalid → residential routing is a no-op.
+const UPSTREAM_PROXY = parseUpstreamProxy(process.env.EGRESS_UPSTREAM_PROXY_URL || '');
+
 // Tabby-owned infrastructure — always allowed, merged into every allowlist at
 // match time. Immune to env/chart misconfiguration (cannot be removed by
 // EGRESS_PROXY_DEFAULT_ALLOWLIST being unset or truncated). Eliminates the
@@ -31,6 +38,10 @@ const TABBY_INFRASTRUCTURE_ALLOWLIST = ['.adopt.ai'];
 const ALLOW_ALL_SENTINEL = '*';
 
 const sessionAllowlist = new Map();
+// sessionId → boolean: whether this session's non-infra egress chains through
+// the residential upstream proxy. Populated alongside the allowlist by the
+// controller's PUT /allowlist. In-memory (same volatility as sessionAllowlist).
+const sessionResidential = new Map();
 
 function log(message, extra) {
   if (typeof extra === 'undefined') {
@@ -64,6 +75,85 @@ function extractHostFromTarget(targetUrl) {
   } catch {
     return null;
   }
+}
+
+function parseUpstreamProxy(raw) {
+  const trimmed = (raw || '').trim();
+  if (!trimmed) {
+    return null;
+  }
+  try {
+    const u = new URL(trimmed);
+    return {
+      hostname: u.hostname,
+      port: u.port ? parseInt(u.port, 10) : 80,
+      // decodeURIComponent so a `{sessionId}` placeholder survives URL parsing
+      // even if the operator percent-encoded the braces.
+      usernameTemplate: decodeURIComponent(u.username || ''),
+      password: decodeURIComponent(u.password || ''),
+    };
+  } catch {
+    // Do not echo the value — it contains credentials.
+    console.error('[egress-proxy] EGRESS_UPSTREAM_PROXY_URL is not a valid URL; residential routing disabled');
+    return null;
+  }
+}
+
+// Suffix/exact match against a domain list (entries beginning with '.' match the
+// bare apex and any subdomain). Mirrors the matching in isHostAllowed; kept
+// separate so the residential-bypass decision does not perturb allowlist logic.
+function hostMatchesList(normalized, list) {
+  for (const entry of list) {
+    if (!entry || entry === ALLOW_ALL_SENTINEL) {
+      continue;
+    }
+    if (entry.startsWith('.')) {
+      const suffix = entry.slice(1);
+      if (normalized === suffix || normalized.endsWith(`.${suffix}`)) {
+        return true;
+      }
+    } else if (normalized === entry) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// Tabby infrastructure (.adopt.ai + env DEFAULT_ALLOWLIST) and cluster-internal
+// hosts always dial direct, never through the residential proxy — residential
+// egress applies only to the external vendor target.
+function isInfraOrInternal(hostname) {
+  const normalized = normalizeHost(hostname);
+  if (!normalized) {
+    return true;
+  }
+  if (hostMatchesList(normalized, TABBY_INFRASTRUCTURE_ALLOWLIST) || hostMatchesList(normalized, DEFAULT_ALLOWLIST)) {
+    return true;
+  }
+  // Single-label names (bare Service names) and cluster-internal suffixes.
+  if (!normalized.includes('.')) {
+    return true;
+  }
+  return /(?:\.local|\.internal|\.svc|\.svc\.cluster\.local|\.cluster\.local)$/.test(normalized);
+}
+
+// A session routes residential only when: an upstream is configured, the session
+// is flagged residential, and the target is an external (non-infra) host.
+function shouldRouteResidential(hostname, sessionId) {
+  if (!UPSTREAM_PROXY || !sessionId || !sessionResidential.get(sessionId)) {
+    return false;
+  }
+  return !isInfraOrInternal(hostname);
+}
+
+// Build the upstream Proxy-Authorization header for a session, substituting the
+// sanitized sessionId into the vendor's sticky-session placeholder so the same
+// session pins the same exit IP.
+function buildUpstreamAuth(sessionId) {
+  const stickyId = String(sessionId).replace(/[^a-zA-Z0-9]/g, '');
+  const username = UPSTREAM_PROXY.usernameTemplate.replace(/\{sessionId\}/g, stickyId);
+  const creds = `${username}:${UPSTREAM_PROXY.password}`;
+  return `Basic ${Buffer.from(creds, 'utf8').toString('base64')}`;
 }
 
 function expectedSessionSecret(sessionId) {
@@ -239,6 +329,11 @@ function proxyHttpRequest(req, res) {
     return;
   }
 
+  if (shouldRouteResidential(hostname, sessionId)) {
+    proxyHttpViaUpstream(req, res, target, sessionId);
+    return;
+  }
+
   const isHttps = target.protocol === 'https:';
   const upstream = (isHttps ? https : http).request(
     {
@@ -279,6 +374,116 @@ function requireProxyAuth(socket) {
   socket.destroy();
 }
 
+// Establish a CONNECT tunnel to the target THROUGH the upstream residential
+// proxy: open a socket to the upstream, send a nested CONNECT with the vendor
+// creds, wait for its "200 Connection Established", then splice the client and
+// upstream sockets. The client's `head` bytes (TLS ClientHello) are held until
+// the upstream tunnel is confirmed, so no plaintext leaks before the tunnel is
+// up. Preserves the browser's TLS fingerprint (blind byte tunnel, no
+// termination). On any upstream failure the client gets a 502.
+const UPSTREAM_CONNECT_TIMEOUT_MS = parseInt(process.env.EGRESS_UPSTREAM_CONNECT_TIMEOUT_MS || '15000', 10);
+const UPSTREAM_MAX_HEADER_BYTES = 65536;
+
+function connectViaUpstream(clientSocket, head, targetHost, targetPort, sessionId) {
+  const auth = buildUpstreamAuth(sessionId);
+  const upstreamSocket = net.connect(UPSTREAM_PROXY.port, UPSTREAM_PROXY.hostname);
+  upstreamSocket.setTimeout(UPSTREAM_CONNECT_TIMEOUT_MS);
+
+  let established = false;
+  let responseBuffer = Buffer.alloc(0);
+
+  const fail = (reason) => {
+    if (!established && !clientSocket.destroyed) {
+      const body = JSON.stringify({ error: 'upstream_proxy_error', reason });
+      clientSocket.write(
+        'HTTP/1.1 502 Bad Gateway\r\n' +
+          'Connection: close\r\n' +
+          'Content-Type: application/json; charset=utf-8\r\n' +
+          `Content-Length: ${Buffer.byteLength(body)}\r\n` +
+          '\r\n' +
+          body,
+      );
+    }
+    upstreamSocket.destroy();
+    clientSocket.destroy();
+  };
+
+  const onData = (chunk) => {
+    responseBuffer = Buffer.concat([responseBuffer, chunk]);
+    const headerEnd = responseBuffer.indexOf('\r\n\r\n');
+    if (headerEnd === -1) {
+      if (responseBuffer.length > UPSTREAM_MAX_HEADER_BYTES) {
+        fail('oversized upstream response');
+      }
+      return; // wait for the rest of the header
+    }
+    upstreamSocket.removeListener('data', onData);
+    const statusLine = responseBuffer.slice(0, headerEnd).toString('utf8').split('\r\n')[0] || '';
+    const match = statusLine.match(/^HTTP\/\d\.\d\s+(\d{3})/);
+    const status = match ? parseInt(match[1], 10) : 0;
+    if (status !== 200) {
+      fail(`upstream CONNECT returned ${status || 'an invalid response'}`);
+      return;
+    }
+    established = true;
+    upstreamSocket.setTimeout(0);
+    // Bytes past the header terminator already belong to the tunnel.
+    const leftover = responseBuffer.slice(headerEnd + 4);
+    clientSocket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+    if (head && head.length > 0) {
+      upstreamSocket.write(head);
+    }
+    if (leftover.length > 0) {
+      clientSocket.write(leftover);
+    }
+    upstreamSocket.pipe(clientSocket);
+    clientSocket.pipe(upstreamSocket);
+    log('residential CONNECT established', { session_id: sessionId, target: `${targetHost}:${targetPort}` });
+  };
+
+  upstreamSocket.on('connect', () => {
+    upstreamSocket.write(
+      `CONNECT ${targetHost}:${targetPort} HTTP/1.1\r\n` +
+        `Host: ${targetHost}:${targetPort}\r\n` +
+        `Proxy-Authorization: ${auth}\r\n` +
+        'Connection: keep-alive\r\n' +
+        '\r\n',
+    );
+  });
+  upstreamSocket.on('data', onData);
+  upstreamSocket.on('timeout', () => fail('upstream connect timeout'));
+  upstreamSocket.on('error', (error) => fail(String(error && error.message ? error.message : 'upstream error')));
+  clientSocket.on('error', () => upstreamSocket.destroy());
+}
+
+// Forward a plain-HTTP request through the upstream residential proxy using
+// absolute-form request target + upstream Proxy-Authorization. Browser egress is
+// almost entirely HTTPS/CONNECT, so this path is secondary.
+function proxyHttpViaUpstream(req, res, target, sessionId) {
+  const headers = stripProxyHeaders(req.headers);
+  headers['proxy-authorization'] = buildUpstreamAuth(sessionId);
+  const upstream = http.request(
+    {
+      host: UPSTREAM_PROXY.hostname,
+      port: UPSTREAM_PROXY.port,
+      method: req.method,
+      path: target.href,
+      headers,
+    },
+    (upstreamRes) => {
+      res.writeHead(upstreamRes.statusCode || 502, upstreamRes.headers);
+      upstreamRes.pipe(res);
+    },
+  );
+  upstream.on('error', (error) => {
+    writeJson(res, 502, {
+      error: 'upstream_proxy_error',
+      message: String(error && error.message ? error.message : error),
+    });
+  });
+  req.pipe(upstream);
+}
+
 function proxyConnect(req, clientSocket, head) {
   const sessionId = resolveSessionId(req);
   if (!sessionId && !ALLOW_INSECURE_SESSION_ALLOWLIST) {
@@ -297,6 +502,11 @@ function proxyConnect(req, clientSocket, head) {
 
   if (!isHostAllowed(hostname, sessionId)) {
     denyConnect(clientSocket, hostname);
+    return;
+  }
+
+  if (shouldRouteResidential(hostname, sessionId)) {
+    connectViaUpstream(clientSocket, head, hostname, port, sessionId);
     return;
   }
 
@@ -356,6 +566,7 @@ async function handleAdmin(req, res) {
       ok: true,
       default_allowlist_size: DEFAULT_ALLOWLIST.length,
       session_allowlist_size: sessionAllowlist.size,
+      upstream_proxy_configured: Boolean(UPSTREAM_PROXY),
     });
     return;
   }
@@ -376,6 +587,7 @@ async function handleAdmin(req, res) {
       // from an AppTemplate, or auth domains discovered during recording.
       const extraAllowlist = Array.isArray(body.extra_allowlist) ? body.extra_allowlist : [];
       const allowAll = body.allow_all === true;
+      const residential = body.residential === true;
 
       if (!sessionId) {
         writeJson(res, 400, { error: 'session_id_required' });
@@ -400,10 +612,12 @@ async function handleAdmin(req, res) {
       }
 
       sessionAllowlist.set(sessionId, domains);
+      sessionResidential.set(sessionId, residential);
       writeJson(res, 200, {
         updated: true,
         session_id: sessionId,
         domains: Array.from(domains).sort(),
+        residential,
       });
       return;
     } catch (error) {
@@ -422,6 +636,7 @@ async function handleAdmin(req, res) {
       return;
     }
     const removed = sessionAllowlist.delete(sessionId);
+    sessionResidential.delete(sessionId);
     writeJson(res, 200, { removed, session_id: sessionId });
     return;
   }
@@ -457,24 +672,44 @@ const adminServer = http.createServer((req, res) => {
   void handleAdmin(req, res);
 });
 
-if (!ADMIN_TOKEN && !ALLOW_INSECURE_ADMIN) {
-  console.error(
-    '[egress-proxy] Refusing to start: EGRESS_PROXY_ADMIN_TOKEN is required unless EGRESS_PROXY_ALLOW_INSECURE_ADMIN=true',
-  );
-  process.exit(1);
+// Only start listening (and enforce the fail-closed startup guards) when run as
+// a script. When required as a module (tests), export the internals instead so
+// the routing decisions and the nested-CONNECT tunnel can be exercised directly.
+if (require.main === module) {
+  if (!ADMIN_TOKEN && !ALLOW_INSECURE_ADMIN) {
+    console.error(
+      '[egress-proxy] Refusing to start: EGRESS_PROXY_ADMIN_TOKEN is required unless EGRESS_PROXY_ALLOW_INSECURE_ADMIN=true',
+    );
+    process.exit(1);
+  }
+
+  if (!SESSION_KEY && !ALLOW_INSECURE_SESSION_ALLOWLIST) {
+    console.error(
+      '[egress-proxy] Refusing to start: EGRESS_PROXY_SESSION_KEY is required unless EGRESS_PROXY_ALLOW_INSECURE_SESSION_ALLOWLIST=true',
+    );
+    process.exit(1);
+  }
+
+  proxyServer.listen(PROXY_PORT, '0.0.0.0', () => {
+    log(`Proxy listening on 0.0.0.0:${PROXY_PORT}`);
+  });
+
+  adminServer.listen(ADMIN_PORT, '0.0.0.0', () => {
+    log(`Admin API listening on 0.0.0.0:${ADMIN_PORT}`);
+  });
 }
 
-if (!SESSION_KEY && !ALLOW_INSECURE_SESSION_ALLOWLIST) {
-  console.error(
-    '[egress-proxy] Refusing to start: EGRESS_PROXY_SESSION_KEY is required unless EGRESS_PROXY_ALLOW_INSECURE_SESSION_ALLOWLIST=true',
-  );
-  process.exit(1);
-}
-
-proxyServer.listen(PROXY_PORT, '0.0.0.0', () => {
-  log(`Proxy listening on 0.0.0.0:${PROXY_PORT}`);
-});
-
-adminServer.listen(ADMIN_PORT, '0.0.0.0', () => {
-  log(`Admin API listening on 0.0.0.0:${ADMIN_PORT}`);
-});
+module.exports = {
+  proxyServer,
+  adminServer,
+  sessionAllowlist,
+  sessionResidential,
+  UPSTREAM_PROXY,
+  parseUpstreamProxy,
+  hostMatchesList,
+  isInfraOrInternal,
+  shouldRouteResidential,
+  buildUpstreamAuth,
+  expectedSessionSecret,
+  TABBY_INFRASTRUCTURE_ALLOWLIST,
+};

--- a/charts/browser-hitl/files/egress-proxy/server.test.js
+++ b/charts/browser-hitl/files/egress-proxy/server.test.js
@@ -1,0 +1,249 @@
+'use strict';
+
+// Integration + unit tests for the egress proxy's residential upstream chaining.
+// Run with: node --test charts/browser-hitl/files/egress-proxy/server.test.js
+//
+// The risky code is the nested-CONNECT tunnel (connect to Oxylabs, send a nested
+// CONNECT, parse its 200, splice sockets). These tests stand up a mock upstream
+// proxy + a mock origin in-process and drive real CONNECT requests through the
+// proxy, covering: happy path (+ sticky sessid), upstream 407, connect timeout,
+// allowlist-denied still 403s, non-residential dials direct, and infra bypass.
+
+const test = require('node:test');
+const assert = require('node:assert');
+const net = require('node:net');
+const http = require('node:http');
+
+const SESSION_ID = 'sess-abc-123-def';
+const SANITIZED_SESSION_ID = 'sessabc123def';
+
+// Mock upstream (Oxylabs) proxy — behaviour switched per test via `upstreamMode`.
+let upstreamMode = 'ok'; // 'ok' | 'auth' | 'hang'
+let upstreamConnects = 0;
+let lastUpstreamAuthB64 = null;
+let lastUpstreamConnectLine = null;
+
+const upstream = net.createServer((sock) => {
+  upstreamConnects += 1;
+  let hbuf = Buffer.alloc(0);
+  const onData = (chunk) => {
+    hbuf = Buffer.concat([hbuf, chunk]);
+    const idx = hbuf.indexOf('\r\n\r\n');
+    if (idx === -1) return;
+    sock.removeListener('data', onData);
+    const lines = hbuf.slice(0, idx).toString('utf8').split('\r\n');
+    lastUpstreamConnectLine = lines[0];
+    const authLine = lines.find((l) => /^proxy-authorization:/i.test(l));
+    lastUpstreamAuthB64 = authLine ? authLine.replace(/^proxy-authorization:\s*basic\s+/i, '') : null;
+
+    if (upstreamMode === 'auth') {
+      sock.write('HTTP/1.1 407 Proxy Authentication Required\r\nConnection: close\r\n\r\n');
+      sock.destroy();
+      return;
+    }
+    if (upstreamMode === 'hang') {
+      return; // never reply → exercises the client-side connect timeout
+    }
+    const m = lines[0].match(/^CONNECT\s+([^:]+):(\d+)/);
+    const target = net.connect(parseInt(m[2], 10), m[1], () => {
+      sock.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+      const leftover = hbuf.slice(idx + 4);
+      if (leftover.length) target.write(leftover);
+      target.pipe(sock);
+      sock.pipe(target);
+    });
+    target.on('error', () => sock.destroy());
+  };
+  sock.on('data', onData);
+  sock.on('error', () => {});
+});
+
+// Mock origin (the "vendor target").
+const origin = http.createServer((req, res) => {
+  res.writeHead(200, { 'content-type': 'text/plain', connection: 'close' });
+  res.end('OK-ORIGIN');
+});
+
+let server; // the module under test
+let proxyPort;
+let originPort;
+
+function listen(srv) {
+  return new Promise((resolve) => srv.listen(0, '127.0.0.1', () => resolve(srv.address().port)));
+}
+
+test.before(async () => {
+  const upstreamPort = await listen(upstream);
+  originPort = await listen(origin);
+
+  process.env.EGRESS_PROXY_SESSION_KEY = 'testkey';
+  process.env.EGRESS_PROXY_ALLOW_INSECURE_ADMIN = 'true';
+  process.env.EGRESS_UPSTREAM_CONNECT_TIMEOUT_MS = '400';
+  process.env.EGRESS_UPSTREAM_PROXY_URL =
+    `http://user-sessid-{sessionId}:secretpass@127.0.0.1:${upstreamPort}`;
+
+  server = require('./server.js');
+  proxyPort = await listen(server.proxyServer);
+});
+
+test.after(() => {
+  server.proxyServer.close();
+  upstream.close();
+  origin.close();
+});
+
+test.beforeEach(() => {
+  upstreamMode = 'ok';
+  upstreamConnects = 0;
+  lastUpstreamAuthB64 = null;
+  lastUpstreamConnectLine = null;
+  server.sessionAllowlist.clear();
+  server.sessionResidential.clear();
+});
+
+// Drive a CONNECT through the proxy using a valid session Proxy-Authorization.
+function connectThroughProxy(host, port, { sendGet = true, timeoutMs = 3000 } = {}) {
+  return new Promise((resolve, reject) => {
+    const sock = net.connect(proxyPort, '127.0.0.1');
+    let buf = Buffer.alloc(0);
+    let status = null;
+    const finish = (extra = {}) => {
+      resolve({ status, body: buf.toString('utf8'), ...extra });
+      sock.destroy();
+    };
+    const timer = setTimeout(() => finish({ timedOut: true }), timeoutMs);
+    sock.on('connect', () => {
+      const secret = server.expectedSessionSecret(SESSION_ID);
+      const auth = Buffer.from(`${SESSION_ID}:${secret}`, 'utf8').toString('base64');
+      sock.write(
+        `CONNECT ${host}:${port} HTTP/1.1\r\nHost: ${host}:${port}\r\n` +
+          `Proxy-Authorization: Basic ${auth}\r\n\r\n`,
+      );
+    });
+    sock.on('data', (chunk) => {
+      buf = Buffer.concat([buf, chunk]);
+      if (status === null) {
+        const idx = buf.indexOf('\r\n\r\n');
+        if (idx !== -1) {
+          const line = buf.slice(0, buf.indexOf('\r\n')).toString('utf8');
+          const m = line.match(/HTTP\/\d\.\d\s+(\d{3})/);
+          status = m ? parseInt(m[1], 10) : 0;
+          buf = buf.slice(idx + 4);
+          if (status === 200 && sendGet) {
+            sock.write(`GET / HTTP/1.1\r\nHost: ${host}\r\nConnection: close\r\n\r\n`);
+          } else if (status !== 200) {
+            clearTimeout(timer);
+            finish();
+          }
+        }
+      }
+    });
+    sock.on('close', () => {
+      clearTimeout(timer);
+      finish();
+    });
+    sock.on('error', (e) => {
+      clearTimeout(timer);
+      reject(e);
+    });
+  });
+}
+
+test('residential CONNECT tunnels through the upstream and reaches the origin', async () => {
+  server.sessionAllowlist.set(SESSION_ID, new Set(['127.0.0.1']));
+  server.sessionResidential.set(SESSION_ID, true);
+
+  const res = await connectThroughProxy('127.0.0.1', originPort);
+
+  assert.strictEqual(res.status, 200, 'proxy established the tunnel');
+  assert.match(res.body, /OK-ORIGIN/, 'origin response came back through the tunnel');
+  assert.strictEqual(upstreamConnects, 1, 'exactly one upstream dial');
+  assert.match(lastUpstreamConnectLine, /^CONNECT 127\.0\.0\.1:/, 'nested CONNECT sent to upstream');
+});
+
+test('sticky sessid: sanitized session id is substituted into the upstream username', async () => {
+  server.sessionAllowlist.set(SESSION_ID, new Set(['127.0.0.1']));
+  server.sessionResidential.set(SESSION_ID, true);
+
+  await connectThroughProxy('127.0.0.1', originPort);
+
+  const decoded = Buffer.from(lastUpstreamAuthB64, 'base64').toString('utf8');
+  assert.ok(decoded.includes(`sessid-${SANITIZED_SESSION_ID}`), `sticky sessid present: ${decoded}`);
+  assert.ok(decoded.endsWith(':secretpass'), 'upstream password preserved');
+});
+
+test('upstream 407 surfaces to the client as 502', async () => {
+  upstreamMode = 'auth';
+  server.sessionAllowlist.set(SESSION_ID, new Set(['127.0.0.1']));
+  server.sessionResidential.set(SESSION_ID, true);
+
+  const res = await connectThroughProxy('127.0.0.1', originPort, { sendGet: false });
+
+  assert.strictEqual(res.status, 502, 'client gets 502 on upstream auth failure');
+});
+
+test('upstream that never responds trips the connect timeout → 502', async () => {
+  upstreamMode = 'hang';
+  server.sessionAllowlist.set(SESSION_ID, new Set(['127.0.0.1']));
+  server.sessionResidential.set(SESSION_ID, true);
+
+  const res = await connectThroughProxy('127.0.0.1', originPort, { sendGet: false, timeoutMs: 3000 });
+
+  assert.strictEqual(res.status, 502, 'client gets 502 after the upstream timeout');
+  assert.ok(!res.timedOut, 'proxy answered before the test timeout (timeout path fired)');
+});
+
+test('allowlist-denied host still 403s and never touches the upstream', async () => {
+  server.sessionAllowlist.set(SESSION_ID, new Set(['127.0.0.1']));
+  server.sessionResidential.set(SESSION_ID, true);
+
+  const res = await connectThroughProxy('evil.example.com', 443, { sendGet: false });
+
+  assert.strictEqual(res.status, 403, 'denied host is 403');
+  assert.strictEqual(upstreamConnects, 0, 'upstream never dialled for a denied host');
+});
+
+test('non-residential session dials the target directly (upstream untouched)', async () => {
+  server.sessionAllowlist.set(SESSION_ID, new Set(['127.0.0.1']));
+  server.sessionResidential.set(SESSION_ID, false);
+
+  const res = await connectThroughProxy('127.0.0.1', originPort);
+
+  assert.strictEqual(res.status, 200, 'direct tunnel established');
+  assert.match(res.body, /OK-ORIGIN/, 'origin reachable directly');
+  assert.strictEqual(upstreamConnects, 0, 'upstream not used for a non-residential session');
+});
+
+// --- Pure routing-decision unit tests ---
+
+test('parseUpstreamProxy: empty → null, valid → parsed with decoded username template', () => {
+  assert.strictEqual(server.parseUpstreamProxy(''), null);
+  const parsed = server.parseUpstreamProxy('http://user-sessid-{sessionId}:p@ss@host.example:7777');
+  assert.strictEqual(parsed.hostname, 'host.example');
+  assert.strictEqual(parsed.port, 7777);
+  assert.strictEqual(parsed.usernameTemplate, 'user-sessid-{sessionId}');
+});
+
+test('isInfraOrInternal: adopt.ai + cluster-internal + bare names bypass; external does not', () => {
+  assert.strictEqual(server.isInfraOrInternal('cdn.adopt.ai'), true);
+  assert.strictEqual(server.isInfraOrInternal('adopt.ai'), true);
+  assert.strictEqual(server.isInfraOrInternal('browser-hitl-api'), true, 'single-label service name');
+  assert.strictEqual(server.isInfraOrInternal('svc.namespace.svc.cluster.local'), true);
+  assert.strictEqual(server.isInfraOrInternal('app.vendor.com'), false, 'external vendor host');
+});
+
+test('shouldRouteResidential: precedence honours flag + infra bypass', () => {
+  const sid = 'route-test';
+  server.sessionResidential.set(sid, true);
+  assert.strictEqual(server.shouldRouteResidential('app.vendor.com', sid), true);
+  assert.strictEqual(server.shouldRouteResidential('cdn.adopt.ai', sid), false, 'infra never routes residential');
+  server.sessionResidential.set(sid, false);
+  assert.strictEqual(server.shouldRouteResidential('app.vendor.com', sid), false, 'flag off → direct');
+  assert.strictEqual(server.shouldRouteResidential('app.vendor.com', null), false, 'no session → direct');
+});
+
+test('buildUpstreamAuth: strips non-alphanumerics from the session id for the sticky sessid', () => {
+  const header = server.buildUpstreamAuth('a1b2-c3d4-e5');
+  const decoded = Buffer.from(header.replace(/^Basic\s+/, ''), 'base64').toString('utf8');
+  assert.ok(decoded.startsWith('user-sessid-a1b2c3d4e5:'), decoded);
+});

--- a/charts/browser-hitl/templates/egress-proxy-deployment.yaml
+++ b/charts/browser-hitl/templates/egress-proxy-deployment.yaml
@@ -58,6 +58,13 @@ spec:
                   name: {{ include "browser-hitl.secretName" . }}
                   key: EGRESS_PROXY_SESSION_KEY
             {{- end }}
+            {{- if .Values.secrets.egressUpstreamProxyUrl }}
+            - name: EGRESS_UPSTREAM_PROXY_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "browser-hitl.secretName" . }}
+                  key: EGRESS_UPSTREAM_PROXY_URL
+            {{- end }}
           ports:
             - name: proxy
               containerPort: {{ .Values.egressProxy.port }}

--- a/charts/browser-hitl/templates/secrets.yaml
+++ b/charts/browser-hitl/templates/secrets.yaml
@@ -19,6 +19,9 @@ data:
   {{- if .Values.secrets.egressProxySessionKey }}
   EGRESS_PROXY_SESSION_KEY: {{ .Values.secrets.egressProxySessionKey | b64enc | quote }}
   {{- end }}
+  {{- if .Values.secrets.egressUpstreamProxyUrl }}
+  EGRESS_UPSTREAM_PROXY_URL: {{ .Values.secrets.egressUpstreamProxyUrl | b64enc | quote }}
+  {{- end }}
   {{- if .Values.secrets.redisPassword }}
   REDIS_PASSWORD: {{ .Values.secrets.redisPassword | b64enc | quote }}
   {{- end }}

--- a/charts/browser-hitl/values-local.yaml
+++ b/charts/browser-hitl/values-local.yaml
@@ -164,6 +164,10 @@ secrets:
   adminBootstrapPassword: "LocalDev123!@#"
   egressProxyAdminToken: "localdev-egress-token"
   egressProxySessionKey: "localdev-egress-session-key"
+  # Set to an Oxylabs (or other) upstream proxy URL to exercise residential
+  # egress locally, e.g. "http://customer-USER-sessid-{sessionId}:PASS@pr.oxylabs.io:7777".
+  # Empty = residential routing disabled (targets dialed direct).
+  egressUpstreamProxyUrl: ""
   serviceAuthClientId: "phase4-bot"
   serviceAuthClientSecret: "phase4-secret"
   metricsAuthToken: ""  # Open access locally

--- a/charts/browser-hitl/values.yaml
+++ b/charts/browser-hitl/values.yaml
@@ -489,6 +489,14 @@ secrets:
   adminBootstrapPassword: "changeme-admin-password"
   egressProxyAdminToken: "changeme-egress-proxy-admin-token"
   egressProxySessionKey: "changeme-egress-proxy-session-key"
+  # Upstream residential proxy gateway (e.g. Oxylabs), incl. server-side creds.
+  # Empty = residential routing disabled (the egress proxy dials targets direct).
+  # Wired into the egress-proxy pod ONLY. Confirm datacenter-vs-residential before
+  # setting: residential = "http://customer-<USER>-sessid-{sessionId}:<PASS>@pr.oxylabs.io:7777"
+  # (the {sessionId} placeholder pins a sticky exit IP per Tabby session);
+  # datacenter = "http://user-<USER>:<PASS>@dc.oxylabs.io:8000". Datacenter IPs
+  # defeat the residential purpose — do not use unless intentional.
+  egressUpstreamProxyUrl: ""
   slackBotToken: ""
   slackSigningSecret: ""
   slackAppToken: ""

--- a/infra/tfy/deploy.yaml
+++ b/infra/tfy/deploy.yaml
@@ -363,6 +363,7 @@ values:
     adminBootstrapPassword: "${ADMIN_BOOTSTRAP_PASSWORD}"
     egressProxyAdminToken: "${EGRESS_PROXY_ADMIN_TOKEN}"
     egressProxySessionKey: "${EGRESS_PROXY_SESSION_KEY}"
+    egressUpstreamProxyUrl: "${EGRESS_UPSTREAM_PROXY_URL}"
     serviceAuthClientId: "${SERVICE_AUTH_CLIENT_ID}"
     serviceAuthClientSecret: "${SERVICE_AUTH_CLIENT_SECRET}"
     slackBotToken: "${SLACK_BOT_TOKEN}"


### PR DESCRIPTION
## What
Adds an optional **residential-proxy egress path**, controlled by two switches:
- `residential_proxy_enabled` on the **App Template** (app-level default; cloned onto auto-provisioned apps, propagated + content-hashed like `execute_enabled`).
- A per-session override `residential_proxy` on `POST /recording/sessions` (nullable session column = inherit).

The controller resolves precedence `session ?? app ?? false` and passes a `residential` flag to the shared egress proxy via `PUT /allowlist`. The egress proxy chains an upstream vendor proxy (e.g. Oxylabs) via a **nested CONNECT** for flagged sessions, with sticky `{sessionId}` substitution. Infra/`.adopt.ai` and cluster-internal hosts always dial direct, and the per-session allowlist stays enforced upstream of the routing decision.

## Why
Route selected browser sessions (login, recording, health checks, `/execute/fetch`) out through a residential/vendor IP without per-worker proxy config or leaking vendor creds into worker pods.

## Key pieces
- Migration `031` adds the flag to `app_templates` + `applications` (NOT NULL default false) and `sessions` (nullable = inherit).
- Egress proxy (`server.js`): `EGRESS_UPSTREAM_PROXY_URL` upstream chaining, 502 on upstream 407/timeout, credentials never logged, env-tunable connect timeout.
- Helm: `EGRESS_UPSTREAM_PROXY_URL` wired as a Secret into the egress-proxy pod **only**.
- Pairs with adoptwebui PR (the App Template editor toggle).

## Risk
Low–moderate. The hand-rolled nested-CONNECT socket handshake is the main surface; covered by unit + integration tests (happy path, sticky sessid, 407, timeout, allowlist-403, non-residential direct). Both controls default **off**.

## Validation
- `pnpm build` + `lint` + `test` (all 7 projects), `helm lint`, helm render on/off.
- New `server.test.js` (`node --test`) 10/10.
- **Live local-Kind run**: egress IP shifted `191.201.123.105` (BR, direct) → `93.115.200.159` (US, via Oxylabs) with denied host still 403; `/healthz` reported `upstream_proxy_configured: true`. Run used the Oxylabs **datacenter** endpoint; residential endpoint is reached correctly but pending valid residential creds (Oxylabs returns 407 for the current creds — an account/entitlement item, not a code issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)