### PR TITLE
fix(recording): idle-reap recording sessions by real activity, not age

### DIFF
--- a/apps/api/src/modules/recording/recording-pool.service.spec.ts
+++ b/apps/api/src/modules/recording/recording-pool.service.spec.ts
@@ -144,6 +144,9 @@ describe('RecordingPoolService.claimWarmSession', () => {
       't1',
       'sess-1',
     ]);
+    // …and stamps last_activity_at so the idle reaper measures idleness from the
+    // claim, not the spare's older started_at.
+    expect(managerQuery.mock.calls[1][0]).toMatch(/last_activity_at = NOW\(\)/);
     // Third UPDATE retains the spare by setting the shell app desired=1 in the
     // SAME transaction (prevents the reconcile scale-down race that would
     // otherwise terminate the just-claimed spare as "excess").

--- a/apps/api/src/modules/recording/recording-pool.service.ts
+++ b/apps/api/src/modules/recording/recording-pool.service.ts
@@ -191,8 +191,13 @@ export class RecordingPoolService implements OnModuleInit {
       // bucket, not the system pool's. (The worker pod's baked TENANT_ID env goes
       // stale here but is unused on the recording path — drain is raw, encrypt +
       // persist are API-side off this DB row.)
+      //
+      // Stamp last_activity_at = NOW() so the idle reaper measures idleness from
+      // the CLAIM, not the spare's (older) started_at. A warm spare may have sat
+      // warm for a while; without this the claimed session would look
+      // pre-aged/idle the instant it's handed over and get reaped mid-login.
       await manager.query(
-        `UPDATE sessions SET app_id = $1, owner_user_id = $2, pool_state = $3, tenant_id = $4 WHERE id = $5`,
+        `UPDATE sessions SET app_id = $1, owner_user_id = $2, pool_state = $3, tenant_id = $4, last_activity_at = NOW() WHERE id = $5`,
         [targetAppId, ownerUserId, RECORDING_POOL.CLAIMED, tenantId, claimedId],
       );
       // Retain the reassigned spare atomically with the claim. The recording-shell

--- a/apps/api/src/modules/streaming/streaming.controller.spec.ts
+++ b/apps/api/src/modules/streaming/streaming.controller.spec.ts
@@ -42,7 +42,7 @@ function buildModule(overrides: {
   streamTokenService?: Record<string, unknown>;
   jwtService?: Record<string, unknown>;
 } = {}) {
-  const sessionRepo = overrides.sessionRepo ?? { findOne: jest.fn(), update: jest.fn() };
+  const sessionRepo = overrides.sessionRepo ?? { findOne: jest.fn(), update: jest.fn().mockResolvedValue(undefined) };
   const appRepo = overrides.appRepo ?? { findOne: jest.fn() };
   const interventionRepo = overrides.interventionRepo ?? { findOne: jest.fn() };
   const streamTokenService = overrides.streamTokenService ?? {
@@ -83,7 +83,7 @@ describe('StreamingController — panel-state', () => {
   let streamTokenService: any;
 
   beforeEach(async () => {
-    sessionRepo = { findOne: jest.fn(), update: jest.fn() };
+    sessionRepo = { findOne: jest.fn(), update: jest.fn().mockResolvedValue(undefined) };
     interventionRepo = { findOne: jest.fn() };
     streamTokenService = {
       verifyToken: jest.fn().mockReturnValue({
@@ -173,7 +173,7 @@ describe('StreamingController — restart', () => {
   let streamTokenService: any;
 
   beforeEach(async () => {
-    sessionRepo = { findOne: jest.fn(), update: jest.fn() };
+    sessionRepo = { findOne: jest.fn(), update: jest.fn().mockResolvedValue(undefined) };
     streamTokenService = {
       verifyToken: jest.fn().mockReturnValue({
         valid: true,
@@ -232,7 +232,7 @@ describe('StreamingController — successor', () => {
   let streamTokenService: any;
 
   beforeEach(async () => {
-    sessionRepo = { findOne: jest.fn(), update: jest.fn() };
+    sessionRepo = { findOne: jest.fn(), update: jest.fn().mockResolvedValue(undefined) };
     appRepo = { findOne: jest.fn() };
     streamTokenService = {
       verifyToken: jest.fn().mockReturnValue({

--- a/apps/api/src/modules/streaming/streaming.controller.ts
+++ b/apps/api/src/modules/streaming/streaming.controller.ts
@@ -1398,6 +1398,16 @@ export class StreamingController {
     const session = await this.sessionRepo.findOne({ where: { id: sessionId } });
     if (!session) throw new NotFoundException('Session not found');
 
+    // Activity heartbeat: the viewer polls panel-state every ~5s while the tab is
+    // open, so treat each poll as "session in use". This keeps a session that a
+    // human is actively viewing/driving (VNC recording, HITL) alive under the idle
+    // reaper, while an abandoned one (viewer closed → polling stops) correctly
+    // falls idle and gets reaped. Fire-and-forget: a heartbeat must never block or
+    // fail the state response.
+    if (session.state !== 'TERMINATED') {
+      this.sessionRepo.update(sessionId, { last_activity_at: new Date() }).catch(() => {});
+    }
+
     let pendingInput = session.pending_input_request as Record<string, unknown> | null;
     if (!pendingInput && (session.state === 'LOGIN_IN_PROGRESS' || session.state === 'LOGIN_NEEDED')) {
       const autoResolved = await this.streamTokenService.isHitlAutoResolved(sessionId);

--- a/apps/controller/src/reconcile.service.spec.ts
+++ b/apps/controller/src/reconcile.service.spec.ts
@@ -370,4 +370,29 @@ describe('ReconcileService checkRecycling', () => {
     expect(appRepo.update).toHaveBeenCalledWith('app-1', { desired_session_count: 0 });
     expect(stateMachine.transition).toHaveBeenCalledWith(healthy, expect.anything());
   });
+
+  it('spares a session with recent last_activity_at even when started_at is old (activity-driven)', async () => {
+    // A recording session actively viewed via the panel-state heartbeat, or a
+    // warm-claimed session, has a fresh last_activity_at even though started_at
+    // (the pool spare's warm time) is old. The reaper must judge by activity, not
+    // age — otherwise it would kill sessions that are actively in use.
+    process.env = { ...originalEnv, IDLE_SHUTDOWN_SECONDS: '60', MAX_SESSION_AGE_HOURS: '24' };
+    const { service, sessionRepo, appRepo, stateMachine } = buildForRecycling();
+
+    const healthy = makeSession({
+      id: 'recently-active',
+      state: 'HEALTHY',
+      owner_user_id: 'user-a',
+      started_at: new Date(Date.now() - 3_600_000), // 1h old (e.g. long-warmed spare)
+      last_activity_at: new Date(Date.now() - 5_000), // but active 5s ago (< 60s threshold)
+    });
+    sessionRepo.find
+      .mockResolvedValueOnce([healthy])
+      .mockResolvedValueOnce([]); // no FAILED
+
+    await (service as any).checkRecycling();
+
+    expect(appRepo.update).not.toHaveBeenCalled();
+    expect(stateMachine.transition).not.toHaveBeenCalled();
+  });
 });

--- a/apps/controller/src/reconcile.service.ts
+++ b/apps/controller/src/reconcile.service.ts
@@ -501,6 +501,13 @@ export class ReconcileService implements OnModuleInit, OnModuleDestroy {
       const idleSeconds = template?.idle_shutdown_seconds ?? globalIdleShutdownSeconds;
       const idleMs = idleSeconds * 1000;
 
+      // Idle shutdown is driven by real activity (last_activity_at), refreshed
+      // while a session is genuinely in use: agent traffic (execute/credentials)
+      // and — for human-driven VNC/recording sessions — the viewer's panel-state
+      // poll heartbeat and human input. A warm-pool claim stamps last_activity_at
+      // at claim time (see claimWarmSession), so a claimed recording is NOT judged
+      // idle from the spare's older started_at. An abandoned recording (viewer
+      // closed → no more heartbeat) falls idle and is reaped like anything else.
       if (idleMs > 0 && session.owner_user_id) {
         const lastUsed = session.last_activity_at || session.last_credential_request_at || session.started_at;
         const idleTime = now - new Date(lastUsed).getTime();


### PR DESCRIPTION
## Symptom

On the prod harness, generating a recording link consistently failed with:
`{"message":"Cannot open stream for TERMINATED session","error":"Bad Request","statusCode":400}`

## Root cause

The cluster is healthy (a direct provision claims a warm spare, stays HEALTHY, mints a short-link 200). The failure was the controller's **idle reaper** terminating per-user recording sessions mid-login — two underlying gaps:

1. **Warm claims inherited the spare's `started_at`.** The reaper uses `lastUsed = last_activity_at || last_credential_request_at || started_at`; recordings set neither of the first two, so it fell back to `started_at` — and a warm-pool claim reuses the spare's row, whose `started_at` is the (older) *warm* time. A just-claimed recording could look idle immediately.
2. **Human-driven sessions had no activity signal.** Nothing refreshed `last_activity_at` for a VNC/recording session, so even a fresh claim would age out with no way to say "a human is using this."

The reaper is owner-gated, which spared agent/pool sessions (`owner=null`) but reaped every per-user (harness) recording. Confirmed live on prod: an `owner=null` claim survived 66+ min while a freshly-claimed harness session went HEALTHY → TERMINATED within minutes (`last_activity_at=null`). Only fires because `IDLE_SHUTDOWN_SECONDS` is currently >0 in prod.

## Fix (activity-driven — no recording special-case)

1. **`claimWarmSession` stamps `last_activity_at = NOW()`** at claim, so idleness is measured from the claim, not the spare's warm time. (Fixes gap #1 for all warm claims.)
2. **`GET /vnc/:id/panel-state` refreshes `last_activity_at`** (fire-and-forget). The viewer polls it every ~5s while the tab is open, so a session actively being viewed/driven stays alive, and an abandoned one (viewer closed → polling stops) correctly falls idle and is reaped — which also prevents the "recording HEALTHY forever" zombies a blanket exemption would reintroduce.
3. With real activity tracking, the reaper no longer needs to special-case recordings, so the earlier blanket `recording_mode` exemption is dropped.

## Validation

- New/updated unit tests: claim stamps `last_activity_at`; the reaper spares a session with recent `last_activity_at` even when `started_at` is old (activity-driven, not age-driven).
- Build 7/7; api 601, controller 68, worker 125 tests green; lint pass (pre-commit hook).

## Ops note

Immediate mitigation without a deploy: set `IDLE_SHUTDOWN_SECONDS=0` on the prod controller. Also worth understanding why it was enabled — a human-in-the-loop recording is *expected* to sit idle during login, so the threshold (if kept >0) should be human-appropriate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)