### PR TITLE
fix(chart): roll egress-proxy when its ConfigMap changes

### DIFF
--- a/charts/browser-hitl/Chart.yaml
+++ b/charts/browser-hitl/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: browser-hitl
 description: Browser Human-in-the-Loop MVP - Kubernetes-native service stack
 type: application
-version: 1.19.7
-appVersion: "1.19.7"
+version: 1.19.8
+appVersion: "1.19.8"
 keywords:
   - browser
   - hitl

--- a/charts/browser-hitl/templates/egress-proxy-deployment.yaml
+++ b/charts/browser-hitl/templates/egress-proxy-deployment.yaml
@@ -17,6 +17,18 @@ spec:
       app.kubernetes.io/component: egress-proxy
   template:
     metadata:
+      annotations:
+        # server.js is the egress proxy's ENTIRE implementation and ships in a
+        # ConfigMap, not in an image — .Values.egressProxy.image is stock
+        # node:alpine and never changes between releases. Without this checksum
+        # the pod template is byte-identical on every deploy, so the Deployment
+        # never rolls; and because server.js is mounted with subPath (below),
+        # Kubernetes never propagates ConfigMap updates into the running
+        # container either. Net effect: code changes to server.js silently never
+        # reach dev/prod until someone manually restarts the pod. This checksum
+        # makes the pod template change whenever server.js does, so a deploy
+        # actually recycles the pod.
+        checksum/config: {{ include (print $.Template.BasePath "/egress-proxy-configmap.yaml") . | sha256sum }}
       labels:
         {{- include "browser-hitl.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: egress-proxy


### PR DESCRIPTION
## Summary

Promotes fix from dev → main. 1 file changed.

Adds checksum/config annotation to the egress-proxy deployment so it actually restarts when server.js changes. Previously, code changes to the egress proxy silently never reached running clusters because the image tag never changes and subPath ConfigMap mounts don't hot-reload.

## Test plan

- [x] helm lint clean
- [x] Checksum stable when server.js unchanged, changes when edited
- [x] CI green on dev
- [ ] deploy-production triggers on merge
- [ ] ⚠️ **MERGE WITH MERGE COMMIT**