### PR TITLE
fix(ci): wire missing env vars through deploy workflows

### DIFF
--- a/.github/workflows/deploy-production.yaml
+++ b/.github/workflows/deploy-production.yaml
@@ -332,6 +332,13 @@ jobs:
       EGRESS_MEM_REQUEST: ${{ secrets.EGRESS_MEM_REQUEST || '128Mi' }}
       EGRESS_MEM_LIMIT: ${{ secrets.EGRESS_MEM_LIMIT || '512Mi' }}
       RECONCILE_BATCH_SIZE: ${{ secrets.RECONCILE_BATCH_SIZE || '50' }}
+      # Egress / residential proxy
+      EGRESS_UPSTREAM_PROXY_URL: ${{ secrets.EGRESS_UPSTREAM_PROXY_URL || '' }}
+      # Warm recording-session pool
+      RECORDING_POOL_SIZE: ${{ secrets.RECORDING_POOL_SIZE || '3' }}
+      RECORDING_POOL_RESIDENTIAL_SIZE: ${{ secrets.RECORDING_POOL_RESIDENTIAL_SIZE || '0' }}
+      RECORDING_POOL_TENANTS: ${{ secrets.RECORDING_POOL_TENANTS || '' }}
+      WORKER_IMAGE_PULL_POLICY: ${{ secrets.WORKER_IMAGE_PULL_POLICY || 'IfNotPresent' }}
       # New Relic APM
       NEWRELIC_ENABLED: ${{ secrets.NEWRELIC_ENABLED || 'false' }}
       NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY || '' }}

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -313,6 +313,13 @@ jobs:
       EGRESS_MEM_REQUEST: ${{ secrets.EGRESS_MEM_REQUEST || '128Mi' }}
       EGRESS_MEM_LIMIT: ${{ secrets.EGRESS_MEM_LIMIT || '512Mi' }}
       RECONCILE_BATCH_SIZE: ${{ secrets.RECONCILE_BATCH_SIZE || '50' }}
+      # Egress / residential proxy
+      EGRESS_UPSTREAM_PROXY_URL: ${{ secrets.EGRESS_UPSTREAM_PROXY_URL || '' }}
+      # Warm recording-session pool
+      RECORDING_POOL_SIZE: ${{ secrets.RECORDING_POOL_SIZE || '3' }}
+      RECORDING_POOL_RESIDENTIAL_SIZE: ${{ secrets.RECORDING_POOL_RESIDENTIAL_SIZE || '0' }}
+      RECORDING_POOL_TENANTS: ${{ secrets.RECORDING_POOL_TENANTS || '' }}
+      WORKER_IMAGE_PULL_POLICY: ${{ secrets.WORKER_IMAGE_PULL_POLICY || 'IfNotPresent' }}
       # New Relic APM
       NEWRELIC_ENABLED: ${{ secrets.NEWRELIC_ENABLED || 'false' }}
       NEW_RELIC_LICENSE_KEY: ${{ secrets.NEW_RELIC_LICENSE_KEY || '' }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,20 @@ Registry: `ghcr.io/adoptai/tabby/{service}:{tag}`
 - `deploy-production.yaml` — Push to `main`: reads already-bumped version from Chart.yaml, builds `prod-*` images, same chart version
 - Secrets are in GitHub Environments (`staging` / `production`), injected via envsubst into `infra/tfy/deploy.yaml`
 
+### Adding a New Environment Variable (STRICT)
+
+Every new env var must be wired through the **entire chain** or `envsubst` silently replaces it with an empty string:
+
+1. **`charts/browser-hitl/values.yaml`** — default value under `config.*` (ConfigMap) or `secrets.*` (Secret)
+2. **`charts/browser-hitl/templates/configmap.yaml`** or **`secrets.yaml`** — render the value into the K8s resource
+3. **Deployment template** (if the env goes to a specific pod only, e.g. `egress-proxy-deployment.yaml`) — inject via `env:` with `secretKeyRef` or `configMapKeyRef`
+4. **`infra/tfy/deploy.yaml`** — add the `${PLACEHOLDER}` so envsubst can substitute it
+5. **`.github/workflows/deploy-staging.yaml`** — map from GitHub secrets in the deploy job `env:` block
+6. **`.github/workflows/deploy-production.yaml`** — same mapping in the production deploy job `env:` block
+7. **Code** — read via `process.env.VAR_NAME` with a sensible fallback
+
+If step 5 or 6 is missing, the var works locally (Helm values) but is always empty in CI deploys. This has caused production issues.
+
 ### Conventional Commits (enforced)
 
 PR titles MUST follow conventional commits (squash merge makes PR title the commit message):

--- a/charts/browser-hitl/Chart.yaml
+++ b/charts/browser-hitl/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: browser-hitl
 description: Browser Human-in-the-Loop MVP - Kubernetes-native service stack
 type: application
-version: 1.19.1
-appVersion: "1.19.1"
+version: 1.19.2
+appVersion: "1.19.2"
 keywords:
   - browser
   - hitl


### PR DESCRIPTION
## Summary

5 env vars were present in `infra/tfy/deploy.yaml` but not mapped in the CI deploy job env blocks. `envsubst` silently replaced them with empty strings — values never reached TrueFoundry regardless of GitHub Environment secrets.

### Added to both deploy-staging.yaml and deploy-production.yaml

- `EGRESS_UPSTREAM_PROXY_URL`
- `RECORDING_POOL_SIZE`
- `RECORDING_POOL_RESIDENTIAL_SIZE`
- `RECORDING_POOL_TENANTS`
- `WORKER_IMAGE_PULL_POLICY`

Also adds a checklist to CLAUDE.md documenting the full env routing chain to prevent this on future PRs.

3 files changed.