### PR TITLE
chore: promote dev to production

### DIFF
--- a/apps/api/src/data-source.ts
+++ b/apps/api/src/data-source.ts
@@ -34,6 +34,7 @@ import { TraceContext1708300000029 } from './migrations/1708300000029-TraceConte
 import { AddTemplateIsActive1708300000030 } from './migrations/1708300000030-AddTemplateIsActive';
 import { AddResidentialProxyEnabled1708300000031 } from './migrations/1708300000031-AddResidentialProxyEnabled';
 import { AddSessionPoolState1708300000032 } from './migrations/1708300000032-AddSessionPoolState';
+import { AddSystemRecordingPoolTenant1708300000033 } from './migrations/1708300000033-AddSystemRecordingPoolTenant';
 
 const poolSize = Number(process.env.DB_POOL_SIZE) || 20;
 
@@ -43,7 +44,7 @@ export const dataSourceOptions: DataSourceOptions = {
     testDefault: 'postgresql://postgres:postgres@localhost:5432/browser_hitl',
   }),
   entities: Object.values(entities),
-  migrations: [InitialSchema1708300000000, WorkerRLS1708300000001, AgentClients1708300000002, AuthRequests1708300000003, LoginQueue1708300000004, AccountLockout1708300000005, ArtifactCascadeDelete1708300000006, ServiceProfiles1708300000007, ProfileAppLink1708300000008, GenericHumanInput1708300000009, AddIdentityProviders1708300000010, AddOwnerUserIds1708300000011, AddAppTemplates1708300000012, AddIdleShutdown1708300000013, AddAppOwnerUserId1708300000014, MultiTenantCloud1708300000015, GenericOAuth1708300000016, NullablePasswordHash1708300000017, GlobalIdp1708300000018, AddRestartRequested1708300000019, AddTemplateLineage1708300000020, DropIdpSecrets1708300000021, AddExecuteEnabled1708300000022, ControllerScaling1708300000023, AddTemplateExecuteEnabled1708300000024, UnrestrictedProfiles1708300000025, AddExtraEgressAllowlist1708300000026, AddRoleMapping1708300000027, AddLastActivityAt1708300000028, TraceContext1708300000029, AddTemplateIsActive1708300000030, AddResidentialProxyEnabled1708300000031, AddSessionPoolState1708300000032],
+  migrations: [InitialSchema1708300000000, WorkerRLS1708300000001, AgentClients1708300000002, AuthRequests1708300000003, LoginQueue1708300000004, AccountLockout1708300000005, ArtifactCascadeDelete1708300000006, ServiceProfiles1708300000007, ProfileAppLink1708300000008, GenericHumanInput1708300000009, AddIdentityProviders1708300000010, AddOwnerUserIds1708300000011, AddAppTemplates1708300000012, AddIdleShutdown1708300000013, AddAppOwnerUserId1708300000014, MultiTenantCloud1708300000015, GenericOAuth1708300000016, NullablePasswordHash1708300000017, GlobalIdp1708300000018, AddRestartRequested1708300000019, AddTemplateLineage1708300000020, DropIdpSecrets1708300000021, AddExecuteEnabled1708300000022, ControllerScaling1708300000023, AddTemplateExecuteEnabled1708300000024, UnrestrictedProfiles1708300000025, AddExtraEgressAllowlist1708300000026, AddRoleMapping1708300000027, AddLastActivityAt1708300000028, TraceContext1708300000029, AddTemplateIsActive1708300000030, AddResidentialProxyEnabled1708300000031, AddSessionPoolState1708300000032, AddSystemRecordingPoolTenant1708300000033],
   migrationsRun: true,
   synchronize: false,
   logging: process.env.NODE_ENV === 'development' ? ['error', 'warn', 'migration'] : ['error'],

--- a/apps/api/src/migrations/1708300000033-AddSystemRecordingPoolTenant.ts
+++ b/apps/api/src/migrations/1708300000033-AddSystemRecordingPoolTenant.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Seed the sentinel "system" tenant that owns the GLOBAL warm recording pool.
+ *
+ * The warm pool moved from one pool app per tenant to a single shared pool: the
+ * pool app(s) and their unclaimed spares live under this well-known tenant id
+ * (RECORDING_POOL.SYSTEM_TENANT_ID), and a claim rebinds the spare's tenant_id
+ * to the real requesting tenant. Because sessions/applications have a FK to
+ * tenants, this row must exist before any pool app is created. Idempotent.
+ *
+ * max_sessions is set high so the controller never refuses to warm spares under
+ * this tenant (real recordings count against the claiming tenant, not this one,
+ * since the claim rebinds tenant_id).
+ */
+export class AddSystemRecordingPoolTenant1708300000033 implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `INSERT INTO "tenants" ("id", "name", "max_sessions")
+       VALUES ('00000000-0000-0000-0000-000000000000', '__system_recording_pool__', 100000)
+       ON CONFLICT ("id") DO NOTHING`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Remove the sentinel tenant only if nothing still references it (its pool
+    // apps/spares should be gone first). Safe no-op if rows remain.
+    await queryRunner.query(
+      `DELETE FROM "tenants" WHERE "id" = '00000000-0000-0000-0000-000000000000'
+         AND NOT EXISTS (SELECT 1 FROM "applications" WHERE "tenant_id" = '00000000-0000-0000-0000-000000000000')
+         AND NOT EXISTS (SELECT 1 FROM "sessions" WHERE "tenant_id" = '00000000-0000-0000-0000-000000000000')`,
+    );
+  }
+}

--- a/apps/api/src/modules/recording/recording-pool.service.spec.ts
+++ b/apps/api/src/modules/recording/recording-pool.service.spec.ts
@@ -133,13 +133,15 @@ describe('RecordingPoolService.claimWarmSession', () => {
     const result = await svc.claimWarmSession('t1', 'shell-app', 'user-1');
 
     expect(result).toEqual(claimedEntity);
-    // SELECT filters pool-app / tenant / WARM.
-    expect(managerQuery.mock.calls[0][1]).toEqual(['pool-app', 't1', RECORDING_POOL.WARM]);
-    // UPDATE sets shell app_id, owner, CLAIMED for the picked id.
+    // SELECT filters by the (global) pool app id + WARM — no tenant predicate.
+    expect(managerQuery.mock.calls[0][1]).toEqual(['pool-app', RECORDING_POOL.WARM]);
+    // UPDATE sets shell app_id, owner, CLAIMED, and rebinds tenant_id to the
+    // claiming tenant, for the picked id.
     expect(managerQuery.mock.calls[1][1]).toEqual([
       'shell-app',
       'user-1',
       RECORDING_POOL.CLAIMED,
+      't1',
       'sess-1',
     ]);
     // Third UPDATE retains the spare by setting the shell app desired=1 in the
@@ -160,7 +162,7 @@ describe('RecordingPoolService.claimWarmSession', () => {
     );
     await svc.claimWarmSession('t1', 'shell-app', 'user-1');
     expect(appRepoFindOne).toHaveBeenCalledWith({
-      where: { tenant_id: 't1', name: RECORDING_POOL.APP_NAME },
+      where: { tenant_id: RECORDING_POOL.SYSTEM_TENANT_ID, name: RECORDING_POOL.APP_NAME },
     });
   });
 
@@ -172,7 +174,7 @@ describe('RecordingPoolService.claimWarmSession', () => {
     );
     await svc.claimWarmSession('t1', 'shell-app', 'user-1', true);
     expect(appRepoFindOne).toHaveBeenCalledWith({
-      where: { tenant_id: 't1', name: RECORDING_POOL.RESIDENTIAL_APP_NAME },
+      where: { tenant_id: RECORDING_POOL.SYSTEM_TENANT_ID, name: RECORDING_POOL.RESIDENTIAL_APP_NAME },
     });
   });
 });

--- a/apps/api/src/modules/recording/recording-pool.service.ts
+++ b/apps/api/src/modules/recording/recording-pool.service.ts
@@ -16,16 +16,21 @@ const CLAIM_POLL_MS = 1_500;
 /**
  * Warm recording-session pool.
  *
- * Maintains, per opt-in tenant, a dedicated "pool app" whose sessions are
- * pre-warmed recording pods sitting on about:blank (browser up, noVNC serving,
- * health PASS). A recording request atomically CLAIMS one of these spares and
- * reassigns it to a per-target recording-shell app, then binds it (navigate +
- * seed cookies) — turning a ~1-2min cold pod bring-up into a sub-second claim.
+ * Maintains a single GLOBAL "pool app" (per flavor) — owned by the sentinel
+ * system tenant — whose sessions are pre-warmed recording pods sitting on
+ * about:blank (browser up, noVNC serving, health PASS). A recording request
+ * atomically CLAIMS one of these spares, reassigns it to a per-target
+ * recording-shell app AND rebinds its tenant_id to the requesting tenant, then
+ * binds it (navigate + seed cookies) — turning a ~1-2min cold pod bring-up into
+ * a sub-second claim, for EVERY tenant, with no per-tenant/per-flavor lazy-warm
+ * gap (the shared pool is warmed once at boot).
  *
- * Cross-tenant reuse is impossible: recording bundles are stored in the tenant's
- * MinIO bucket under its encryption key, so a spare can only ever serve its own
- * tenant. The pool is therefore strictly per-tenant and opt-in via
- * RECORDING_POOL_TENANTS (empty = feature off → cold path everywhere).
+ * Cross-tenant reuse is safe: the bundle encryption key is process-wide (not
+ * per-tenant), the MinIO bucket is derived from the session's tenant_id at
+ * persist time (which the claim rebinds to the requesting tenant), and a spare
+ * is single-use — claimed → becomes a real recording → terminated, never
+ * re-pooled. The feature is opt-in via RECORDING_POOL_TENANTS (empty = off);
+ * that list now gates only WHICH tenants may claim from the shared pool.
  */
 @Injectable()
 export class RecordingPoolService implements OnModuleInit {
@@ -76,35 +81,43 @@ export class RecordingPoolService implements OnModuleInit {
     return this.allTenants || this.poolTenants.has(tenantId);
   }
 
+  /**
+   * Is the pool feature on for this flavor at all — i.e. size>0 AND at least one
+   * tenant (or '*') may claim? The tenant-agnostic counterpart of
+   * isEnabledForTenant, used to decide whether to warm the shared pool at boot.
+   */
+  private featureEnabled(residential: boolean): boolean {
+    return this.sizeFor(residential) > 0 && (this.allTenants || this.poolTenants.size > 0);
+  }
+
   async onModuleInit(): Promise<void> {
     if (this.poolSize <= 0 && this.residentialPoolSize <= 0) return;
-    // Eagerly ensure pool apps for explicitly-listed tenants so spares warm
-    // before the first request. A '*' wildcard can't be pre-enumerated, so those
-    // tenants warm lazily on their first recording request. Each enabled flavor
-    // gets its own pool app.
-    for (const tenantId of this.poolTenants) {
-      for (const residential of [false, true]) {
-        if (this.sizeFor(residential) <= 0) continue;
-        try {
-          await this.ensurePoolApp(tenantId, residential);
-        } catch (err) {
-          this.logger.warn(
-            `Failed to ensure ${residential ? 'residential ' : ''}pool app for tenant ${tenantId}: ${err}`,
-          );
-        }
+    // Warm the GLOBAL pool once at boot. Unlike the old per-tenant pool this no
+    // longer depends on enumerating tenants (the shared pool serves every enabled
+    // tenant), so a '*' wildcard is pre-warmed too — eliminating the first-request
+    // cold start. Each enabled flavor gets its own global pool app.
+    for (const residential of [false, true]) {
+      if (!this.featureEnabled(residential)) continue;
+      try {
+        await this.ensurePoolApp(residential);
+      } catch (err) {
+        this.logger.warn(
+          `Failed to ensure ${residential ? 'residential ' : ''}global pool app: ${err}`,
+        );
       }
     }
   }
 
   /**
-   * Find-or-create the tenant's pool app for the given flavor and keep its
-   * desired_session_count in sync with the flavor's configured size. Idempotent +
-   * safe under concurrent API replicas (re-reads on create race). Returns the
-   * pool app id.
+   * Find-or-create the GLOBAL pool app for the given flavor (owned by the system
+   * tenant) and keep its desired_session_count in sync with the flavor's
+   * configured size. Idempotent + safe under concurrent API replicas (re-reads on
+   * create race). Returns the pool app id.
    */
-  async ensurePoolApp(tenantId: string, residential = false): Promise<string> {
+  async ensurePoolApp(residential = false): Promise<string> {
     const appName = this.appNameFor(residential);
     const size = this.sizeFor(residential);
+    const tenantId = RECORDING_POOL.SYSTEM_TENANT_ID;
     const existing = await this.appRepo.findOne({
       where: { tenant_id: tenantId, name: appName },
     });
@@ -121,7 +134,7 @@ export class RecordingPoolService implements OnModuleInit {
         'system:recording-pool',
       );
       this.logger.log(
-        `Created ${residential ? 'residential ' : ''}recording pool app ${app_id} for tenant ${tenantId} (size ${size})`,
+        `Created global ${residential ? 'residential ' : ''}recording pool app ${app_id} (size ${size})`,
       );
       return app_id;
     } catch (err) {
@@ -149,7 +162,7 @@ export class RecordingPoolService implements OnModuleInit {
     residential = false,
   ): Promise<SessionEntity | null> {
     const poolApp = await this.appRepo.findOne({
-      where: { tenant_id: tenantId, name: this.appNameFor(residential) },
+      where: { tenant_id: RECORDING_POOL.SYSTEM_TENANT_ID, name: this.appNameFor(residential) },
     });
     if (!poolApp) return null;
 
@@ -157,22 +170,30 @@ export class RecordingPoolService implements OnModuleInit {
     // the picked spare for the txn so concurrent API replicas grab distinct
     // rows. (We don't use UPDATE ... RETURNING here: TypeORM's query() does not
     // reliably surface RETURNING rows for an UPDATE, which would make the claim
-    // look empty even though it committed.)
+    // look empty even though it committed.) app_id alone scopes the pick to the
+    // global pool app — no tenant predicate, since spares are tenant-agnostic
+    // until claimed.
     return this.dataSource.transaction(async (manager) => {
       const picked = await manager.query(
         `SELECT id FROM sessions
-          WHERE app_id = $1 AND tenant_id = $2 AND pool_state = $3
+          WHERE app_id = $1 AND pool_state = $2
             AND state = 'HEALTHY' AND pod_name IS NOT NULL
           ORDER BY started_at ASC
           LIMIT 1
           FOR UPDATE SKIP LOCKED`,
-        [poolApp.id, tenantId, RECORDING_POOL.WARM],
+        [poolApp.id, RECORDING_POOL.WARM],
       );
       if (!picked || picked.length === 0) return null;
       const claimedId = picked[0].id;
+      // Rebind the spare to the requesting tenant AS PART OF the claim. This is
+      // load-bearing: persist() derives the per-tenant MinIO bucket from
+      // session.tenant_id, so the exported bundle lands in the CLAIMING tenant's
+      // bucket, not the system pool's. (The worker pod's baked TENANT_ID env goes
+      // stale here but is unused on the recording path — drain is raw, encrypt +
+      // persist are API-side off this DB row.)
       await manager.query(
-        `UPDATE sessions SET app_id = $1, owner_user_id = $2, pool_state = $3 WHERE id = $4`,
-        [targetAppId, ownerUserId, RECORDING_POOL.CLAIMED, claimedId],
+        `UPDATE sessions SET app_id = $1, owner_user_id = $2, pool_state = $3, tenant_id = $4 WHERE id = $5`,
+        [targetAppId, ownerUserId, RECORDING_POOL.CLAIMED, tenantId, claimedId],
       );
       // Retain the reassigned spare atomically with the claim. The recording-shell
       // app is created with desired_session_count=0 (see the provision controller)
@@ -205,7 +226,7 @@ export class RecordingPoolService implements OnModuleInit {
     if (immediate) return immediate;
     if (CLAIM_WAIT_MS <= 0) return null;
     // Nothing warming → nothing to wait for; let the caller cold-start now.
-    if ((await this.countWarmingSpares(tenantId, residential)) === 0) return null;
+    if ((await this.countWarmingSpares(residential)) === 0) return null;
     const deadline = Date.now() + CLAIM_WAIT_MS;
     while (Date.now() < deadline) {
       await new Promise((resolve) => setTimeout(resolve, CLAIM_POLL_MS));
@@ -220,15 +241,14 @@ export class RecordingPoolService implements OnModuleInit {
    * not yet HEALTHY). >0 means a refill is in flight and worth waiting a moment
    * for; 0 means the pool is genuinely empty and the caller should cold-start.
    */
-  private async countWarmingSpares(tenantId: string, residential: boolean): Promise<number> {
+  private async countWarmingSpares(residential: boolean): Promise<number> {
     const poolApp = await this.appRepo.findOne({
-      where: { tenant_id: tenantId, name: this.appNameFor(residential) },
+      where: { tenant_id: RECORDING_POOL.SYSTEM_TENANT_ID, name: this.appNameFor(residential) },
     });
     if (!poolApp) return 0;
     return this.sessionRepo.count({
       where: {
         app_id: poolApp.id,
-        tenant_id: tenantId,
         pool_state: RECORDING_POOL.WARM,
         state: In(['STARTING', 'UNHEALTHY']),
       },

--- a/apps/api/src/modules/recording/recording-provision.controller.ts
+++ b/apps/api/src/modules/recording/recording-provision.controller.ts
@@ -184,9 +184,9 @@ export class RecordingProvisionController {
     //    seconds away and far cheaper than a cold bring-up (which also leaves an
     //    extra pod behind). A genuinely empty pool returns immediately → cold.
     if (poolEligible) {
-      // Keep the tenant's pool warm / topped up (best-effort, off the hot path).
-      this.recordingPool.ensurePoolApp(tenantId, wantResidential).catch((err) =>
-        this.logger.warn(`ensurePoolApp failed for tenant ${tenantId}: ${err}`),
+      // Keep the shared global pool warm / topped up (best-effort, off the hot path).
+      this.recordingPool.ensurePoolApp(wantResidential).catch((err) =>
+        this.logger.warn(`ensurePoolApp failed (${wantResidential ? 'residential' : 'standard'}): ${err}`),
       );
 
       const claimed = await this.recordingPool.claimWarmSessionWithWait(

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -294,6 +294,13 @@ async function main() {
       // navigate. The already-running RecordingRunner captures from here on.
       const boundContext = context;
       healthServer.setBindHandler(async ({ start_url, seed_cookies }) => {
+        // Seed cookies synchronously — the human must start authenticated before
+        // they interact — but do NOT await the navigation. Loading the target
+        // through the residential proxy can take tens of seconds, and the API
+        // awaits this bind on the provision response's critical path; awaiting the
+        // full page load there is what made residential links ~50s to hand over.
+        // The RecordingRunner captures from navigation onward regardless, and the
+        // human watches the page load in the viewer (where they'd wait anyway).
         if (Array.isArray(seed_cookies) && seed_cookies.length > 0) {
           try {
             await boundContext.addCookies(seed_cookies as Parameters<typeof boundContext.addCookies>[0]);
@@ -302,8 +309,10 @@ async function main() {
             console.warn(`Bind: failed to seed cookies: ${err}`);
           }
         }
-        await page.goto(start_url, { waitUntil: 'domcontentloaded' });
-        console.log(`Bind: navigated to ${start_url}`);
+        page
+          .goto(start_url, { waitUntil: 'domcontentloaded' })
+          .then(() => console.log(`Bind: navigated to ${start_url}`))
+          .catch((err) => console.warn(`Bind: navigation to ${start_url} failed: ${err}`));
       });
 
       // Session reuse: seed cookies captured from a prior login recording so the

--- a/charts/browser-hitl/Chart.yaml
+++ b/charts/browser-hitl/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: browser-hitl
 description: Browser Human-in-the-Loop MVP - Kubernetes-native service stack
 type: application
-version: 1.19.3
-appVersion: "1.19.3"
+version: 1.19.4
+appVersion: "1.19.4"
 keywords:
   - browser
   - hitl

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -141,18 +141,27 @@ export const DEFAULTS = {
 } as const;
 
 /**
- * Warm recording-session pool. A per-tenant pool of pre-warmed recording pods
+ * Warm recording-session pool. A single GLOBAL pool of pre-warmed recording pods
  * (browser up, sitting on about:blank) that a recording request claims + binds
  * in place of cold-starting a pod — cutting link provisioning from ~1-2min to
- * seconds. Cross-tenant reuse is impossible (bundles are stored in the tenant's
- * MinIO bucket under its encryption key), so the pool is strictly per-tenant and
- * opt-in via RECORDING_POOL_TENANTS (empty = feature off, cold path everywhere).
+ * seconds. The pool app + its warm spares live under a well-known system tenant
+ * (SYSTEM_TENANT_ID); a claim reassigns a spare to the requesting tenant's shell
+ * app AND rebinds the session's tenant_id to that tenant in one transaction, so
+ * the exported bundle persists to the correct per-tenant MinIO bucket.
+ *
+ * Cross-tenant reuse is safe: the bundle encryption key is process-wide (not
+ * per-tenant), the bucket is derived from the session's tenant_id at persist
+ * time, and a spare is single-use (claimed -> becomes a real recording ->
+ * terminated, never re-pooled), so no data from one tenant is ever visible to
+ * another. The feature is opt-in via RECORDING_POOL_TENANTS (empty = off); that
+ * list now gates only WHICH tenants may claim from the shared pool — the pool
+ * itself is warmed once, globally, at boot.
  */
 export const RECORDING_POOL = {
-  /** Well-known app name the controller/API use to find a tenant's pool app. */
+  /** Well-known app name the controller/API use to find the global pool app. */
   APP_NAME: '__recording_pool__',
   /**
-   * Well-known app name for the tenant's RESIDENTIAL warm pool. Its spares boot
+   * Well-known app name for the global RESIDENTIAL warm pool. Its spares boot
    * with residential_proxy_enabled so their egress is chained through the
    * residential proxy while they warm and after they're claimed. A recording
    * request that asks for residential egress claims from this pool; all other
@@ -160,6 +169,12 @@ export const RECORDING_POOL = {
    * so each flavor has its own desired_session_count / warm capacity.
    */
   RESIDENTIAL_APP_NAME: '__recording_pool_residential__',
+  /**
+   * Sentinel tenant that owns the global pool app(s) and their unclaimed warm
+   * spares. Seeded by migration 033. A claim rebinds the spare's tenant_id to the
+   * real requesting tenant, so this id only ever appears on unclaimed spares.
+   */
+  SYSTEM_TENANT_ID: '00000000-0000-0000-0000-000000000000',
   WARM: 'WARM',
   CLAIMED: 'CLAIMED',
 } as const;


### PR DESCRIPTION
## Summary

Promotes dev → main. **Merge with merge commit, NOT squash.**

### Changes

- feat(recording): global warm pool + non-blocking bind (#133)
- fix: stop reconcile from terminating just-claimed warm recording spares (#131)
- fix(ci): wire missing env vars through deploy workflows (#130)
- Chart version bump

### Post-deploy

Delete orphaned per-tenant pool apps (`__recording_pool__` / `__recording_pool_residential__`) — replaced by the global pool under the system tenant.

## Test plan

- [x] CI green on dev
- [ ] deploy-production triggers on merge
- [ ] ⚠️ **MERGE WITH MERGE COMMIT**