### PR TITLE
fix(egress-proxy): log residential upstream config, allowlist sync and tunnel bytes

### DIFF
--- a/charts/browser-hitl/files/egress-proxy/server.js
+++ b/charts/browser-hitl/files/egress-proxy/server.js
@@ -137,21 +137,45 @@ function isInfraOrInternal(hostname) {
   return /(?:\.local|\.internal|\.svc|\.svc\.cluster\.local|\.cluster\.local)$/.test(normalized);
 }
 
+// Sessions already warned about wanting residential egress with no upstream
+// configured, so the warning lands once per session instead of once per request.
+const residentialMisconfigWarned = new Set();
+
 // A session routes residential only when: an upstream is configured, the session
 // is flagged residential, and the target is an external (non-infra) host.
 function shouldRouteResidential(hostname, sessionId) {
-  if (!UPSTREAM_PROXY || !sessionId || !sessionResidential.get(sessionId)) {
+  if (!sessionId || !sessionResidential.get(sessionId)) {
+    return false;
+  }
+  // The session ASKED for residential egress but no upstream exists, so it is
+  // about to egress directly from the cluster instead. Silence here is what
+  // makes a missing/corrupt EGRESS_UPSTREAM_PROXY_URL look like success, so say
+  // so loudly — once per session.
+  if (!UPSTREAM_PROXY) {
+    if (!residentialMisconfigWarned.has(sessionId)) {
+      residentialMisconfigWarned.add(sessionId);
+      log('WARNING residential requested but NO upstream configured — egressing DIRECTLY from the cluster', {
+        session_id: sessionId,
+        fix: 'set EGRESS_UPSTREAM_PROXY_URL on the egress-proxy deployment',
+      });
+    }
     return false;
   }
   return !isInfraOrInternal(hostname);
+}
+
+// Vendor sticky-session id for a Tabby session: same value → same exit IP.
+// Non-alphanumerics are stripped because vendors use '-' as their username
+// parameter delimiter (a raw UUID's hyphens would be parsed as extra params).
+function stickySessionId(sessionId) {
+  return String(sessionId).replace(/[^a-zA-Z0-9]/g, '');
 }
 
 // Build the upstream Proxy-Authorization header for a session, substituting the
 // sanitized sessionId into the vendor's sticky-session placeholder so the same
 // session pins the same exit IP.
 function buildUpstreamAuth(sessionId) {
-  const stickyId = String(sessionId).replace(/[^a-zA-Z0-9]/g, '');
-  const username = UPSTREAM_PROXY.usernameTemplate.replace(/\{sessionId\}/g, stickyId);
+  const username = UPSTREAM_PROXY.usernameTemplate.replace(/\{sessionId\}/g, stickySessionId(sessionId));
   const creds = `${username}:${UPSTREAM_PROXY.password}`;
   return `Basic ${Buffer.from(creds, 'utf8').toString('base64')}`;
 }
@@ -391,9 +415,19 @@ function connectViaUpstream(clientSocket, head, targetHost, targetPort, sessionI
 
   let established = false;
   let responseBuffer = Buffer.alloc(0);
+  // Tunnel byte counters. A residential exit that accepts the CONNECT and then
+  // returns nothing is indistinguishable from success without these.
+  let bytesFromUpstream = 0;
+  let bytesToUpstream = 0;
 
   const fail = (reason) => {
     if (!established && !clientSocket.destroyed) {
+      log('residential CONNECT failed', {
+        session_id: sessionId,
+        target: `${targetHost}:${targetPort}`,
+        upstream: `${UPSTREAM_PROXY.hostname}:${UPSTREAM_PROXY.port}`,
+        reason,
+      });
       const body = JSON.stringify({ error: 'upstream_proxy_error', reason });
       clientSocket.write(
         'HTTP/1.1 502 Bad Gateway\r\n' +
@@ -403,6 +437,16 @@ function connectViaUpstream(clientSocket, head, targetHost, targetPort, sessionI
           '\r\n' +
           body,
       );
+    } else if (established) {
+      // Post-establish errors used to destroy both sockets in silence, so the
+      // browser saw ERR_CONNECTION_CLOSED while the logs still claimed success.
+      log('residential tunnel aborted after establish', {
+        session_id: sessionId,
+        target: `${targetHost}:${targetPort}`,
+        reason,
+        bytes_from_upstream: bytesFromUpstream,
+        bytes_to_upstream: bytesToUpstream,
+      });
     }
     upstreamSocket.destroy();
     clientSocket.destroy();
@@ -436,9 +480,43 @@ function connectViaUpstream(clientSocket, head, targetHost, targetPort, sessionI
     if (leftover.length > 0) {
       clientSocket.write(leftover);
     }
+    bytesFromUpstream += leftover.length;
+    bytesToUpstream += head && head.length > 0 ? head.length : 0;
+    // Counted alongside pipe() rather than instead of it, so the tunnel stays a
+    // blind byte relay and the browser's TLS fingerprint is untouched.
+    upstreamSocket.on('data', (chunk) => {
+      bytesFromUpstream += chunk.length;
+    });
+    clientSocket.on('data', (chunk) => {
+      bytesToUpstream += chunk.length;
+    });
+    upstreamSocket.once('close', () => {
+      // The vendor said 200 and then sent nothing back: a dead/over-quota exit
+      // node. Surfaces as ERR_CONNECTION_CLOSED in the browser, so name it here.
+      if (bytesFromUpstream === 0) {
+        log('WARNING residential exit returned ZERO bytes — exit node likely dead, request FAILED', {
+          session_id: sessionId,
+          target: `${targetHost}:${targetPort}`,
+          sticky_session: stickySessionId(sessionId),
+          bytes_to_upstream: bytesToUpstream,
+        });
+        return;
+      }
+      log('residential tunnel closed', {
+        session_id: sessionId,
+        target: `${targetHost}:${targetPort}`,
+        bytes_from_upstream: bytesFromUpstream,
+        bytes_to_upstream: bytesToUpstream,
+      });
+    });
     upstreamSocket.pipe(clientSocket);
     clientSocket.pipe(upstreamSocket);
-    log('residential CONNECT established', { session_id: sessionId, target: `${targetHost}:${targetPort}` });
+    log('residential CONNECT established', {
+      session_id: sessionId,
+      target: `${targetHost}:${targetPort}`,
+      upstream: `${UPSTREAM_PROXY.hostname}:${UPSTREAM_PROXY.port}`,
+      sticky_session: stickySessionId(sessionId),
+    });
   };
 
   upstreamSocket.on('connect', () => {
@@ -613,6 +691,16 @@ async function handleAdmin(req, res) {
 
       sessionAllowlist.set(sessionId, domains);
       sessionResidential.set(sessionId, residential);
+      // Proves what the controller actually asked for. No line at all for a
+      // session means the controller never synced it; `residential_effective`
+      // is the one to read — it is only true when the flag AND an upstream exist.
+      log('session allowlist synced', {
+        session_id: sessionId,
+        residential,
+        residential_effective: residential && Boolean(UPSTREAM_PROXY),
+        domains: domains.size,
+        allow_all: allowAll,
+      });
       writeJson(res, 200, {
         updated: true,
         session_id: sessionId,
@@ -672,6 +760,36 @@ const adminServer = http.createServer((req, res) => {
   void handleAdmin(req, res);
 });
 
+// Announce the residential upstream at boot, credential-free, so a missing or
+// corrupt EGRESS_UPSTREAM_PROXY_URL is obvious in the first lines of pod logs
+// instead of silently degrading every residential session to direct egress.
+// Only shape is logged (host, port, placeholder/country presence) — never the
+// username or password.
+function logResidentialConfig() {
+  const raw = (process.env.EGRESS_UPSTREAM_PROXY_URL || '').trim();
+  if (!UPSTREAM_PROXY) {
+    log('residential egress DISABLED', {
+      reason: raw
+        ? 'EGRESS_UPSTREAM_PROXY_URL is set but could not be parsed as a URL'
+        : 'EGRESS_UPSTREAM_PROXY_URL is empty or unset',
+      raw_length: raw.length,
+      // A wrapped YAML '>-' folded scalar joins lines with a space, which
+      // corrupts the URL — worth calling out explicitly.
+      contains_whitespace: /\s/.test(raw),
+      effect: 'sessions flagged residential WILL egress directly from the cluster',
+    });
+    return;
+  }
+  const template = UPSTREAM_PROXY.usernameTemplate || '';
+  const countryMatch = /-cc-([a-zA-Z]{2})/.exec(template);
+  log('residential egress ENABLED', {
+    upstream: `${UPSTREAM_PROXY.hostname}:${UPSTREAM_PROXY.port}`,
+    sticky_session_placeholder: template.includes('{sessionId}'),
+    country_pin: countryMatch ? countryMatch[1].toUpperCase() : null,
+    connect_timeout_ms: UPSTREAM_CONNECT_TIMEOUT_MS,
+  });
+}
+
 // Only start listening (and enforce the fail-closed startup guards) when run as
 // a script. When required as a module (tests), export the internals instead so
 // the routing decisions and the nested-CONNECT tunnel can be exercised directly.
@@ -689,6 +807,8 @@ if (require.main === module) {
     );
     process.exit(1);
   }
+
+  logResidentialConfig();
 
   proxyServer.listen(PROXY_PORT, '0.0.0.0', () => {
     log(`Proxy listening on 0.0.0.0:${PROXY_PORT}`);


### PR DESCRIPTION
## What changed

Observability only — **no behaviour change**. One file: `charts/browser-hitl/files/egress-proxy/server.js` (+124/−4).

## Why

Residential egress could fail in three ways that produced **no log line at all**, so a session silently egressing direct from the cluster was indistinguishable from one genuinely exiting through Oxylabs.

Measured on the clusters, A/B through the existing warm pools with `start_url` pointed at an IP echo:

| cluster | residential ON | residential OFF | owner |
|---|---|---|---|
| local Kind | `50.37.178.142` | host IP | AS20055 Wholesail (residential ISP) ✅ |
| dev | `48.223.242.66` | `48.223.242.66` | AS8075 Microsoft (Azure) ❌ |
| prod | `52.5.11.46` | `52.5.11.46` | AS14618 Amazon (EC2) ❌ |

Identical IPs on dev/prod, so the Oxylabs hop never happens — yet the API still reported `residential_proxy_enabled: true`, the residential warm pool claimed correctly, and nothing logged an error. Diagnosing it required instrumenting the proxy by hand.

## What it adds

- **Boot summary** — upstream host/port, sticky-session placeholder, country pin. When disabled, whether the env var was *empty* vs *unparseable*, with `raw_length` and `contains_whitespace` — the latter identifies a wrapped YAML `>-` folded scalar corrupting the URL (a space in the host position makes `new URL()` throw). Credentials are never logged, only shape.
- **`session allowlist synced`** on every controller push, with `residential_effective` = flag AND upstream configured. No line for a session means the controller never synced it.
- **Once-per-session warning** when a session requests residential egress but no upstream is configured.
- **Tunnel byte counters**, so a success log proves bytes actually moved, plus an explicit warning when the vendor accepts the CONNECT then returns **zero bytes** (dead/over-quota exit node — surfaces as `ERR_CONNECTION_CLOSED` in the browser).
- **Logging for pre-establish CONNECT failures and post-establish teardown**, which previously destroyed both sockets in silence.

Counters attach alongside `pipe()` rather than replacing it, so the tunnel stays a blind byte relay and the browser's TLS fingerprint is untouched.

## Validation

Every path exercised against a live local Kind cluster (ConfigMap patched + pod restarted), not just unit-tested.

Working upstream:
```
[egress-proxy] residential egress ENABLED { upstream: 'pr.oxylabs.io:7777',
  sticky_session_placeholder: true, country_pin: 'US', connect_timeout_ms: 15000 }
[egress-proxy] session allowlist synced { session_id: '...', residential: true,
  residential_effective: true, domains: 1, allow_all: false }
[egress-proxy] residential CONNECT established { ..., sticky_session: 'logtest111122223333' }
[egress-proxy] residential tunnel closed { ..., bytes_from_upstream: 3706, bytes_to_upstream: 531 }
```

Empty env var (the dev/prod hypothesis):
```
residential egress DISABLED { reason: 'EGRESS_UPSTREAM_PROXY_URL is empty or unset',
  raw_length: 0, contains_whitespace: false,
  effect: 'sessions flagged residential WILL egress directly from the cluster' }
```

Value corrupted by a wrapped YAML `>-` fold:
```
residential egress DISABLED { reason: '...set but could not be parsed as a URL',
  raw_length: 67, contains_whitespace: true, ... }
```

Residential requested with no upstream (drove a real CONNECT):
```
WARNING residential requested but NO upstream configured — egressing DIRECTLY from the cluster
  { session_id: 'warn-no-upstream', fix: 'set EGRESS_UPSTREAM_PROXY_URL ...' }
```

Dead exit node (fake upstream: 200 OK then silence):
```
WARNING residential exit returned ZERO bytes — exit node likely dead, request FAILED
  { session_id: 'warn-dead-exit', sticky_session: 'warndeadexit', bytes_to_upstream: 0 }
```

Also: existing `server.test.js` 10/10 pass, `helm lint` clean, `helm template` renders with all six markers embedded, pre-commit build green across 7 projects.

## Risk

Low. Logging only — no routing, auth or tunnel semantics touched. Worst case is log volume: `session allowlist synced` fires once per controller sync per session, and the misconfig warning is deduped per session.

## Follow-ups (deliberately not in this PR)

1. **Set `EGRESS_UPSTREAM_PROXY_URL` on dev and prod.** This PR makes the problem visible; it does not fix it. Note both `dev` and `main` already contain the residential code, so the gap is config, not deployment.
2. **Fail closed** — reject a session requesting `residential_proxy: true` when no upstream is configured, instead of silently egressing from the datacenter. For US bank logins, quietly using the wrong IP is worse than failing.
3. **Retry on zero bytes** — buffer the client's first bytes and retry once on a fresh sticky session. The new warning shows when this would have helped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)