### PR TITLE
fix(worker): reset recording capture at warm-pool bind

### DIFF
--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -309,6 +309,10 @@ async function main() {
             console.warn(`Bind: failed to seed cookies: ${err}`);
           }
         }
+        // Drop the pre-bind capture (the spare's warm-up navigation to the pool
+        // placeholder URL) so the bundle starts clean at the real target — the
+        // placeholder must never leak into the compiled login_url / HAR.
+        recordingRunner?.reset();
         page
           .goto(start_url, { waitUntil: 'domcontentloaded' })
           .then(() => console.log(`Bind: navigated to ${start_url}`))

--- a/apps/worker/src/recording-runner.spec.ts
+++ b/apps/worker/src/recording-runner.spec.ts
@@ -105,6 +105,31 @@ describe('RecordingRunner', () => {
     expect(bundle.stopped_at).toBeTruthy();
   });
 
+  it('reset() drops pre-bind capture so the bundle starts at the real target', async () => {
+    // A warm spare warms on the pool placeholder page, then bind resets + navigates.
+    const f = makeFakes('https://example.com/');
+    const runner = new RecordingRunner(f.page, f.context, 'sess-1', 'login');
+    await runner.start();
+
+    // Pre-bind (warm-up) activity on the placeholder that must NOT leak.
+    f.emit(clickEvent);
+    f.navigate('https://example.com/warmup');
+
+    // Bind: reset, then navigate to the real target.
+    runner.reset();
+    f.navigate('https://www.airbnb.com/');
+
+    const bundle = await runner.drain();
+
+    // Placeholder click + url events are gone.
+    expect(bundle.click_events).toHaveLength(0);
+    // First url_event is the real target, with from_url cleared by reset — so the
+    // NoUI login compiler resolves login_url to the target, not the placeholder.
+    expect(bundle.url_events).toEqual([
+      expect.objectContaining({ from_url: '', to_url: 'https://www.airbnb.com/' }),
+    ]);
+  });
+
   it('does not record a url event when the url is unchanged', async () => {
     const f = makeFakes('https://example.com/login');
     const runner = new RecordingRunner(f.page, f.context, 'sess-1', 'workflow');

--- a/apps/worker/src/recording-runner.ts
+++ b/apps/worker/src/recording-runner.ts
@@ -116,6 +116,30 @@ export class RecordingRunner {
     console.log(`[Recording] started: session=${this.sessionId}, mode=${this.recordingMode}`);
   }
 
+  /**
+   * Discard everything captured so far and start fresh. Called when a warm-pool
+   * spare is bound to its real target: the spare booted + navigated to the pool
+   * placeholder URL (RECORDING_POOL_WARM_URL, e.g. about:blank/example.com) while
+   * warming, and that pre-bind activity would otherwise pollute the bundle —
+   * most visibly, the first url_event's to_url is the placeholder, which the NoUI
+   * login compiler picks as the login_url. Resetting here makes a warm capture
+   * indistinguishable from a cold one (recording starts at the real target).
+   *
+   * lastUrl is cleared (not set to the current placeholder page) so the imminent
+   * navigation to the real start_url is recorded as the first url_event.
+   */
+  reset(): void {
+    if (!this.started) return;
+    this.events.length = 0;
+    this.urlEvents.length = 0;
+    this.lastUrl = '';
+    // Re-arm HAR capture: startHarCapture detaches the existing listeners and
+    // installs fresh ones over a new (empty) entries buffer, dropping any
+    // placeholder-page requests captured while the spare was warm.
+    startHarCapture(this.page);
+    console.log(`[Recording] reset at bind: session=${this.sessionId} (dropped pre-bind capture)`);
+  }
+
   /** Assemble and return the bundle. Detaches listeners (idempotent). */
   async drain(): Promise<RecordingBundle> {
     // Capture session cookies before tearing down so a workflow recording can


### PR DESCRIPTION
## What & why

A warm-pool spare boots and navigates to the pool placeholder URL (`RECORDING_POOL_WARM_URL`, e.g. `example.com`) while warming. That pre-bind activity was captured into the recording bundle, so the **first `url_event`'s `to_url` was the placeholder** — which NoUI's login compiler picks as the `login_url`.

Result: a combined/login capture made on a warm spare compiled a login App Template whose `login_url` (and first `goto` step) pointed at `example.com` instead of the real site — so auto-provisioning from that template would navigate to the wrong page. Confirmed live: an Airbnb combined capture on dev compiled `login_url: https://example.com/`.

## Fix

`RecordingRunner.reset()` clears the DOM-event + url-event buffers, clears `lastUrl`, and re-arms HAR capture (dropping placeholder-page entries). The worker's `/recording/bind` handler calls it right before navigating to the real target, so a warm capture is indistinguishable from a cold one — recording starts clean at the target.

- `apps/worker/src/recording-runner.ts` — add `reset()`.
- `apps/worker/src/main.ts` — call `recordingRunner?.reset()` in the bind handler before `page.goto(start_url)`.

## Validation

- New unit test: pre-bind click + url events are dropped; the first post-reset `url_event` is the real target with `from_url` cleared. Full worker suite green (125 tests), build + lint pass (pre-commit hook).

## Note

Worker-side change — takes effect for **new** recordings once the worker image is rebuilt/deployed. Pairs with the NoUI recording fixes (adoptai/noui#121).

🤖 Generated with [Claude Code](https://claude.com/claude-code)