### PR TITLE
feat: warm recording-session pool + cold-start quick wins for VNC links

### DIFF
--- a/apps/api/src/data-source.ts
+++ b/apps/api/src/data-source.ts
@@ -33,6 +33,7 @@ import { AddLastActivityAt1708300000028 } from './migrations/1708300000028-AddLa
 import { TraceContext1708300000029 } from './migrations/1708300000029-TraceContext';
 import { AddTemplateIsActive1708300000030 } from './migrations/1708300000030-AddTemplateIsActive';
 import { AddResidentialProxyEnabled1708300000031 } from './migrations/1708300000031-AddResidentialProxyEnabled';
+import { AddSessionPoolState1708300000032 } from './migrations/1708300000032-AddSessionPoolState';
 
 const poolSize = Number(process.env.DB_POOL_SIZE) || 20;
 
@@ -42,7 +43,7 @@ export const dataSourceOptions: DataSourceOptions = {
     testDefault: 'postgresql://postgres:postgres@localhost:5432/browser_hitl',
   }),
   entities: Object.values(entities),
-  migrations: [InitialSchema1708300000000, WorkerRLS1708300000001, AgentClients1708300000002, AuthRequests1708300000003, LoginQueue1708300000004, AccountLockout1708300000005, ArtifactCascadeDelete1708300000006, ServiceProfiles1708300000007, ProfileAppLink1708300000008, GenericHumanInput1708300000009, AddIdentityProviders1708300000010, AddOwnerUserIds1708300000011, AddAppTemplates1708300000012, AddIdleShutdown1708300000013, AddAppOwnerUserId1708300000014, MultiTenantCloud1708300000015, GenericOAuth1708300000016, NullablePasswordHash1708300000017, GlobalIdp1708300000018, AddRestartRequested1708300000019, AddTemplateLineage1708300000020, DropIdpSecrets1708300000021, AddExecuteEnabled1708300000022, ControllerScaling1708300000023, AddTemplateExecuteEnabled1708300000024, UnrestrictedProfiles1708300000025, AddExtraEgressAllowlist1708300000026, AddRoleMapping1708300000027, AddLastActivityAt1708300000028, TraceContext1708300000029, AddTemplateIsActive1708300000030, AddResidentialProxyEnabled1708300000031],
+  migrations: [InitialSchema1708300000000, WorkerRLS1708300000001, AgentClients1708300000002, AuthRequests1708300000003, LoginQueue1708300000004, AccountLockout1708300000005, ArtifactCascadeDelete1708300000006, ServiceProfiles1708300000007, ProfileAppLink1708300000008, GenericHumanInput1708300000009, AddIdentityProviders1708300000010, AddOwnerUserIds1708300000011, AddAppTemplates1708300000012, AddIdleShutdown1708300000013, AddAppOwnerUserId1708300000014, MultiTenantCloud1708300000015, GenericOAuth1708300000016, NullablePasswordHash1708300000017, GlobalIdp1708300000018, AddRestartRequested1708300000019, AddTemplateLineage1708300000020, DropIdpSecrets1708300000021, AddExecuteEnabled1708300000022, ControllerScaling1708300000023, AddTemplateExecuteEnabled1708300000024, UnrestrictedProfiles1708300000025, AddExtraEgressAllowlist1708300000026, AddRoleMapping1708300000027, AddLastActivityAt1708300000028, TraceContext1708300000029, AddTemplateIsActive1708300000030, AddResidentialProxyEnabled1708300000031, AddSessionPoolState1708300000032],
   migrationsRun: true,
   synchronize: false,
   logging: process.env.NODE_ENV === 'development' ? ['error', 'warn', 'migration'] : ['error'],

--- a/apps/api/src/entities/session.entity.ts
+++ b/apps/api/src/entities/session.entity.ts
@@ -104,4 +104,13 @@ export class SessionEntity {
    */
   @Column({ type: 'boolean', nullable: true })
   residential_proxy_enabled: boolean | null;
+
+  /**
+   * Warm-pool marker. 'WARM' = a pre-warmed recording spare sitting on
+   * about:blank, ready to be claimed. 'CLAIMED' = claimed by a recording
+   * request and reassigned to a per-target recording-shell app. null = an
+   * ordinary (non-pool) session.
+   */
+  @Column({ type: 'varchar', length: 16, nullable: true })
+  pool_state: 'WARM' | 'CLAIMED' | null;
 }

--- a/apps/api/src/migrations/1708300000032-AddSessionPoolState.ts
+++ b/apps/api/src/migrations/1708300000032-AddSessionPoolState.ts
@@ -1,0 +1,26 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Warm recording-session pool support. `pool_state` marks a session as a
+ * pre-warmed spare ('WARM') that a recording request can atomically claim
+ * ('CLAIMED'). null = an ordinary session (all existing rows). The partial
+ * index backs the hot claim query
+ *   SELECT ... WHERE app_id = $pool AND pool_state = 'WARM' AND state = 'HEALTHY'
+ *   FOR UPDATE SKIP LOCKED
+ * so concurrent API replicas grab distinct spares without contention.
+ */
+export class AddSessionPoolState1708300000032 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "sessions" ADD COLUMN "pool_state" varchar(16)`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "idx_sessions_pool_claim" ON "sessions" ("app_id", "pool_state", "state") WHERE "pool_state" IS NOT NULL`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_sessions_pool_claim"`);
+    await queryRunner.query(`ALTER TABLE "sessions" DROP COLUMN "pool_state"`);
+  }
+}

--- a/apps/api/src/modules/recording/recording-pool.service.spec.ts
+++ b/apps/api/src/modules/recording/recording-pool.service.spec.ts
@@ -1,0 +1,116 @@
+import { RECORDING_POOL } from '@browser-hitl/shared';
+import { RecordingPoolService } from './recording-pool.service';
+
+/**
+ * Build a service with a given env config + mocked deps. The constructor reads
+ * RECORDING_POOL_SIZE / RECORDING_POOL_TENANTS from process.env, so we set them
+ * before instantiating.
+ */
+function makeService(
+  env: { size?: string; tenants?: string },
+  deps: { appRepoFindOne?: jest.Mock; managerQuery?: jest.Mock; findOne?: jest.Mock } = {},
+) {
+  const prevSize = process.env.RECORDING_POOL_SIZE;
+  const prevTenants = process.env.RECORDING_POOL_TENANTS;
+  if (env.size === undefined) delete process.env.RECORDING_POOL_SIZE;
+  else process.env.RECORDING_POOL_SIZE = env.size;
+  if (env.tenants === undefined) delete process.env.RECORDING_POOL_TENANTS;
+  else process.env.RECORDING_POOL_TENANTS = env.tenants;
+
+  const appRepo = { findOne: deps.appRepoFindOne ?? jest.fn(), update: jest.fn() } as any;
+  const sessionRepo = {} as any;
+  // claimWarmSession runs inside dataSource.transaction(cb): the callback gets a
+  // manager exposing query() (SELECT ... FOR UPDATE SKIP LOCKED, then UPDATE) and
+  // getRepository().findOne() to return the claimed entity.
+  const managerQuery = deps.managerQuery ?? jest.fn();
+  const findOne = deps.findOne ?? jest.fn();
+  const manager = { query: managerQuery, getRepository: () => ({ findOne }) };
+  const dataSource = {
+    transaction: jest.fn(async (cb: any) => cb(manager)),
+  } as any;
+  const appsService = { create: jest.fn() } as any;
+
+  const svc = new RecordingPoolService(appsService, appRepo, sessionRepo, dataSource);
+
+  // Restore env so tests don't leak.
+  if (prevSize === undefined) delete process.env.RECORDING_POOL_SIZE;
+  else process.env.RECORDING_POOL_SIZE = prevSize;
+  if (prevTenants === undefined) delete process.env.RECORDING_POOL_TENANTS;
+  else process.env.RECORDING_POOL_TENANTS = prevTenants;
+
+  return { svc, appRepo, dataSource, managerQuery, findOne };
+}
+
+describe('RecordingPoolService.isEnabledForTenant', () => {
+  it('is disabled when size is 0 / unset regardless of tenants', () => {
+    expect(makeService({ tenants: '*' }).svc.isEnabledForTenant('t1')).toBe(false);
+    expect(makeService({ size: '0', tenants: 't1' }).svc.isEnabledForTenant('t1')).toBe(false);
+  });
+
+  it('is disabled when size > 0 but no tenants opted in', () => {
+    expect(makeService({ size: '3' }).svc.isEnabledForTenant('t1')).toBe(false);
+    expect(makeService({ size: '3', tenants: '' }).svc.isEnabledForTenant('t1')).toBe(false);
+  });
+
+  it('enables all tenants with wildcard', () => {
+    const { svc } = makeService({ size: '3', tenants: '*' });
+    expect(svc.isEnabledForTenant('t1')).toBe(true);
+    expect(svc.isEnabledForTenant('anything')).toBe(true);
+  });
+
+  it('enables only explicitly-listed tenants', () => {
+    const { svc } = makeService({ size: '2', tenants: 't1, t2 ' });
+    expect(svc.isEnabledForTenant('t1')).toBe(true);
+    expect(svc.isEnabledForTenant('t2')).toBe(true);
+    expect(svc.isEnabledForTenant('t3')).toBe(false);
+  });
+});
+
+describe('RecordingPoolService.claimWarmSession', () => {
+  it('returns null when the tenant has no pool app', async () => {
+    const { svc, dataSource } = makeService(
+      { size: '2', tenants: '*' },
+      { appRepoFindOne: jest.fn().mockResolvedValue(null) },
+    );
+    expect(await svc.claimWarmSession('t1', 'shell-app', 'user-1')).toBeNull();
+    expect(dataSource.transaction).not.toHaveBeenCalled();
+  });
+
+  it('returns null when no warm spare is available', async () => {
+    const { svc } = makeService(
+      { size: '2', tenants: '*' },
+      {
+        appRepoFindOne: jest.fn().mockResolvedValue({ id: 'pool-app' }),
+        managerQuery: jest.fn().mockResolvedValue([]), // SELECT finds no spare
+      },
+    );
+    expect(await svc.claimWarmSession('t1', 'shell-app', 'user-1')).toBeNull();
+  });
+
+  it('atomically reassigns a warm spare with the right claim params', async () => {
+    const claimedEntity = { id: 'sess-1', pod_name: 'worker-abc', app_id: 'shell-app' };
+    // First manager.query = SELECT (returns picked id); second = UPDATE.
+    const managerQuery = jest.fn()
+      .mockResolvedValueOnce([{ id: 'sess-1' }])
+      .mockResolvedValueOnce(undefined);
+    const findOne = jest.fn().mockResolvedValue(claimedEntity);
+    const { svc } = makeService(
+      { size: '2', tenants: '*' },
+      { appRepoFindOne: jest.fn().mockResolvedValue({ id: 'pool-app' }), managerQuery, findOne },
+    );
+
+    const result = await svc.claimWarmSession('t1', 'shell-app', 'user-1');
+
+    expect(result).toEqual(claimedEntity);
+    // SELECT filters pool-app / tenant / WARM.
+    expect(managerQuery.mock.calls[0][1]).toEqual(['pool-app', 't1', RECORDING_POOL.WARM]);
+    // UPDATE sets shell app_id, owner, CLAIMED for the picked id.
+    expect(managerQuery.mock.calls[1][1]).toEqual([
+      'shell-app',
+      'user-1',
+      RECORDING_POOL.CLAIMED,
+      'sess-1',
+    ]);
+    expect(findOne).toHaveBeenCalledWith({ where: { id: 'sess-1' } });
+  });
+});

--- a/apps/api/src/modules/recording/recording-pool.service.spec.ts
+++ b/apps/api/src/modules/recording/recording-pool.service.spec.ts
@@ -7,13 +7,16 @@ import { RecordingPoolService } from './recording-pool.service';
  * before instantiating.
  */
 function makeService(
-  env: { size?: string; tenants?: string },
+  env: { size?: string; residentialSize?: string; tenants?: string },
   deps: { appRepoFindOne?: jest.Mock; managerQuery?: jest.Mock; findOne?: jest.Mock } = {},
 ) {
   const prevSize = process.env.RECORDING_POOL_SIZE;
+  const prevResidentialSize = process.env.RECORDING_POOL_RESIDENTIAL_SIZE;
   const prevTenants = process.env.RECORDING_POOL_TENANTS;
   if (env.size === undefined) delete process.env.RECORDING_POOL_SIZE;
   else process.env.RECORDING_POOL_SIZE = env.size;
+  if (env.residentialSize === undefined) delete process.env.RECORDING_POOL_RESIDENTIAL_SIZE;
+  else process.env.RECORDING_POOL_RESIDENTIAL_SIZE = env.residentialSize;
   if (env.tenants === undefined) delete process.env.RECORDING_POOL_TENANTS;
   else process.env.RECORDING_POOL_TENANTS = env.tenants;
 
@@ -35,6 +38,8 @@ function makeService(
   // Restore env so tests don't leak.
   if (prevSize === undefined) delete process.env.RECORDING_POOL_SIZE;
   else process.env.RECORDING_POOL_SIZE = prevSize;
+  if (prevResidentialSize === undefined) delete process.env.RECORDING_POOL_RESIDENTIAL_SIZE;
+  else process.env.RECORDING_POOL_RESIDENTIAL_SIZE = prevResidentialSize;
   if (prevTenants === undefined) delete process.env.RECORDING_POOL_TENANTS;
   else process.env.RECORDING_POOL_TENANTS = prevTenants;
 
@@ -63,6 +68,24 @@ describe('RecordingPoolService.isEnabledForTenant', () => {
     expect(svc.isEnabledForTenant('t1')).toBe(true);
     expect(svc.isEnabledForTenant('t2')).toBe(true);
     expect(svc.isEnabledForTenant('t3')).toBe(false);
+  });
+
+  it('gates the residential flavor on RECORDING_POOL_RESIDENTIAL_SIZE independently', () => {
+    // Non-residential pool on, residential pool off.
+    const nonResiOnly = makeService({ size: '2', tenants: '*' }).svc;
+    expect(nonResiOnly.isEnabledForTenant('t1', false)).toBe(true);
+    expect(nonResiOnly.isEnabledForTenant('t1', true)).toBe(false);
+
+    // Residential pool on, non-residential pool off.
+    const resiOnly = makeService({ residentialSize: '2', tenants: '*' }).svc;
+    expect(resiOnly.isEnabledForTenant('t1', false)).toBe(false);
+    expect(resiOnly.isEnabledForTenant('t1', true)).toBe(true);
+
+    // Both flavors sized (the 2+2 config).
+    const both = makeService({ size: '2', residentialSize: '2', tenants: 't1' }).svc;
+    expect(both.isEnabledForTenant('t1', false)).toBe(true);
+    expect(both.isEnabledForTenant('t1', true)).toBe(true);
+    expect(both.isEnabledForTenant('t2', true)).toBe(false);
   });
 });
 
@@ -112,5 +135,29 @@ describe('RecordingPoolService.claimWarmSession', () => {
       'sess-1',
     ]);
     expect(findOne).toHaveBeenCalledWith({ where: { id: 'sess-1' } });
+  });
+
+  it('claims from the non-residential pool app by default', async () => {
+    const appRepoFindOne = jest.fn().mockResolvedValue(null);
+    const { svc } = makeService(
+      { size: '2', residentialSize: '2', tenants: '*' },
+      { appRepoFindOne },
+    );
+    await svc.claimWarmSession('t1', 'shell-app', 'user-1');
+    expect(appRepoFindOne).toHaveBeenCalledWith({
+      where: { tenant_id: 't1', name: RECORDING_POOL.APP_NAME },
+    });
+  });
+
+  it('claims from the residential pool app when residential=true', async () => {
+    const appRepoFindOne = jest.fn().mockResolvedValue(null);
+    const { svc } = makeService(
+      { size: '2', residentialSize: '2', tenants: '*' },
+      { appRepoFindOne },
+    );
+    await svc.claimWarmSession('t1', 'shell-app', 'user-1', true);
+    expect(appRepoFindOne).toHaveBeenCalledWith({
+      where: { tenant_id: 't1', name: RECORDING_POOL.RESIDENTIAL_APP_NAME },
+    });
   });
 });

--- a/apps/api/src/modules/recording/recording-pool.service.ts
+++ b/apps/api/src/modules/recording/recording-pool.service.ts
@@ -23,6 +23,7 @@ import { AppsService } from '../apps/apps.service';
 export class RecordingPoolService implements OnModuleInit {
   private readonly logger = new Logger(RecordingPoolService.name);
   private readonly poolSize: number;
+  private readonly residentialPoolSize: number;
   private readonly poolTenants: Set<string>;
   private readonly allTenants: boolean;
 
@@ -35,6 +36,10 @@ export class RecordingPoolService implements OnModuleInit {
     private readonly dataSource: DataSource,
   ) {
     this.poolSize = Math.max(0, parseInt(process.env.RECORDING_POOL_SIZE || '0', 10) || 0);
+    this.residentialPoolSize = Math.max(
+      0,
+      parseInt(process.env.RECORDING_POOL_RESIDENTIAL_SIZE || '0', 10) || 0,
+    );
     const raw = (process.env.RECORDING_POOL_TENANTS || '').trim();
     this.allTenants = raw === '*';
     this.poolTenants = new Set(
@@ -42,54 +47,78 @@ export class RecordingPoolService implements OnModuleInit {
     );
   }
 
-  /** Pool active for this tenant? size>0 AND (tenant listed OR wildcard). */
-  isEnabledForTenant(tenantId: string): boolean {
-    if (this.poolSize <= 0) return false;
+  /** Desired warm-spare count for the requested flavor. */
+  private sizeFor(residential: boolean): number {
+    return residential ? this.residentialPoolSize : this.poolSize;
+  }
+
+  /** Well-known pool app name for the requested flavor. */
+  private appNameFor(residential: boolean): string {
+    return residential ? RECORDING_POOL.RESIDENTIAL_APP_NAME : RECORDING_POOL.APP_NAME;
+  }
+
+  /**
+   * Pool active for this tenant + flavor? The flavor's size>0 AND (tenant listed
+   * OR wildcard). Residential and non-residential capacity are sized
+   * independently (RECORDING_POOL_SIZE vs RECORDING_POOL_RESIDENTIAL_SIZE), so a
+   * tenant can have a warm pool for one flavor and cold-start the other.
+   */
+  isEnabledForTenant(tenantId: string, residential = false): boolean {
+    if (this.sizeFor(residential) <= 0) return false;
     return this.allTenants || this.poolTenants.has(tenantId);
   }
 
   async onModuleInit(): Promise<void> {
-    if (this.poolSize <= 0) return;
+    if (this.poolSize <= 0 && this.residentialPoolSize <= 0) return;
     // Eagerly ensure pool apps for explicitly-listed tenants so spares warm
     // before the first request. A '*' wildcard can't be pre-enumerated, so those
-    // tenants warm lazily on their first recording request.
+    // tenants warm lazily on their first recording request. Each enabled flavor
+    // gets its own pool app.
     for (const tenantId of this.poolTenants) {
-      try {
-        await this.ensurePoolApp(tenantId);
-      } catch (err) {
-        this.logger.warn(`Failed to ensure pool app for tenant ${tenantId}: ${err}`);
+      for (const residential of [false, true]) {
+        if (this.sizeFor(residential) <= 0) continue;
+        try {
+          await this.ensurePoolApp(tenantId, residential);
+        } catch (err) {
+          this.logger.warn(
+            `Failed to ensure ${residential ? 'residential ' : ''}pool app for tenant ${tenantId}: ${err}`,
+          );
+        }
       }
     }
   }
 
   /**
-   * Find-or-create the tenant's pool app and keep its desired_session_count in
-   * sync with RECORDING_POOL_SIZE. Idempotent + safe under concurrent API
-   * replicas (re-reads on create race). Returns the pool app id.
+   * Find-or-create the tenant's pool app for the given flavor and keep its
+   * desired_session_count in sync with the flavor's configured size. Idempotent +
+   * safe under concurrent API replicas (re-reads on create race). Returns the
+   * pool app id.
    */
-  async ensurePoolApp(tenantId: string): Promise<string> {
+  async ensurePoolApp(tenantId: string, residential = false): Promise<string> {
+    const appName = this.appNameFor(residential);
+    const size = this.sizeFor(residential);
     const existing = await this.appRepo.findOne({
-      where: { tenant_id: tenantId, name: RECORDING_POOL.APP_NAME },
+      where: { tenant_id: tenantId, name: appName },
     });
     if (existing) {
-      if (existing.desired_session_count !== this.poolSize) {
-        await this.appRepo.update(existing.id, { desired_session_count: this.poolSize });
+      if (existing.desired_session_count !== size) {
+        await this.appRepo.update(existing.id, { desired_session_count: size });
       }
       return existing.id;
     }
     try {
       const { app_id } = await this.appsService.create(
-        this.buildPoolAppInput(),
+        this.buildPoolAppInput(residential),
         tenantId,
         'system:recording-pool',
       );
       this.logger.log(
-        `Created recording pool app ${app_id} for tenant ${tenantId} (size ${this.poolSize})`,
+        `Created ${residential ? 'residential ' : ''}recording pool app ${app_id} for tenant ${tenantId} (size ${size})`,
       );
       return app_id;
     } catch (err) {
       const raced = await this.appRepo.findOne({
-        where: { tenant_id: tenantId, name: RECORDING_POOL.APP_NAME },
+        where: { tenant_id: tenantId, name: appName },
       });
       if (raced) return raced.id;
       throw err;
@@ -109,9 +138,10 @@ export class RecordingPoolService implements OnModuleInit {
     tenantId: string,
     targetAppId: string,
     ownerUserId: string | null,
+    residential = false,
   ): Promise<SessionEntity | null> {
     const poolApp = await this.appRepo.findOne({
-      where: { tenant_id: tenantId, name: RECORDING_POOL.APP_NAME },
+      where: { tenant_id: tenantId, name: this.appNameFor(residential) },
     });
     if (!poolApp) return null;
 
@@ -140,7 +170,7 @@ export class RecordingPoolService implements OnModuleInit {
     });
   }
 
-  private buildPoolAppInput() {
+  private buildPoolAppInput(residential = false) {
     // HTTPS placeholder: app validation requires https target_urls / goto steps,
     // and about:blank fails it. The value is inert — recording mode runs
     // unrestricted egress (resolveEgressOptions allowAll), so a claimed spare can
@@ -148,8 +178,12 @@ export class RecordingPoolService implements OnModuleInit {
     // warms on this page and bind re-navigates it to the real target.
     const PLACEHOLDER_URL = process.env.RECORDING_POOL_WARM_URL || 'https://example.com';
     return {
-      name: RECORDING_POOL.APP_NAME,
+      name: this.appNameFor(residential),
       target_urls: [PLACEHOLDER_URL],
+      // Residential pool spares warm with residential egress active (the session
+      // rows also carry an explicit residential flag — see reconcile.createSession
+      // — so it survives reassignment to the target shell app on claim).
+      residential_proxy_enabled: residential,
       login_config: {
         login_url: PLACEHOLDER_URL,
         credential_ref: 'manual:',
@@ -172,7 +206,7 @@ export class RecordingPoolService implements OnModuleInit {
         recording_mode: 'login' as RecordingMode,
       },
       notification_config: {},
-      desired_session_count: this.poolSize,
+      desired_session_count: this.sizeFor(residential),
     };
   }
 }

--- a/apps/api/src/modules/recording/recording-pool.service.ts
+++ b/apps/api/src/modules/recording/recording-pool.service.ts
@@ -1,0 +1,178 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { RECORDING_POOL, type RecordingMode } from '@browser-hitl/shared';
+import { ApplicationEntity, SessionEntity } from '../../entities';
+import { AppsService } from '../apps/apps.service';
+
+/**
+ * Warm recording-session pool.
+ *
+ * Maintains, per opt-in tenant, a dedicated "pool app" whose sessions are
+ * pre-warmed recording pods sitting on about:blank (browser up, noVNC serving,
+ * health PASS). A recording request atomically CLAIMS one of these spares and
+ * reassigns it to a per-target recording-shell app, then binds it (navigate +
+ * seed cookies) — turning a ~1-2min cold pod bring-up into a sub-second claim.
+ *
+ * Cross-tenant reuse is impossible: recording bundles are stored in the tenant's
+ * MinIO bucket under its encryption key, so a spare can only ever serve its own
+ * tenant. The pool is therefore strictly per-tenant and opt-in via
+ * RECORDING_POOL_TENANTS (empty = feature off → cold path everywhere).
+ */
+@Injectable()
+export class RecordingPoolService implements OnModuleInit {
+  private readonly logger = new Logger(RecordingPoolService.name);
+  private readonly poolSize: number;
+  private readonly poolTenants: Set<string>;
+  private readonly allTenants: boolean;
+
+  constructor(
+    private readonly appsService: AppsService,
+    @InjectRepository(ApplicationEntity)
+    private readonly appRepo: Repository<ApplicationEntity>,
+    @InjectRepository(SessionEntity)
+    private readonly sessionRepo: Repository<SessionEntity>,
+    private readonly dataSource: DataSource,
+  ) {
+    this.poolSize = Math.max(0, parseInt(process.env.RECORDING_POOL_SIZE || '0', 10) || 0);
+    const raw = (process.env.RECORDING_POOL_TENANTS || '').trim();
+    this.allTenants = raw === '*';
+    this.poolTenants = new Set(
+      raw && raw !== '*' ? raw.split(',').map((s) => s.trim()).filter(Boolean) : [],
+    );
+  }
+
+  /** Pool active for this tenant? size>0 AND (tenant listed OR wildcard). */
+  isEnabledForTenant(tenantId: string): boolean {
+    if (this.poolSize <= 0) return false;
+    return this.allTenants || this.poolTenants.has(tenantId);
+  }
+
+  async onModuleInit(): Promise<void> {
+    if (this.poolSize <= 0) return;
+    // Eagerly ensure pool apps for explicitly-listed tenants so spares warm
+    // before the first request. A '*' wildcard can't be pre-enumerated, so those
+    // tenants warm lazily on their first recording request.
+    for (const tenantId of this.poolTenants) {
+      try {
+        await this.ensurePoolApp(tenantId);
+      } catch (err) {
+        this.logger.warn(`Failed to ensure pool app for tenant ${tenantId}: ${err}`);
+      }
+    }
+  }
+
+  /**
+   * Find-or-create the tenant's pool app and keep its desired_session_count in
+   * sync with RECORDING_POOL_SIZE. Idempotent + safe under concurrent API
+   * replicas (re-reads on create race). Returns the pool app id.
+   */
+  async ensurePoolApp(tenantId: string): Promise<string> {
+    const existing = await this.appRepo.findOne({
+      where: { tenant_id: tenantId, name: RECORDING_POOL.APP_NAME },
+    });
+    if (existing) {
+      if (existing.desired_session_count !== this.poolSize) {
+        await this.appRepo.update(existing.id, { desired_session_count: this.poolSize });
+      }
+      return existing.id;
+    }
+    try {
+      const { app_id } = await this.appsService.create(
+        this.buildPoolAppInput(),
+        tenantId,
+        'system:recording-pool',
+      );
+      this.logger.log(
+        `Created recording pool app ${app_id} for tenant ${tenantId} (size ${this.poolSize})`,
+      );
+      return app_id;
+    } catch (err) {
+      const raced = await this.appRepo.findOne({
+        where: { tenant_id: tenantId, name: RECORDING_POOL.APP_NAME },
+      });
+      if (raced) return raced.id;
+      throw err;
+    }
+  }
+
+  /**
+   * Atomically claim one WARM+HEALTHY spare and reassign it to the target
+   * recording-shell app (stamping owner + CLAIMED) in a single UPDATE. FOR UPDATE
+   * SKIP LOCKED lets concurrent API replicas grab distinct spares. Returns the
+   * claimed session (with pod_name) or null if the pool is empty/not present.
+   * Reassigning out of the pool app drops its active count, so the controller's
+   * reconcile refills the spare on its next tick — top-up is free, off the
+   * request path.
+   */
+  async claimWarmSession(
+    tenantId: string,
+    targetAppId: string,
+    ownerUserId: string | null,
+  ): Promise<SessionEntity | null> {
+    const poolApp = await this.appRepo.findOne({
+      where: { tenant_id: tenantId, name: RECORDING_POOL.APP_NAME },
+    });
+    if (!poolApp) return null;
+
+    // Select-then-update inside one transaction. FOR UPDATE SKIP LOCKED locks
+    // the picked spare for the txn so concurrent API replicas grab distinct
+    // rows. (We don't use UPDATE ... RETURNING here: TypeORM's query() does not
+    // reliably surface RETURNING rows for an UPDATE, which would make the claim
+    // look empty even though it committed.)
+    return this.dataSource.transaction(async (manager) => {
+      const picked = await manager.query(
+        `SELECT id FROM sessions
+          WHERE app_id = $1 AND tenant_id = $2 AND pool_state = $3
+            AND state = 'HEALTHY' AND pod_name IS NOT NULL
+          ORDER BY started_at ASC
+          LIMIT 1
+          FOR UPDATE SKIP LOCKED`,
+        [poolApp.id, tenantId, RECORDING_POOL.WARM],
+      );
+      if (!picked || picked.length === 0) return null;
+      const claimedId = picked[0].id;
+      await manager.query(
+        `UPDATE sessions SET app_id = $1, owner_user_id = $2, pool_state = $3 WHERE id = $4`,
+        [targetAppId, ownerUserId, RECORDING_POOL.CLAIMED, claimedId],
+      );
+      return manager.getRepository(SessionEntity).findOne({ where: { id: claimedId } });
+    });
+  }
+
+  private buildPoolAppInput() {
+    // HTTPS placeholder: app validation requires https target_urls / goto steps,
+    // and about:blank fails it. The value is inert — recording mode runs
+    // unrestricted egress (resolveEgressOptions allowAll), so a claimed spare can
+    // navigate to ANY target on bind with no per-target egress sync. The spare
+    // warms on this page and bind re-navigates it to the real target.
+    const PLACEHOLDER_URL = process.env.RECORDING_POOL_WARM_URL || 'https://example.com';
+    return {
+      name: RECORDING_POOL.APP_NAME,
+      target_urls: [PLACEHOLDER_URL],
+      login_config: {
+        login_url: PLACEHOLDER_URL,
+        credential_ref: 'manual:',
+        steps: [{ action: 'goto', url: PLACEHOLDER_URL }],
+      },
+      keepalive_config: {
+        interval_seconds: 60,
+        actions: [],
+        health_checks: [{ type: 'dom_check', selector: 'body', exists: true }],
+      },
+      export_policy: {
+        artifact_types: ['cookies'],
+        encryption: { algo: 'AES-256-GCM', key_version: 'v1' },
+        ttl_seconds: 300,
+      },
+      browser_policy: {
+        downloads: false,
+        clipboard: false,
+        file_chooser: false,
+        recording_mode: 'login' as RecordingMode,
+      },
+      notification_config: {},
+      desired_session_count: this.poolSize,
+    };
+  }
+}

--- a/apps/api/src/modules/recording/recording-provision.controller.ts
+++ b/apps/api/src/modules/recording/recording-provision.controller.ts
@@ -19,6 +19,7 @@ import { AppsService } from '../apps/apps.service';
 import { SessionsService } from '../sessions/sessions.service';
 import { VncStreamProvider } from '../streaming/vnc-stream.provider';
 import { RecordingStore } from './recording.store';
+import { RecordingPoolService } from './recording-pool.service';
 
 interface CreateRecordingSessionBody {
   recording_mode?: RecordingMode;
@@ -58,6 +59,7 @@ export class RecordingProvisionController {
     private readonly sessionsService: SessionsService,
     private readonly vncStreamProvider: VncStreamProvider,
     private readonly recordingStore: RecordingStore,
+    private readonly recordingPool: RecordingPoolService,
     @InjectRepository(SessionEntity)
     private readonly sessionRepo: Repository<SessionEntity>,
     @InjectRepository(ApplicationEntity)
@@ -108,7 +110,16 @@ export class RecordingProvisionController {
       }
     }
 
+    // Warm pool is used only when enabled for this tenant AND the request isn't
+    // asking for residential egress (a warm spare booted with the pool's proxy
+    // config; honoring a per-request residential override needs a cold pod).
+    const poolEligible =
+      this.recordingPool.isEnabledForTenant(tenantId) && body?.residential_proxy !== true;
+
     // 1. Create the recording-shell app (no login, manual creds, recording mode).
+    // desired=1 when pool-eligible so a claimed spare (or a reconcile-created
+    // cold session on pool miss) is retained; desired=0 otherwise so the cold
+    // path's scale() creates the session row inline (fast) in the request path.
     const shortId = randomUUID().slice(0, 8);
     const { app_id } = await this.appsService.create(
       {
@@ -142,22 +153,55 @@ export class RecordingProvisionController {
           recording_mode: mode,
         },
         notification_config: {},
-        desired_session_count: 0,
+        desired_session_count: poolEligible ? 1 : 0,
       },
       tenantId,
       actorId,
     );
 
     // 2. Scope the session to the requesting user (if federated) so the VNC
-    //    OAuth gate matches, then scale up a single session.
+    //    OAuth gate matches.
     if (ownerUserId) {
       await this.appRepo.update(app_id, { owner_user_id: ownerUserId });
     }
-    await this.sessionsService.scale(app_id, 1, tenantId, actorId, undefined, {
-      residentialProxy: body?.residential_proxy,
-    });
 
-    // 3. Wait for the controller to create the session row, then mint the URL.
+    // 3. Warm-pool fast path: claim a pre-warmed spare and bind it to this
+    //    target (seed cookies + navigate) instead of cold-starting a pod.
+    if (poolEligible) {
+      // Keep the tenant's pool warm / topped up (best-effort, off the hot path).
+      this.recordingPool.ensurePoolApp(tenantId).catch((err) =>
+        this.logger.warn(`ensurePoolApp failed for tenant ${tenantId}: ${err}`),
+      );
+
+      const claimed = await this.recordingPool.claimWarmSession(tenantId, app_id, ownerUserId);
+      if (claimed?.pod_name) {
+        await this.bindClaimedSession(claimed.pod_name, startUrl, seedCookies);
+        const stream = await this.vncStreamProvider.getStreamUrl(claimed.id, ownerUserId || actorId);
+        const vncUrl = stream.url.replace('#', '?mode=recording#');
+        this.logger.log(
+          `Provisioned recording session ${claimed.id} from warm pool (app ${app_id}, mode ${mode})`,
+        );
+        return {
+          session_id: claimed.id,
+          app_id,
+          recording_mode: mode,
+          vnc_url: vncUrl,
+          expires_at: stream.expires_at,
+          warm: true,
+        };
+      }
+      this.logger.log(`Warm pool empty for tenant ${tenantId}; falling back to cold provisioning`);
+      // Pool miss: the shell app already has desired=1, so the controller
+      // reconcile will create a cold session; waitForSession picks it up below.
+    } else {
+      // Cold path: bump desired 0 -> 1, which creates the session row inline in
+      // this request (fast) rather than waiting a reconcile tick.
+      await this.sessionsService.scale(app_id, 1, tenantId, actorId, undefined, {
+        residentialProxy: body?.residential_proxy,
+      });
+    }
+
+    // 4. Wait for the session row, then mint the URL.
     const session = await this.waitForSession(app_id, tenantId);
     if (!session) {
       throw new GatewayTimeoutException(
@@ -176,6 +220,35 @@ export class RecordingProvisionController {
       vnc_url: vncUrl,
       expires_at: stream.expires_at,
     };
+  }
+
+  /**
+   * Bind a claimed warm spare to the recording target. Best-effort with one
+   * retry: the pod is already HEALTHY (browser up on about:blank), so if the
+   * bind navigation fails we still return the working VNC URL — the human sees
+   * a live browser and can navigate manually — rather than failing the request.
+   */
+  private async bindClaimedSession(
+    podName: string,
+    startUrl: string,
+    seedCookies: unknown[],
+  ): Promise<void> {
+    for (let attempt = 1; attempt <= 2; attempt++) {
+      try {
+        await this.recordingStore.bindWorker(podName, {
+          start_url: startUrl,
+          seed_cookies: seedCookies,
+        });
+        return;
+      } catch (err) {
+        if (attempt === 2) {
+          this.logger.warn(
+            `Bind failed for pod ${podName} after ${attempt} attempts (returning URL anyway): ${err}`,
+          );
+          return;
+        }
+      }
+    }
   }
 
   private async waitForSession(

--- a/apps/api/src/modules/recording/recording-provision.controller.ts
+++ b/apps/api/src/modules/recording/recording-provision.controller.ts
@@ -110,11 +110,14 @@ export class RecordingProvisionController {
       }
     }
 
-    // Warm pool is used only when enabled for this tenant AND the request isn't
-    // asking for residential egress (a warm spare booted with the pool's proxy
-    // config; honoring a per-request residential override needs a cold pod).
-    const poolEligible =
-      this.recordingPool.isEnabledForTenant(tenantId) && body?.residential_proxy !== true;
+    // Residential egress is opt-in per request (default: non-residential). Each
+    // flavor has its own warm pool (RECORDING_POOL_SIZE vs
+    // RECORDING_POOL_RESIDENTIAL_SIZE): a residential request claims a spare that
+    // was warmed WITH residential egress, a non-residential request claims one
+    // warmed without. Pool-eligible only when that flavor's pool is enabled for
+    // the tenant; otherwise the cold path honors the flag via the shell app.
+    const wantResidential = body?.residential_proxy === true;
+    const poolEligible = this.recordingPool.isEnabledForTenant(tenantId, wantResidential);
 
     // 1. Create the recording-shell app (no login, manual creds, recording mode).
     // desired=1 when pool-eligible so a claimed spare (or a reconcile-created
@@ -152,6 +155,12 @@ export class RecordingProvisionController {
           file_chooser: false,
           recording_mode: mode,
         },
+        // The shell app carries the residential intent so that on a warm-pool
+        // MISS the reconcile-created cold session (session-level flag null →
+        // inherits the app default) still routes through the residential proxy.
+        // On a pool HIT the claimed spare already carries an explicit session-level
+        // flag, which wins regardless.
+        residential_proxy_enabled: wantResidential,
         notification_config: {},
         desired_session_count: poolEligible ? 1 : 0,
       },
@@ -169,11 +178,16 @@ export class RecordingProvisionController {
     //    target (seed cookies + navigate) instead of cold-starting a pod.
     if (poolEligible) {
       // Keep the tenant's pool warm / topped up (best-effort, off the hot path).
-      this.recordingPool.ensurePoolApp(tenantId).catch((err) =>
+      this.recordingPool.ensurePoolApp(tenantId, wantResidential).catch((err) =>
         this.logger.warn(`ensurePoolApp failed for tenant ${tenantId}: ${err}`),
       );
 
-      const claimed = await this.recordingPool.claimWarmSession(tenantId, app_id, ownerUserId);
+      const claimed = await this.recordingPool.claimWarmSession(
+        tenantId,
+        app_id,
+        ownerUserId,
+        wantResidential,
+      );
       if (claimed?.pod_name) {
         await this.bindClaimedSession(claimed.pod_name, startUrl, seedCookies);
         const stream = await this.vncStreamProvider.getStreamUrl(claimed.id, ownerUserId || actorId);

--- a/apps/api/src/modules/recording/recording-provision.module.ts
+++ b/apps/api/src/modules/recording/recording-provision.module.ts
@@ -6,6 +6,7 @@ import { SessionsModule } from '../sessions/sessions.module';
 import { StreamingModule } from '../streaming/streaming.module';
 import { RecordingModule } from './recording.module';
 import { RecordingProvisionController } from './recording-provision.controller';
+import { RecordingPoolService } from './recording-pool.service';
 
 /**
  * Recording-session provisioning ("agent generates a URL"). Separate from
@@ -22,5 +23,6 @@ import { RecordingProvisionController } from './recording-provision.controller';
     RecordingModule,
   ],
   controllers: [RecordingProvisionController],
+  providers: [RecordingPoolService],
 })
 export class RecordingProvisionModule {}

--- a/apps/api/src/modules/recording/recording.store.ts
+++ b/apps/api/src/modules/recording/recording.store.ts
@@ -31,6 +31,34 @@ export class RecordingStore {
     return `http://${podName}-worker.${this.workerNamespace}.svc.cluster.local:${PORTS.WORKER_HEALTH}${path}`;
   }
 
+  /**
+   * Bind a warm-pool recording pod to a real target: the worker seeds cookies
+   * (so the human starts authenticated) then navigates to start_url. Pod-internal
+   * HTTP, same trust boundary as drainFromWorker.
+   */
+  async bindWorker(
+    podName: string,
+    params: { start_url: string; seed_cookies?: unknown[] },
+  ): Promise<void> {
+    const url = this.buildWorkerUrl(podName, '/recording/bind');
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 30_000);
+    try {
+      const resp = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(params),
+        signal: controller.signal,
+      });
+      const json = (await resp.json().catch(() => ({}))) as { success?: boolean; error?: string };
+      if (!resp.ok || !json.success) {
+        throw new Error(json.error || `Worker bind failed (HTTP ${resp.status})`);
+      }
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
   /** Drain the recording bundle from the worker pod (synchronous flush). */
   async drainFromWorker(podName: string, sessionId: string): Promise<RecordingBundle> {
     const url = this.buildWorkerUrl(podName, '/recording/stop');

--- a/apps/api/src/modules/streaming/streaming.controller.ts
+++ b/apps/api/src/modules/streaming/streaming.controller.ts
@@ -904,7 +904,7 @@ export class CdpStreamingController {
               if (data.started_at) {
                 stUptime.textContent = Math.round((Date.now() - new Date(data.started_at).getTime()) / 60000) + 'm';
               }
-              if (data.state === 'TERMINATED') { sessionTerminated = true; handleTerminated(); return; }
+              if (data.state === 'TERMINATED') { sessionTerminated = true; window.__sessionTerminated = true; handleTerminated(); return; }
               if (!fromMcp) return;
               var pending = data.pending_input_request;
               if (pending && pending.step_index != null) {
@@ -1785,7 +1785,7 @@ export class StreamingController {
               if (data.started_at) {
                 stUptime.textContent = Math.round((Date.now() - new Date(data.started_at).getTime()) / 60000) + 'm';
               }
-              if (data.state === 'TERMINATED') { sessionTerminated = true; handleTerminated(); return; }
+              if (data.state === 'TERMINATED') { sessionTerminated = true; window.__sessionTerminated = true; handleTerminated(); return; }
               if (!fromMcp) return;
               var pending = data.pending_input_request;
               if (pending && pending.step_index != null) {
@@ -1925,20 +1925,49 @@ export class StreamingController {
       document.getElementById('panel-config').setAttribute('data-stream-token', token);
 
       const wsUrl = proto + '://' + window.location.host + '/vnc-ws?session_id=' + encodeURIComponent(sessionId);
-      const rfb = new RFB(document.getElementById('screen'), wsUrl, { wsProtocols: ['binary', 'token.' + token] });
-      rfb.scaleViewport = true;
-      rfb.resizeSession = true;
-      rfb.background = '#0b1020';
-      // Trade server CPU (now uncapped) for fewer bytes over the slow transport:
-      // max zlib compression, JPEG quality kept legible for login forms.
-      rfb.qualityLevel = 6;
-      rfb.compressionLevel = 9;
-      window.rfb = rfb;
 
-      rfb.addEventListener('connect', () => { stateEl.textContent = 'Connected'; });
-      rfb.addEventListener('disconnect', (e) => {
-        stateEl.textContent = 'Disconnected (' + (e.detail?.clean ? 'clean' : 'error') + ')';
-      });
+      // The VNC/recording link is minted before the worker pod is ready, so the
+      // first connect commonly lands on a pod whose noVNC isn't accepting yet
+      // (the WS proxy returns 409/502) — and noVNC's RFB has no built-in retry,
+      // so the viewer would strand on "Disconnected" until a manual reload.
+      // Auto-reconnect on an error-disconnect (mirrors the CDP viewer's 3s x20
+      // loop) so the link self-heals the moment the pod comes up. A CLEAN
+      // disconnect means the session ended — do not reconnect.
+      const RECONNECT_DELAY_MS = 3000;
+      const MAX_RECONNECT_ATTEMPTS = 20;
+      let rfb = null;
+      let reconnectAttempts = 0;
+
+      function connect() {
+        if (window.__sessionTerminated) return;
+        // Reconnect with the freshest token (refreshToken rotates window.__streamToken).
+        const activeToken = window.__streamToken || token;
+        rfb = new RFB(document.getElementById('screen'), wsUrl, { wsProtocols: ['binary', 'token.' + activeToken] });
+        rfb.scaleViewport = true;
+        rfb.resizeSession = true;
+        rfb.background = '#0b1020';
+        // Trade server CPU (now uncapped) for fewer bytes over the slow transport:
+        // max zlib compression, JPEG quality kept legible for login forms.
+        rfb.qualityLevel = 6;
+        rfb.compressionLevel = 9;
+        window.rfb = rfb;
+
+        rfb.addEventListener('connect', () => {
+          reconnectAttempts = 0;
+          stateEl.textContent = 'Connected';
+        });
+        rfb.addEventListener('disconnect', (e) => {
+          const clean = !!(e.detail && e.detail.clean);
+          if (clean || window.__sessionTerminated || reconnectAttempts >= MAX_RECONNECT_ATTEMPTS) {
+            stateEl.textContent = 'Disconnected (' + (clean ? 'clean' : 'error') + ')';
+            return;
+          }
+          reconnectAttempts += 1;
+          stateEl.textContent = 'Connecting… (attempt ' + reconnectAttempts + '/' + MAX_RECONNECT_ATTEMPTS + ')';
+          setTimeout(connect, RECONNECT_DELAY_MS);
+        });
+      }
+      connect();
 
       // Side panel clipboard: paste text → sends to VNC remote clipboard → user Ctrl+V inside VNC
       const clipInput = document.getElementById('clip-input');

--- a/apps/controller/src/entities/session.entity.ts
+++ b/apps/controller/src/entities/session.entity.ts
@@ -93,4 +93,13 @@ export class SessionEntity {
   /** Per-session override for residential-proxy egress. null = inherit app default. */
   @Column({ type: 'boolean', nullable: true })
   residential_proxy_enabled: boolean | null;
+
+  /**
+   * Warm-pool marker. 'WARM' = a pre-warmed recording spare on about:blank
+   * awaiting claim; 'CLAIMED' = claimed and reassigned to a recording-shell
+   * app; null = ordinary session. Set to WARM by the controller when creating
+   * sessions for the recording-pool app; the idle reaper and pool top-up read it.
+   */
+  @Column({ type: 'varchar', length: 16, nullable: true })
+  pool_state: 'WARM' | 'CLAIMED' | null;
 }

--- a/apps/controller/src/pod-manager.service.ts
+++ b/apps/controller/src/pod-manager.service.ts
@@ -428,9 +428,22 @@ export class PodManagerService {
       workerPorts.push({ containerPort: CDP_PORTS.CDP_RELAY, name: 'cdp-relay' });
     }
 
+    // Startup budget for the worker container: image already local + browser
+    // cold start is a few seconds, but a cold-node image pull can take much
+    // longer. failureThreshold * periodSeconds caps how long we wait for the
+    // browser to become viewable before liveness takes over.
+    const startupPeriodSeconds = this.readPositiveInt('WORKER_STARTUP_PERIOD_SECONDS', 2);
+    const startupFailureThreshold = this.readPositiveInt('WORKER_STARTUP_FAILURE_THRESHOLD', 90);
+
     const workerContainer = {
       name: 'worker',
       image: process.env.WORKER_IMAGE || 'browser-hitl/worker:latest',
+      // Dynamic worker pods had no pull policy: with the default `:latest` tag
+      // K8s implies `Always`, forcing a registry round-trip (multi-GB Playwright
+      // + Chromium image) on every cold start. Pin to IfNotPresent so a node
+      // that already has the image skips the pull. Override via env when running
+      // a mutable dev tag that must always re-pull.
+      imagePullPolicy: process.env.WORKER_IMAGE_PULL_POLICY || 'IfNotPresent',
       ports: workerPorts,
       env: workerEnv,
       resources: {
@@ -443,15 +456,24 @@ export class PodManagerService {
           memory: process.env.WORKER_MEM_LIMIT || '1536Mi',
         },
       },
+      // startupProbe gates liveness+readiness until the browser is actually up
+      // (GET /ready flips 200 once the page is rendering). This lets us drop the
+      // old fixed `readinessProbe.initialDelaySeconds: 15` — the noVNC Service
+      // now gets endpoints the instant VNC is serveable, not 15s later — while
+      // still giving a generous cold-start budget before liveness can kill.
+      startupProbe: {
+        httpGet: { path: '/ready', port: 8091 },
+        periodSeconds: startupPeriodSeconds,
+        failureThreshold: startupFailureThreshold,
+        timeoutSeconds: 2,
+      },
       livenessProbe: {
         httpGet: { path: '/health', port: 8091 },
-        initialDelaySeconds: 30,
         periodSeconds: 10,
       },
       readinessProbe: {
-        httpGet: { path: '/health', port: 8091 },
-        initialDelaySeconds: 15,
-        periodSeconds: 5,
+        httpGet: { path: '/ready', port: 8091 },
+        periodSeconds: 3,
       },
       volumeMounts: workerVolumeMounts,
       securityContext: {
@@ -467,6 +489,7 @@ export class PodManagerService {
       containers.push({
         name: 'novnc',
         image: process.env.NOVNC_IMAGE || 'browser-hitl/novnc:latest',
+        imagePullPolicy: process.env.NOVNC_IMAGE_PULL_POLICY || process.env.WORKER_IMAGE_PULL_POLICY || 'IfNotPresent',
         ports: [{ containerPort: 6080, name: 'novnc' }],
         command: ['websockify', '--web', '/usr/share/novnc', '6080', 'localhost:5900'],
         resources: {
@@ -894,5 +917,11 @@ export class PodManagerService {
       this.logger.warn(`Invalid JSON in ${envVar} — skipping ${key}: ${raw}`);
       return {};
     }
+  }
+
+  /** Read a positive integer env var, falling back to `fallback` if unset/invalid. */
+  private readPositiveInt(envVar: string, fallback: number): number {
+    const parsed = parseInt(process.env[envVar] || '', 10);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
   }
 }

--- a/apps/controller/src/reconcile.service.ts
+++ b/apps/controller/src/reconcile.service.ts
@@ -307,7 +307,8 @@ export class ReconcileService implements OnModuleInit, OnModuleDestroy {
     // They boot as recording pods on about:blank and wait to be claimed, so they
     // must never inherit an owner (claimed on demand) and are marked WARM so the
     // idle reaper leaves them alone and the claim query can find them.
-    const isPoolSession = app.name === RECORDING_POOL.APP_NAME;
+    const isResidentialPool = app.name === RECORDING_POOL.RESIDENTIAL_APP_NAME;
+    const isPoolSession = app.name === RECORDING_POOL.APP_NAME || isResidentialPool;
     // Create session record — inherit owner_user_id from app (per-user isolation)
     const session = this.sessionRepo.create({
       app_id: app.id,
@@ -319,6 +320,12 @@ export class ReconcileService implements OnModuleInit, OnModuleDestroy {
       hitl_attempt_count: 0,
       owner_user_id: isPoolSession ? null : (app.owner_user_id ?? null),
       pool_state: isPoolSession ? RECORDING_POOL.WARM : null,
+      // Warm spares carry an explicit session-level residential flag so the
+      // residential egress is (a) pushed to the egress proxy while they warm and
+      // (b) preserved after claimWarmSession reassigns them to the (non-residential)
+      // target shell app — the per-session flag wins over the app default in
+      // resolveResidential(). Non-pool sessions leave it null to inherit the app default.
+      residential_proxy_enabled: isPoolSession ? isResidentialPool : null,
       // Continue the distributed trace originated by the API scale request.
       // pod-manager stamps this onto the worker pod's TRACEPARENT env so the
       // browser worker joins the same trace (api -> controller -> worker).

--- a/apps/controller/src/reconcile.service.ts
+++ b/apps/controller/src/reconcile.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/commo
 import * as Sentry from '@sentry/node';
 import { InjectRepository } from '@nestjs/typeorm';
 import { MoreThan, Repository, DataSource } from 'typeorm';
-import { SessionState, StreamingMode } from '@browser-hitl/shared';
+import { SessionState, StreamingMode, RECORDING_POOL } from '@browser-hitl/shared';
 import { ApplicationEntity } from './entities/application.entity';
 import { SessionEntity } from './entities/session.entity';
 import { SessionBatonEntity } from './entities/session-baton.entity';
@@ -303,6 +303,11 @@ export class ReconcileService implements OnModuleInit, OnModuleDestroy {
   }
 
   private async createSession(app: ApplicationEntity): Promise<void> {
+    // Warm-pool spares are the sessions of the well-known per-tenant pool app.
+    // They boot as recording pods on about:blank and wait to be claimed, so they
+    // must never inherit an owner (claimed on demand) and are marked WARM so the
+    // idle reaper leaves them alone and the claim query can find them.
+    const isPoolSession = app.name === RECORDING_POOL.APP_NAME;
     // Create session record — inherit owner_user_id from app (per-user isolation)
     const session = this.sessionRepo.create({
       app_id: app.id,
@@ -312,7 +317,8 @@ export class ReconcileService implements OnModuleInit, OnModuleDestroy {
       retry_count: 0,
       intervention_count: 0,
       hitl_attempt_count: 0,
-      owner_user_id: app.owner_user_id ?? null,
+      owner_user_id: isPoolSession ? null : (app.owner_user_id ?? null),
+      pool_state: isPoolSession ? RECORDING_POOL.WARM : null,
       // Continue the distributed trace originated by the API scale request.
       // pod-manager stamps this onto the worker pod's TRACEPARENT env so the
       // browser worker joins the same trace (api -> controller -> worker).
@@ -463,6 +469,16 @@ export class ReconcileService implements OnModuleInit, OnModuleDestroy {
     for (const session of healthySessions) {
       const age = now - new Date(session.started_at).getTime();
       if (age >= maxAgeMs) {
+        // A WARM pool spare recycles like any pod at max age, but must NOT scale
+        // its (shared) pool app to 0 — that would drain the whole pool. Just
+        // terminate it; the pool top-up creates a fresh spare next tick.
+        if (session.pool_state === RECORDING_POOL.WARM) {
+          this.logger.log(
+            `Max-age recycle of warm pool spare ${session.id} (age=${Math.round(age / 3600000)}h) — pool will refill`,
+          );
+          await this.terminateSession(session);
+          continue;
+        }
         this.logger.log(
           `Max-age shutdown: session ${session.id} age=${Math.round(age / 3600000)}h ` +
           `(max: ${maxAgeHours}h) — scaling app ${session.app_id} to 0`,

--- a/apps/worker/src/health-server.ts
+++ b/apps/worker/src/health-server.ts
@@ -8,6 +8,12 @@ import { registerBrowserHandler, cleanupHarListeners } from './execute-browser-h
 import { executeAuthMiddleware } from './execute-auth';
 import type { RecordingRunner } from './recording-runner';
 
+/** Params for binding a warm pool recording pod to a real recording target. */
+export interface BindParams {
+  start_url: string;
+  seed_cookies?: unknown[];
+}
+
 /**
  * Worker Health HTTP Server per spec section 15.5.
  * GET /health - Kubernetes liveness/readiness probe
@@ -21,8 +27,18 @@ export class HealthServer {
   private app: Express | null = null;
   private page: Page | null = null;
   private healthy = true;
+  // Readiness is distinct from liveness (`healthy`). The pod's K8s readinessProbe
+  // hits /ready, which stays 503 until the browser window is actually up and
+  // rendering in Xvfb — i.e. until VNC/noVNC can serve a real frame. This
+  // replaces the old fixed `readinessProbe.initialDelaySeconds: 15` guess with an
+  // accurate signal, so the per-session noVNC Service gets endpoints the moment
+  // the browser is viewable instead of ~15s later. Flipped true right after the
+  // page is created (main.ts), NOT after login/DSL — a HITL login session must be
+  // viewable while the human is still completing the login.
+  private ready = false;
   private recordingRunner: RecordingRunner | null = null;
   private recording = false;
+  private bindHandler: ((params: BindParams) => Promise<void>) | null = null;
 
   constructor(private readonly sessionId: string) {}
 
@@ -41,6 +57,15 @@ export class HealthServer {
    */
   setRecordingRunner(runner: RecordingRunner): void {
     this.recordingRunner = runner;
+  }
+
+  /**
+   * Register the warm-pool bind handler. A pool pod boots as a recording session
+   * on about:blank; when a recording request claims it, the API POSTs
+   * /recording/bind with the real target so the worker seeds cookies + navigates.
+   */
+  setBindHandler(handler: (params: BindParams) => Promise<void>): void {
+    this.bindHandler = handler;
   }
 
   /**
@@ -90,6 +115,17 @@ export class HealthServer {
       }
     });
 
+    // Readiness probe (and startup probe) target. 503 until the browser window
+    // is up and rendering in Xvfb so the noVNC Service only gets endpoints once
+    // VNC can actually serve a frame. See the `ready` field comment.
+    app.get('/ready', (_req, res) => {
+      if (this.ready) {
+        res.json({ status: 'ready', session_id: this.sessionId });
+      } else {
+        res.status(503).json({ status: 'starting', session_id: this.sessionId });
+      }
+    });
+
     app.get('/status', (_req, res) => {
       res.json({
         session_id: this.sessionId,
@@ -125,6 +161,28 @@ export class HealthServer {
         });
     });
 
+    // Bind a warm pool pod to a real recording target (seed cookies + navigate).
+    // Pod-internal only — the API authenticates the caller before proxying here.
+    app.post('/recording/bind', (req, res) => {
+      if (!this.bindHandler) {
+        res.status(409).json({ success: false, error: 'Session does not support binding' });
+        return;
+      }
+      const body = (req.body || {}) as Partial<BindParams>;
+      const startUrl = typeof body.start_url === 'string' ? body.start_url.trim() : '';
+      if (!startUrl) {
+        res.status(400).json({ success: false, error: 'start_url is required' });
+        return;
+      }
+      this.bindHandler({ start_url: startUrl, seed_cookies: Array.isArray(body.seed_cookies) ? body.seed_cookies : [] })
+        .then(() => res.json({ success: true }))
+        .catch((err: unknown) => {
+          const message = err instanceof Error ? err.message : String(err);
+          console.error(`Recording bind error: ${message}`);
+          res.status(500).json({ success: false, error: message });
+        });
+    });
+
     this.server = app.listen(port, () => {
       console.log(`Health server listening on port ${port}`);
     });
@@ -138,5 +196,15 @@ export class HealthServer {
 
   setHealthy(healthy: boolean): void {
     this.healthy = healthy;
+  }
+
+  /**
+   * Flip the K8s readiness/startup signal. Called once the browser window is up
+   * and rendering (main.ts, right after the page is created) — for every mode,
+   * BEFORE login/DSL runs, so HITL login sessions are viewable while the human
+   * completes the login.
+   */
+  setReady(ready: boolean): void {
+    this.ready = ready;
   }
 }

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -234,6 +234,12 @@ async function main() {
     // Register execute endpoint on the health server
     healthServer.setPage(page);
 
+    // The browser window is now up and rendering in Xvfb (VNC mode) / headless
+    // (CDP). Mark the pod Ready so its noVNC Service gets endpoints immediately,
+    // rather than after a fixed 15s probe delay. Done BEFORE login/DSL so a HITL
+    // login session is viewable while the human is still completing the login.
+    healthServer.setReady(true);
+
     // Start CDP relay server if in CDP mode
     if (streamingMode === 'cdp') {
       const { CdpRelayServer } = await import('./cdp-relay-server');
@@ -281,6 +287,24 @@ async function main() {
       recordingRunner = new RecordingRunner(page, context, sessionId, recordingMode);
       await recordingRunner.start();
       healthServer.setRecordingRunner(recordingRunner);
+
+      // Warm-pool bind: a pooled recording pod boots on about:blank; when a
+      // recording request claims it, the API POSTs /recording/bind with the real
+      // target. Seed cookies first (so the human starts authenticated), then
+      // navigate. The already-running RecordingRunner captures from here on.
+      const boundContext = context;
+      healthServer.setBindHandler(async ({ start_url, seed_cookies }) => {
+        if (Array.isArray(seed_cookies) && seed_cookies.length > 0) {
+          try {
+            await boundContext.addCookies(seed_cookies as Parameters<typeof boundContext.addCookies>[0]);
+            console.log(`Bind: seeded ${seed_cookies.length} cookie(s)`);
+          } catch (err) {
+            console.warn(`Bind: failed to seed cookies: ${err}`);
+          }
+        }
+        await page.goto(start_url, { waitUntil: 'domcontentloaded' });
+        console.log(`Bind: navigated to ${start_url}`);
+      });
 
       // Session reuse: seed cookies captured from a prior login recording so the
       // human starts already authenticated (no stored credentials). Provisioned

--- a/charts/browser-hitl/templates/configmap.yaml
+++ b/charts/browser-hitl/templates/configmap.yaml
@@ -60,7 +60,7 @@ data:
   WORKER_IMAGE_PULL_POLICY: {{ .Values.config.workerImagePullPolicy | default "IfNotPresent" | quote }}
   # Warm recording-session pool (see RecordingPoolService). size 0 / empty
   # tenants list = feature off (cold path everywhere). Tenants: comma list or '*'.
-  RECORDING_POOL_SIZE: {{ .Values.config.recordingPoolSize | default "0" | quote }}
+  RECORDING_POOL_SIZE: {{ .Values.config.recordingPoolSize | default "3" | quote }}
   RECORDING_POOL_TENANTS: {{ .Values.config.recordingPoolTenants | default "" | quote }}
   WORKER_CPU_REQUEST: {{ .Values.worker.resources.requests.cpu | quote }}
   WORKER_CPU_LIMIT: {{ .Values.worker.resources.limits.cpu | quote }}

--- a/charts/browser-hitl/templates/configmap.yaml
+++ b/charts/browser-hitl/templates/configmap.yaml
@@ -61,6 +61,7 @@ data:
   # Warm recording-session pool (see RecordingPoolService). size 0 / empty
   # tenants list = feature off (cold path everywhere). Tenants: comma list or '*'.
   RECORDING_POOL_SIZE: {{ .Values.config.recordingPoolSize | default "3" | quote }}
+  RECORDING_POOL_RESIDENTIAL_SIZE: {{ .Values.config.recordingPoolResidentialSize | default "0" | quote }}
   RECORDING_POOL_TENANTS: {{ .Values.config.recordingPoolTenants | default "" | quote }}
   WORKER_CPU_REQUEST: {{ .Values.worker.resources.requests.cpu | quote }}
   WORKER_CPU_LIMIT: {{ .Values.worker.resources.limits.cpu | quote }}

--- a/charts/browser-hitl/templates/configmap.yaml
+++ b/charts/browser-hitl/templates/configmap.yaml
@@ -56,6 +56,12 @@ data:
   WORKER_ALLOW_ENV_CREDENTIAL_FALLBACK: {{ .Values.config.workerAllowEnvCredentialFallback | quote }}
   WORKER_IMAGE: {{ $workerImage | quote }}
   NOVNC_IMAGE: {{ $novncImage | quote }}
+  # Skip the registry pull when the (multi-GB) image is already on the node.
+  WORKER_IMAGE_PULL_POLICY: {{ .Values.config.workerImagePullPolicy | default "IfNotPresent" | quote }}
+  # Warm recording-session pool (see RecordingPoolService). size 0 / empty
+  # tenants list = feature off (cold path everywhere). Tenants: comma list or '*'.
+  RECORDING_POOL_SIZE: {{ .Values.config.recordingPoolSize | default "0" | quote }}
+  RECORDING_POOL_TENANTS: {{ .Values.config.recordingPoolTenants | default "" | quote }}
   WORKER_CPU_REQUEST: {{ .Values.worker.resources.requests.cpu | quote }}
   WORKER_CPU_LIMIT: {{ .Values.worker.resources.limits.cpu | quote }}
   WORKER_MEM_REQUEST: {{ .Values.worker.resources.requests.memory | quote }}

--- a/charts/browser-hitl/values-local.yaml
+++ b/charts/browser-hitl/values-local.yaml
@@ -152,6 +152,14 @@ config:
   reconcileBatchSize: "50"
   extractTabTimeoutMs: "15000"
   extractTabPollIntervalMs: "3000"
+  # Warm recording-session pool (off by default locally — set recordingPoolTenants
+  # to "*" or a tenant id to warm spares; residential spares also need
+  # EGRESS_UPSTREAM_PROXY_URL on the egress-proxy). IfNotPresent is required for
+  # local Kind (images are `kind load`ed at :dev, there's no registry to pull from).
+  recordingPoolSize: "3"
+  recordingPoolResidentialSize: "0"
+  recordingPoolTenants: ""
+  workerImagePullPolicy: "IfNotPresent"
 
 
 # Development secrets (NEVER use in production)

--- a/charts/browser-hitl/values.yaml
+++ b/charts/browser-hitl/values.yaml
@@ -436,6 +436,11 @@ config:
   reconcileIntervalSeconds: "15"
   maxSessionAgeHours: "24"
   idleShutdownSeconds: "0"  # 0 = disabled. Set >DEFAULT_KEEPALIVE_SECONDS (300) to enable idle pod reclaim.
+  workerImagePullPolicy: "IfNotPresent"  # dynamic worker/noVNC pods; avoids re-pulling the multi-GB image per cold start
+  # Warm recording-session pool: pre-warmed recording pods claimed on demand to
+  # cut VNC link provisioning from ~1-2min to seconds. Per-tenant + opt-in.
+  recordingPoolSize: "0"        # spares kept warm per opted-in tenant (0 = feature off)
+  recordingPoolTenants: ""      # comma-separated tenant ids, or "*" for all (empty = off)
   natsStreamMaxAgeHours: "8"
   minioOrphanMaxAgeHours: "2"
   publicBaseUrl: ""

--- a/charts/browser-hitl/values.yaml
+++ b/charts/browser-hitl/values.yaml
@@ -438,9 +438,11 @@ config:
   idleShutdownSeconds: "0"  # 0 = disabled. Set >DEFAULT_KEEPALIVE_SECONDS (300) to enable idle pod reclaim.
   workerImagePullPolicy: "IfNotPresent"  # dynamic worker/noVNC pods; avoids re-pulling the multi-GB image per cold start
   # Warm recording-session pool: pre-warmed recording pods claimed on demand to
-  # cut VNC link provisioning from ~1-2min to seconds. Per-tenant + opt-in.
-  recordingPoolSize: "0"        # spares kept warm per opted-in tenant (0 = feature off)
-  recordingPoolTenants: ""      # comma-separated tenant ids, or "*" for all (empty = off)
+  # cut VNC link provisioning from ~1-2min to seconds. Per-tenant + opt-in — the
+  # pool stays OFF until recordingPoolTenants is non-empty; recordingPoolSize is
+  # the number of warm spares kept per opted-in tenant once enabled.
+  recordingPoolSize: "3"        # warm spares per opted-in tenant (default when enabled)
+  recordingPoolTenants: ""      # comma-separated tenant ids, or "*" for all. EMPTY = pool disabled.
   natsStreamMaxAgeHours: "8"
   minioOrphanMaxAgeHours: "2"
   publicBaseUrl: ""

--- a/charts/browser-hitl/values.yaml
+++ b/charts/browser-hitl/values.yaml
@@ -441,7 +441,8 @@ config:
   # cut VNC link provisioning from ~1-2min to seconds. Per-tenant + opt-in — the
   # pool stays OFF until recordingPoolTenants is non-empty; recordingPoolSize is
   # the number of warm spares kept per opted-in tenant once enabled.
-  recordingPoolSize: "3"        # warm spares per opted-in tenant (default when enabled)
+  recordingPoolSize: "3"        # non-residential warm spares per opted-in tenant (default when enabled)
+  recordingPoolResidentialSize: "0"  # warm spares warmed WITH residential-proxy egress, claimed by residential_proxy=true requests. 0 = residential requests cold-start.
   recordingPoolTenants: ""      # comma-separated tenant ids, or "*" for all. EMPTY = pool disabled.
   natsStreamMaxAgeHours: "8"
   minioOrphanMaxAgeHours: "2"

--- a/infra/tfy/deploy.yaml
+++ b/infra/tfy/deploy.yaml
@@ -138,6 +138,13 @@ values:
     minioOrphanMaxAgeHours: "${MINIO_ORPHAN_MAX_AGE_HOURS}"
     apiDocsEnabled: "${API_DOCS_ENABLED}"
     reconcileBatchSize: "${RECONCILE_BATCH_SIZE}"
+    # Warm recording-session pool (per-environment control via GitHub secrets).
+    # Unset ⇒ envsubst leaves these empty and the chart falls back to its
+    # defaults (size 3 / residential 0 / tenants "" ⇒ pool off).
+    recordingPoolSize: "${RECORDING_POOL_SIZE}"
+    recordingPoolResidentialSize: "${RECORDING_POOL_RESIDENTIAL_SIZE}"
+    recordingPoolTenants: "${RECORDING_POOL_TENANTS}"
+    workerImagePullPolicy: "${WORKER_IMAGE_PULL_POLICY}"
 
   postgres:
     enabled: ${POSTGRES_ENABLED}

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -141,6 +141,21 @@ export const DEFAULTS = {
 } as const;
 
 /**
+ * Warm recording-session pool. A per-tenant pool of pre-warmed recording pods
+ * (browser up, sitting on about:blank) that a recording request claims + binds
+ * in place of cold-starting a pod — cutting link provisioning from ~1-2min to
+ * seconds. Cross-tenant reuse is impossible (bundles are stored in the tenant's
+ * MinIO bucket under its encryption key), so the pool is strictly per-tenant and
+ * opt-in via RECORDING_POOL_TENANTS (empty = feature off, cold path everywhere).
+ */
+export const RECORDING_POOL = {
+  /** Well-known app name the controller/API use to find a tenant's pool app. */
+  APP_NAME: '__recording_pool__',
+  WARM: 'WARM',
+  CLAIMED: 'CLAIMED',
+} as const;
+
+/**
  * Password complexity rules (C2 remediation).
  * Minimum 12 chars, at least one uppercase, lowercase, digit, and special character.
  */

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -151,6 +151,15 @@ export const DEFAULTS = {
 export const RECORDING_POOL = {
   /** Well-known app name the controller/API use to find a tenant's pool app. */
   APP_NAME: '__recording_pool__',
+  /**
+   * Well-known app name for the tenant's RESIDENTIAL warm pool. Its spares boot
+   * with residential_proxy_enabled so their egress is chained through the
+   * residential proxy while they warm and after they're claimed. A recording
+   * request that asks for residential egress claims from this pool; all other
+   * requests claim from APP_NAME. Kept as a separate app (not a flag on one pool)
+   * so each flavor has its own desired_session_count / warm capacity.
+   */
+  RESIDENTIAL_APP_NAME: '__recording_pool_residential__',
   WARM: 'WARM',
   CLAIMED: 'CLAIMED',
 } as const;


### PR DESCRIPTION
## ⚠️ How to enable (env vars to add)

Ships **OFF by default** — no behavior change on merge. To turn it on in an environment, add these under `config.*` in that env's Helm values (they render into the shared ConfigMap and reach **both** the API and controller):

| Helm value (`config.*`) | Env var | Default | Notes |
|---|---|---|---|
| `recordingPoolTenants` | `RECORDING_POOL_TENANTS` | `""` (off) | **Required to enable.** Comma-separated tenant IDs, or `*` for all. Empty ⇒ pool disabled. |
| `recordingPoolSize` | `RECORDING_POOL_SIZE` | `3` | Non-residential warm spares kept **per opted-in tenant**. |
| `recordingPoolResidentialSize` | `RECORDING_POOL_RESIDENTIAL_SIZE` | `0` | Warm spares warmed **with residential-proxy egress**, claimed by `residential_proxy=true` requests. `0` ⇒ residential requests cold-start (prior behavior). |
| `workerImagePullPolicy` | `WORKER_IMAGE_PULL_POLICY` | `IfNotPresent` | Optional (QW1); applies to dynamic worker/noVNC pods. |

Also read by the service but **not yet wired as a Helm value** (env-only override, defaults are fine): `RECORDING_POOL_WARM_URL` (default `https://example.com`) — the inert HTTPS page spares sit on before they're claimed.

**Minimum to activate:** set `recordingPoolTenants` (e.g. `"*"` or specific tenant IDs). `recordingPoolSize` defaults to **3**; `recordingPoolResidentialSize` defaults to **0** (set it to warm residential spares too — requires `EGRESS_UPSTREAM_PROXY_URL` configured on the egress-proxy, per the residential-proxy feature #125).

**Cost:** total warm pods = `(recordingPoolSize + recordingPoolResidentialSize) × (# opted-in tenants)`, each a full browser pod (~1.5 GB), always on. Size to peak concurrent recording starts per tenant; explicitly-listed tenants pre-warm at API startup, `*` warms lazily on first request. Idle residential spares consume **zero** proxy bandwidth/credits — they sit on `about:blank` and residential billing is per-GB.

---

## What & why

Provisioning a VNC recording link (NoUI "record a login / workflow") took **~1–2 min** because every request cold-started a browser pod: controller reconcile poll (≤15s) + image pull + a fixed `readinessProbe.initialDelaySeconds: 15` + Chromium launch. Config tuning alone can't reach ≤15s — the browser has to already be running.

This adds a **per-tenant, opt-in warm pool** of recording-ready pods claimed on demand, plus cold-start quick wins that help every session.

## Changes

**Quick wins**
- **QW1** — `imagePullPolicy: IfNotPresent` on dynamic worker/noVNC pods (env-overridable); avoids re-pulling the multi-GB image per cold start.
- **QW2** — real readiness: the worker exposes `/ready` that flips true once the browser window is up (before login/DSL, so HITL sessions stay viewable). A `startupProbe` on `/ready` replaces the fixed `readinessProbe.initialDelaySeconds: 15`, so the noVNC Service gets endpoints the moment VNC is serveable.
- **QW4** — noVNC RFB viewer auto-reconnect (20×3s), matching the existing CDP viewer (the RFB viewer previously had none).

**Warm pool** (off by default; enable with `RECORDING_POOL_SIZE` + `RECORDING_POOL_TENANTS`)
- Migration **032** adds `sessions.pool_state` (+ partial claim index).
- Controller stamps `WARM` spares for a per-tenant `__recording_pool__` app and auto-refills via the existing `desired_session_count` reconcile when one is claimed. Max-age reaper guarded so a stale spare recycles without draining the pool.
- `POST /recording/sessions` does an atomic `SELECT … FOR UPDATE SKIP LOCKED` claim, reassigns the spare to a per-target recording-shell app, and binds it via the worker's new pod-internal `POST /recording/bind` (seed cookies + navigate). **Falls back to the existing cold path when the pool is empty — never worse than today.**
- Recording apps already run `allowAll` egress, so a claimed spare reaches any target on bind with no per-target egress sync.

**Residential split** (added in this update — pairs with residential-proxy #125)
- Previously a `residential_proxy=true` recording request **bypassed the pool and cold-started**. Now it claims from a dedicated residential warm pool, so residential logins (e.g. bank portals that block datacenter IPs) also provision in ~1s.
- Fixed **2-flavor split**: a second per-tenant pool app `__recording_pool_residential__` (created with `residential_proxy_enabled: true`), sized independently via `RECORDING_POOL_RESIDENTIAL_SIZE`. Non-residential and residential capacity are sized separately; a request claims the pool matching its flag.
- Residential spares carry an **explicit session-level** `residential_proxy_enabled` flag (stamped in `reconcile.createSession` by pool-app name), so residential egress is pushed to the egress proxy **while they warm** and **survives claim-reassignment** to the (non-residential) target shell app — the per-session flag wins over the app default in `resolveResidential()`. This also makes residential leak-safe by construction (no first-navigation window on a datacenter IP).
- The recording-shell app is stamped with the residential intent so a pool-**miss** cold fallback stays residential.
- Provision controller routes by the existing `residential_proxy` flag (default off) instead of skipping the pool; `isEnabledForTenant` / `ensurePoolApp` / `claimWarmSession` / `buildPoolAppInput` all take a `residential` param.
- **No new migration** — the `residential_proxy_enabled` columns (#125) and `sessions.pool_state` (032) already exist.

Cross-tenant reuse is impossible (bundles live in the tenant's MinIO bucket under its key), so the pool is strictly per-tenant.

## Validation

- Unit/build: all 7 projects build + lint; API + **67** controller tests pass; `helm lint` clean. `recording-pool.service.spec.ts` covers enablement + the atomic claim, plus new cases for **independent residential-flavor gating** and **claiming from the residential vs non-residential pool app**. `helm template` renders `RECORDING_POOL_RESIDENTIAL_SIZE` (`"2"` when set, `"0"` by default).
- **e2e on local Kind (warm pool):**
  - Migration 032 applied; pool warmed 2 spares (`HEALTHY|WARM`), workers `2/2 Ready` (QW2 readiness working).
  - **Warm claim: provision call ~1.15s, session usable ~1.3s** — bind confirmed navigating the claimed pod to the target; API logged "from warm pool"; pool auto-refilled to 2.
  - Cold fallback path exercised (pool empty) and still returns a working link.
  - Cold baseline stayed `STARTING` for minutes under a contended local node — i.e. cold ≫ 15s, warm ≈ 1.3s.
- **e2e on local Kind (residential):** with `EGRESS_UPSTREAM_PROXY_URL` (Oxylabs) wired on the egress-proxy, a `residential_proxy=true` login recording session had `sessions.residential_proxy_enabled = t`, and the egress-proxy logged `residential CONNECT established … target: www.pnc.com:443` for live traffic — confirming end-to-end routing through the residential upstream.

> e2e caught a real bug (fixed here): the claim used `UPDATE … RETURNING` via TypeORM `query()`, which didn't surface the row, so the warm branch was skipped (no bind). Rewritten as a `SELECT … FOR UPDATE SKIP LOCKED` + `UPDATE` inside a transaction.

## Risk

- Low by default (feature off; quick wins are additive). QW2 changes readiness semantics — validated on-cluster (pods reach Ready and VNC connects) but worth a look in staging.
- Cost when enabled: N always-on browser pods per opted-in tenant across both flavors. Size for peak concurrent recording starts.
- Residential split trade-off: fixed per-flavor capacity — a burst beyond `recordingPoolResidentialSize` concurrent residential requests falls back to cold-start (same as today's residential behavior), it does not borrow non-residential spares.
- Follow-up: worker unit tests don't yet cover the new `/ready` + bind paths (they build clean and were validated e2e).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
