### PR TITLE
chore: bump chart version to 1.19.1

### DIFF
--- a/charts/browser-hitl/Chart.yaml
+++ b/charts/browser-hitl/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: browser-hitl
 description: Browser Human-in-the-Loop MVP - Kubernetes-native service stack
 type: application
-version: 1.18.0
-appVersion: "1.18.0"
+version: 1.19.0
+appVersion: "1.19.0"
 keywords:
   - browser
   - hitl

--- a/charts/browser-hitl/Chart.yaml
+++ b/charts/browser-hitl/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: browser-hitl
 description: Browser Human-in-the-Loop MVP - Kubernetes-native service stack
 type: application
-version: 1.19.0
-appVersion: "1.19.0"
+version: 1.19.1
+appVersion: "1.19.1"
 keywords:
   - browser
   - hitl


### PR DESCRIPTION
Chart version bump only. Triggers deploy-production to rebuild images with the correct version tag.

1 file changed: `charts/browser-hitl/Chart.yaml` (1.18.0 → 1.19.1)