### PR TITLE
fix: stop reconcile from terminating just-claimed warm recording spares

### DIFF
--- a/apps/api/src/modules/recording/recording-pool.service.spec.ts
+++ b/apps/api/src/modules/recording/recording-pool.service.spec.ts
@@ -8,7 +8,12 @@ import { RecordingPoolService } from './recording-pool.service';
  */
 function makeService(
   env: { size?: string; residentialSize?: string; tenants?: string },
-  deps: { appRepoFindOne?: jest.Mock; managerQuery?: jest.Mock; findOne?: jest.Mock } = {},
+  deps: {
+    appRepoFindOne?: jest.Mock;
+    managerQuery?: jest.Mock;
+    findOne?: jest.Mock;
+    sessionCount?: jest.Mock;
+  } = {},
 ) {
   const prevSize = process.env.RECORDING_POOL_SIZE;
   const prevResidentialSize = process.env.RECORDING_POOL_RESIDENTIAL_SIZE;
@@ -21,7 +26,9 @@ function makeService(
   else process.env.RECORDING_POOL_TENANTS = env.tenants;
 
   const appRepo = { findOne: deps.appRepoFindOne ?? jest.fn(), update: jest.fn() } as any;
-  const sessionRepo = {} as any;
+  // countWarmingSpares() reads sessionRepo.count(); default to 0 (nothing warming).
+  const sessionCount = deps.sessionCount ?? jest.fn().mockResolvedValue(0);
+  const sessionRepo = { count: sessionCount } as any;
   // claimWarmSession runs inside dataSource.transaction(cb): the callback gets a
   // manager exposing query() (SELECT ... FOR UPDATE SKIP LOCKED, then UPDATE) and
   // getRepository().findOne() to return the claimed entity.
@@ -43,7 +50,7 @@ function makeService(
   if (prevTenants === undefined) delete process.env.RECORDING_POOL_TENANTS;
   else process.env.RECORDING_POOL_TENANTS = prevTenants;
 
-  return { svc, appRepo, dataSource, managerQuery, findOne };
+  return { svc, appRepo, dataSource, managerQuery, findOne, sessionCount };
 }
 
 describe('RecordingPoolService.isEnabledForTenant', () => {
@@ -112,9 +119,10 @@ describe('RecordingPoolService.claimWarmSession', () => {
 
   it('atomically reassigns a warm spare with the right claim params', async () => {
     const claimedEntity = { id: 'sess-1', pod_name: 'worker-abc', app_id: 'shell-app' };
-    // First manager.query = SELECT (returns picked id); second = UPDATE.
+    // manager.query order: SELECT (picked id), UPDATE sessions, UPDATE applications.
     const managerQuery = jest.fn()
       .mockResolvedValueOnce([{ id: 'sess-1' }])
+      .mockResolvedValueOnce(undefined)
       .mockResolvedValueOnce(undefined);
     const findOne = jest.fn().mockResolvedValue(claimedEntity);
     const { svc } = makeService(
@@ -134,6 +142,13 @@ describe('RecordingPoolService.claimWarmSession', () => {
       RECORDING_POOL.CLAIMED,
       'sess-1',
     ]);
+    // Third UPDATE retains the spare by setting the shell app desired=1 in the
+    // SAME transaction (prevents the reconcile scale-down race that would
+    // otherwise terminate the just-claimed spare as "excess").
+    expect(managerQuery.mock.calls[2][0]).toMatch(
+      /UPDATE applications SET desired_session_count = 1/,
+    );
+    expect(managerQuery.mock.calls[2][1]).toEqual(['shell-app']);
     expect(findOne).toHaveBeenCalledWith({ where: { id: 'sess-1' } });
   });
 
@@ -160,4 +175,63 @@ describe('RecordingPoolService.claimWarmSession', () => {
       where: { tenant_id: 't1', name: RECORDING_POOL.RESIDENTIAL_APP_NAME },
     });
   });
+});
+
+describe('RecordingPoolService.claimWarmSessionWithWait', () => {
+  it('returns a spare immediately on a hit, without checking for warming spares', async () => {
+    const managerQuery = jest.fn()
+      .mockResolvedValueOnce([{ id: 'sess-1' }]) // SELECT (hit)
+      .mockResolvedValueOnce(undefined) // UPDATE sessions
+      .mockResolvedValueOnce(undefined); // UPDATE applications
+    const findOne = jest.fn().mockResolvedValue({ id: 'sess-1', pod_name: 'worker-abc' });
+    const sessionCount = jest.fn().mockResolvedValue(3);
+    const { svc } = makeService(
+      { size: '2', tenants: '*' },
+      { appRepoFindOne: jest.fn().mockResolvedValue({ id: 'pool-app' }), managerQuery, findOne, sessionCount },
+    );
+
+    const result = await svc.claimWarmSessionWithWait('t1', 'shell-app', 'user-1');
+
+    expect(result).toEqual({ id: 'sess-1', pod_name: 'worker-abc' });
+    // A hit never needs the warming-spare probe.
+    expect(sessionCount).not.toHaveBeenCalled();
+  });
+
+  it('does NOT wait when nothing is warming — cold-starts immediately', async () => {
+    const managerQuery = jest.fn().mockResolvedValue([]); // SELECT always misses
+    const sessionCount = jest.fn().mockResolvedValue(0); // no warming spare
+    const { svc } = makeService(
+      { size: '2', tenants: '*' },
+      { appRepoFindOne: jest.fn().mockResolvedValue({ id: 'pool-app' }), managerQuery, sessionCount },
+    );
+
+    const started = Date.now();
+    const result = await svc.claimWarmSessionWithWait('t1', 'shell-app', 'user-1');
+
+    expect(result).toBeNull();
+    expect(sessionCount).toHaveBeenCalledTimes(1);
+    // Only the single immediate claim attempt ran — no poll loop.
+    expect(managerQuery).toHaveBeenCalledTimes(1);
+    expect(Date.now() - started).toBeLessThan(1000);
+  });
+
+  it('waits for a warming spare and claims it once it becomes HEALTHY', async () => {
+    // First claim misses; a spare is warming (count=1); the poll retry hits.
+    const managerQuery = jest.fn()
+      .mockResolvedValueOnce([]) // immediate SELECT (miss)
+      .mockResolvedValueOnce([{ id: 'sess-2' }]) // poll SELECT (hit)
+      .mockResolvedValueOnce(undefined) // UPDATE sessions
+      .mockResolvedValueOnce(undefined); // UPDATE applications
+    const findOne = jest.fn().mockResolvedValue({ id: 'sess-2', pod_name: 'worker-xyz' });
+    const sessionCount = jest.fn().mockResolvedValue(1);
+    const { svc } = makeService(
+      { size: '2', tenants: '*' },
+      { appRepoFindOne: jest.fn().mockResolvedValue({ id: 'pool-app' }), managerQuery, findOne, sessionCount },
+    );
+
+    const result = await svc.claimWarmSessionWithWait('t1', 'shell-app', 'user-1');
+
+    expect(result).toEqual({ id: 'sess-2', pod_name: 'worker-xyz' });
+    expect(sessionCount).toHaveBeenCalledTimes(1);
+  }, 10_000);
 });

--- a/apps/api/src/modules/recording/recording-pool.service.ts
+++ b/apps/api/src/modules/recording/recording-pool.service.ts
@@ -1,9 +1,17 @@
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, In, Repository } from 'typeorm';
 import { RECORDING_POOL, type RecordingMode } from '@browser-hitl/shared';
 import { ApplicationEntity, SessionEntity } from '../../entities';
 import { AppsService } from '../apps/apps.service';
+
+// Warm-claim miss handling. When the pool is momentarily drained (a burst claimed
+// every HEALTHY spare) but a refill is already warming, waiting a few seconds for
+// a spare to go HEALTHY beats cold-starting a brand-new pod: a warming spare is
+// usually seconds away, whereas a cold bring-up is ~1min AND leaves an extra pod
+// behind. Kept as constants (not env) to avoid widening the deploy env chain.
+const CLAIM_WAIT_MS = 15_000;
+const CLAIM_POLL_MS = 1_500;
 
 /**
  * Warm recording-session pool.
@@ -166,7 +174,64 @@ export class RecordingPoolService implements OnModuleInit {
         `UPDATE sessions SET app_id = $1, owner_user_id = $2, pool_state = $3 WHERE id = $4`,
         [targetAppId, ownerUserId, RECORDING_POOL.CLAIMED, claimedId],
       );
+      // Retain the reassigned spare atomically with the claim. The recording-shell
+      // app is created with desired_session_count=0 (see the provision controller)
+      // so a claim-wait poll can neither spawn a phantom cold pod (desired=1 with 0
+      // sessions) nor let reconcile reap the spare (desired=0 with 1 session). Set
+      // desired=1 in the SAME transaction so reconcile only ever sees a consistent
+      // (desired=1, 1 session) pair.
+      await manager.query(
+        `UPDATE applications SET desired_session_count = 1 WHERE id = $1`,
+        [targetAppId],
+      );
       return manager.getRepository(SessionEntity).findOne({ where: { id: claimedId } });
+    });
+  }
+
+  /**
+   * Claim a warm spare, waiting briefly for one to become HEALTHY on a transient
+   * miss. Returns immediately on a hit. On a miss it waits ONLY when a spare is
+   * already warming (a refill is in flight) — an empty pool with nothing warming
+   * cold-starts right away, adding zero latency. Bounded by CLAIM_WAIT_MS so a
+   * slow refill still falls back to cold provisioning rather than hanging.
+   */
+  async claimWarmSessionWithWait(
+    tenantId: string,
+    targetAppId: string,
+    ownerUserId: string | null,
+    residential = false,
+  ): Promise<SessionEntity | null> {
+    const immediate = await this.claimWarmSession(tenantId, targetAppId, ownerUserId, residential);
+    if (immediate) return immediate;
+    if (CLAIM_WAIT_MS <= 0) return null;
+    // Nothing warming → nothing to wait for; let the caller cold-start now.
+    if ((await this.countWarmingSpares(tenantId, residential)) === 0) return null;
+    const deadline = Date.now() + CLAIM_WAIT_MS;
+    while (Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, CLAIM_POLL_MS));
+      const claimed = await this.claimWarmSession(tenantId, targetAppId, ownerUserId, residential);
+      if (claimed) return claimed;
+    }
+    return null;
+  }
+
+  /**
+   * How many spares for this tenant+flavor are still warming (WARM pool_state but
+   * not yet HEALTHY). >0 means a refill is in flight and worth waiting a moment
+   * for; 0 means the pool is genuinely empty and the caller should cold-start.
+   */
+  private async countWarmingSpares(tenantId: string, residential: boolean): Promise<number> {
+    const poolApp = await this.appRepo.findOne({
+      where: { tenant_id: tenantId, name: this.appNameFor(residential) },
+    });
+    if (!poolApp) return 0;
+    return this.sessionRepo.count({
+      where: {
+        app_id: poolApp.id,
+        tenant_id: tenantId,
+        pool_state: RECORDING_POOL.WARM,
+        state: In(['STARTING', 'UNHEALTHY']),
+      },
     });
   }
 

--- a/apps/api/src/modules/recording/recording-provision.controller.ts
+++ b/apps/api/src/modules/recording/recording-provision.controller.ts
@@ -120,9 +120,11 @@ export class RecordingProvisionController {
     const poolEligible = this.recordingPool.isEnabledForTenant(tenantId, wantResidential);
 
     // 1. Create the recording-shell app (no login, manual creds, recording mode).
-    // desired=1 when pool-eligible so a claimed spare (or a reconcile-created
-    // cold session on pool miss) is retained; desired=0 otherwise so the cold
-    // path's scale() creates the session row inline (fast) in the request path.
+    // Always desired=0 at creation: a warm claim sets desired=1 in the SAME
+    // transaction as the reassignment (so the claim-wait poll can't race
+    // reconcile), and the cold path bumps desired 0->1 via scale() below. This
+    // keeps reconcile from spawning a phantom cold pod while we wait for a
+    // warming spare.
     const shortId = randomUUID().slice(0, 8);
     const { app_id } = await this.appsService.create(
       {
@@ -162,7 +164,7 @@ export class RecordingProvisionController {
         // flag, which wins regardless.
         residential_proxy_enabled: wantResidential,
         notification_config: {},
-        desired_session_count: poolEligible ? 1 : 0,
+        desired_session_count: 0,
       },
       tenantId,
       actorId,
@@ -175,14 +177,19 @@ export class RecordingProvisionController {
     }
 
     // 3. Warm-pool fast path: claim a pre-warmed spare and bind it to this
-    //    target (seed cookies + navigate) instead of cold-starting a pod.
+    //    target (seed cookies + navigate) instead of cold-starting a pod. On a
+    //    transient miss (pool momentarily drained but a refill is warming),
+    //    claimWarmSessionWithWait waits a few seconds for a spare to go HEALTHY
+    //    rather than cold-starting a fresh pod — a warming spare is usually
+    //    seconds away and far cheaper than a cold bring-up (which also leaves an
+    //    extra pod behind). A genuinely empty pool returns immediately → cold.
     if (poolEligible) {
       // Keep the tenant's pool warm / topped up (best-effort, off the hot path).
       this.recordingPool.ensurePoolApp(tenantId, wantResidential).catch((err) =>
         this.logger.warn(`ensurePoolApp failed for tenant ${tenantId}: ${err}`),
       );
 
-      const claimed = await this.recordingPool.claimWarmSession(
+      const claimed = await this.recordingPool.claimWarmSessionWithWait(
         tenantId,
         app_id,
         ownerUserId,
@@ -205,17 +212,16 @@ export class RecordingProvisionController {
         };
       }
       this.logger.log(`Warm pool empty for tenant ${tenantId}; falling back to cold provisioning`);
-      // Pool miss: the shell app already has desired=1, so the controller
-      // reconcile will create a cold session; waitForSession picks it up below.
-    } else {
-      // Cold path: bump desired 0 -> 1, which creates the session row inline in
-      // this request (fast) rather than waiting a reconcile tick.
-      await this.sessionsService.scale(app_id, 1, tenantId, actorId, undefined, {
-        residentialProxy: body?.residential_proxy,
-      });
     }
 
-    // 4. Wait for the session row, then mint the URL.
+    // 4. Cold path (pool disabled, or a miss with nothing warming in time): bump
+    //    desired 0 -> 1, which creates the session row inline in this request
+    //    (fast) rather than waiting a reconcile tick.
+    await this.sessionsService.scale(app_id, 1, tenantId, actorId, undefined, {
+      residentialProxy: body?.residential_proxy,
+    });
+
+    // 5. Wait for the session row, then mint the URL.
     const session = await this.waitForSession(app_id, tenantId);
     if (!session) {
       throw new GatewayTimeoutException(


### PR DESCRIPTION
## Problem

Recording provisioning against the warm pool intermittently **failed** (`Cannot open stream for TERMINATED session`) or fell back to a **~60s cold start** even when the tenant's pool had HEALTHY spares. Observed live on prod: a session with `pool_state=CLAIMED` but `state=TERMINATED` and `pod_name=null` — a warm spare that was claimed and then killed mid-provision.

## Root cause — a reconcile scale-down race

The recording-shell app was created with `desired_session_count=1`, then a warm spare was reassigned into it. If a controller reconcile tick landed in the **create→claim window**, it spawned a phantom cold session (`desired=1`, 0 sessions). The claim then added the warm spare → **2 sessions vs desired 1** → reconcile's "terminate excess, oldest-first" (`reconcile.service.ts` step 4) killed the **oldest**, which is the warm spare (its `started_at` predates the just-created cold one). The claimed spare died before the viewer link could be minted → the client waited out the dead pod (~60s) and either reprovisioned or failed.

## Fix

- **Create the shell app with `desired=0`**, and set `desired=1` **in the same transaction as the claim** (`claimWarmSession`). Reconcile now only ever sees a consistent `(1 desired, 1 session)` pair, so a just-claimed spare can never be treated as excess. The cold path bumps `desired 0→1` via `scale()` as before.
- **`claimWarmSessionWithWait`**: on a transient miss where a spare is *already warming* (a refill is in flight), poll briefly (15s) for it to go HEALTHY instead of cold-starting a fresh pod. A genuinely empty pool (nothing warming) returns immediately — **zero added latency**. This also stops creating an extra cold pod on every drained-pool miss (a zombie-session source).

## Validation

- `npx nx test api` (recording-pool): **13/13 pass**, incl. new `claimWarmSessionWithWait` cases + the in-tx `desired=1` assertion.
- `npx nx build api` + `lint` (tsc): clean.
- ⚠️ **Needs local-Kind / staging e2e before prod.** This touches the claim/reconcile interaction (an area with prior subtle bugs). Merging to `dev` deploys to staging (`tabby-api.adoptai.dev`) — validate a warm claim there (record twice, second sub-second, no reprovision), then promote `dev→main`.

## Note (separate, config)

Pool **depth** is still the lever for a burst that drains the pool faster than it refills — raise `RECORDING_POOL_SIZE` (GH env secret) if misses persist. Pools are strictly per-tenant + per-flavor (bundle encryption/isolation), so a tenant can't borrow another's spares.

🤖 Generated with [Claude Code](https://claude.com/claude-code)