### PR TITLE
fix(chart): roll egress-proxy when its ConfigMap changes

### DIFF
--- a/charts/browser-hitl/templates/egress-proxy-deployment.yaml
+++ b/charts/browser-hitl/templates/egress-proxy-deployment.yaml
@@ -17,6 +17,18 @@ spec:
       app.kubernetes.io/component: egress-proxy
   template:
     metadata:
+      annotations:
+        # server.js is the egress proxy's ENTIRE implementation and ships in a
+        # ConfigMap, not in an image — .Values.egressProxy.image is stock
+        # node:alpine and never changes between releases. Without this checksum
+        # the pod template is byte-identical on every deploy, so the Deployment
+        # never rolls; and because server.js is mounted with subPath (below),
+        # Kubernetes never propagates ConfigMap updates into the running
+        # container either. Net effect: code changes to server.js silently never
+        # reach dev/prod until someone manually restarts the pod. This checksum
+        # makes the pod template change whenever server.js does, so a deploy
+        # actually recycles the pod.
+        checksum/config: {{ include (print $.Template.BasePath "/egress-proxy-configmap.yaml") . | sha256sum }}
       labels:
         {{- include "browser-hitl.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: egress-proxy


### PR DESCRIPTION
## The bug

Changes to `charts/browser-hitl/files/egress-proxy/server.js` **have never reached dev or prod** unless someone manually restarted the pod. The residential egress support added in 1.19.x was not actually running on either cluster — which is the real root cause of the residential-proxy investigation, not a misconfigured secret.

The egress proxy is the only component whose *entire implementation* ships in a ConfigMap rather than an image, and three things combine so that a deploy never picks it up:

1. **Its image never changes.** `infra/tfy/deploy.yaml` gives `tag: "${IMAGE_TAG}"` to the 7 built images, but the `egressProxy` block has no image override — it stays on the stock `node:20.18.1-alpine` from chart values. The pod template is therefore byte-identical on every release, so Helm/ArgoCD sees no diff and the Deployment never rolls.
2. **No `checksum/config` annotation** existed anywhere in the chart.
3. **`subPath: server.js`** — Kubernetes never propagates ConfigMap updates into a `subPath` mount, so a running container's `/app/server.js` is frozen at pod creation.

Net effect: the ConfigMap updated correctly on every deploy while the running proxy kept its original code indefinitely. Chart version bumping was never the problem — a new chart version simply rendered an identical egress-proxy pod template.

## The fix

Add the ConfigMap checksum to the pod template so a deploy recycles the pod exactly when `server.js` changes.

## Validation

Rendered the chart repeatedly and compared the egress-proxy Deployment's `checksum/config`:

| render | checksum |
|---|---|
| baseline | `9881cc0c17557e63` |
| re-render, no edit | `9881cc0c17557e63` — stable, so no spurious rollouts |
| after touching `server.js` | `2f0a4d2128305f9a` — **changes, so the deploy rolls the pod** |
| `server.js` restored | `9881cc0c17557e63` |

`helm lint` clean. `server.js` is byte-identical to `dev` in this branch — the diff is the template only. Pre-commit build green across 7 projects.

## Risk

Low, but note the intended behaviour change: from now on a deploy that alters `server.js` **will** restart the egress proxy. That is the point, and it is worth knowing because the session allowlist is held in memory — a restart drops it and in-flight sessions get 403 until the controller re-syncs (~15s, automatic and self-healing; observed locally). Deploys that don't touch `server.js` leave the pod alone, as verified above.

The other static-tag components (redis, postgres, nats, minio) are stock third-party images carrying no repo code, so they are unaffected and deliberately left as-is.

## Follow-ups (not in this PR)

1. **`allowInsecureSessionAllowlist: true` on dev *and* prod** (`infra/tfy/deploy.yaml:232`). With it on, a CONNECT whose HMAC does not resolve proceeds with `sessionId = null` instead of returning 407 — which silently disables both per-session egress allowlisting and residential routing. It also disarms the `!SESSION_KEY` startup guard. Deserves its own review, including whether `EGRESS_PROXY_SESSION_KEY` is actually populated on both clusters.
2. **Log the residential decision boundary** — an unresolved session identity currently produces no log line at all, which is why diagnosing this took several rounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)