### PR TITLE
fix(egress): require session identity so residential egress applies

### DIFF
--- a/charts/browser-hitl/files/egress-proxy/server.js
+++ b/charts/browser-hitl/files/egress-proxy/server.js
@@ -141,6 +141,28 @@ function isInfraOrInternal(hostname) {
 // configured, so the warning lands once per session instead of once per request.
 const residentialMisconfigWarned = new Set();
 
+// Unidentified CONNECTs are counted rather than logged individually: with
+// insecure mode on, EVERY browser request lands here, so per-request logging
+// would bury the signal. First occurrence plus every 100th keeps it visible
+// without flooding.
+let unidentifiedConnectCount = 0;
+const UNIDENTIFIED_LOG_INTERVAL = 100;
+
+function logUnidentifiedConnect(hostname, port) {
+  unidentifiedConnectCount += 1;
+  if (unidentifiedConnectCount !== 1 && unidentifiedConnectCount % UNIDENTIFIED_LOG_INTERVAL !== 0) {
+    return;
+  }
+  log('WARNING CONNECT has NO resolved session identity — per-session allowlist AND residential egress are both bypassed', {
+    target: `${hostname}:${port}`,
+    occurrences: unidentifiedConnectCount,
+    cause: SESSION_KEY
+      ? 'no valid Proxy-Authorization on the request; note that clients only send it in response to a 407, which EGRESS_PROXY_ALLOW_INSECURE_SESSION_ALLOWLIST=true suppresses'
+      : 'EGRESS_PROXY_SESSION_KEY is not set, so no request can ever be identified',
+    fix: 'set EGRESS_PROXY_ALLOW_INSECURE_SESSION_ALLOWLIST=false so the proxy challenges clients with 407',
+  });
+}
+
 // A session routes residential only when: an upstream is configured, the session
 // is flagged residential, and the target is an external (non-infra) host.
 function shouldRouteResidential(hostname, sessionId) {
@@ -578,6 +600,15 @@ function proxyConnect(req, clientSocket, head) {
     return;
   }
 
+  // An unidentified CONNECT that is nonetheless allowed through (insecure mode)
+  // silently loses BOTH the per-session allowlist and residential egress, since
+  // every session-scoped lookup below is keyed on sessionId. Browsers only send
+  // Proxy-Authorization in response to a 407, and insecure mode never issues
+  // one — so this is the normal case whenever the flag is on, not an edge case.
+  if (!sessionId) {
+    logUnidentifiedConnect(hostname, port);
+  }
+
   if (!isHostAllowed(hostname, sessionId)) {
     denyConnect(clientSocket, hostname);
     return;
@@ -809,6 +840,18 @@ if (require.main === module) {
   }
 
   logResidentialConfig();
+
+  // Insecure session mode is not merely "less strict": because it suppresses the
+  // 407 challenge, clients never send Proxy-Authorization, so no request can be
+  // attributed to a session. Per-session allowlists and residential egress both
+  // silently stop applying while still looking correctly configured everywhere
+  // else. Say so at boot.
+  if (ALLOW_INSECURE_SESSION_ALLOWLIST) {
+    log('WARNING EGRESS_PROXY_ALLOW_INSECURE_SESSION_ALLOWLIST=true — no 407 challenge is issued', {
+      effect: 'requests cannot be attributed to a session: per-session allowlists fall back to the default allowlist and residential egress NEVER applies',
+      recommendation: 'set it to false (EGRESS_PROXY_SESSION_KEY is ' + (SESSION_KEY ? 'present, so clients will authenticate)' : 'MISSING — set it first, or the proxy will refuse to start)'),
+    });
+  }
 
   proxyServer.listen(PROXY_PORT, '0.0.0.0', () => {
     log(`Proxy listening on 0.0.0.0:${PROXY_PORT}`);

--- a/infra/tfy/deploy.yaml
+++ b/infra/tfy/deploy.yaml
@@ -229,7 +229,13 @@ values:
   egressProxy:
     enabled: true
     allowInsecureAdmin: true
-    allowInsecureSessionAllowlist: true
+    # MUST stay false. When true the proxy never issues a 407, and browsers only
+    # send Proxy-Authorization in response to one — so no request can be attributed
+    # to a session. Per-session allowlists silently fall back to defaultAllowlist
+    # and residential egress never applies, while every other signal (session flag,
+    # controller sync, upstream config) still looks correct. Requires
+    # EGRESS_PROXY_SESSION_KEY to be set, or the proxy refuses to start.
+    allowInsecureSessionAllowlist: false
     resources:
       requests:
         cpu: "${EGRESS_CPU_REQUEST}"


### PR DESCRIPTION
## Root cause

`infra/tfy/deploy.yaml` set `allowInsecureSessionAllowlist: true` on dev and prod. That flag does far more than relax a check — **it suppresses the 407 challenge**, and browsers only send `Proxy-Authorization` in response to a 407.

```js
const sessionId = resolveSessionId(req);
if (!sessionId && !ALLOW_INSECURE_SESSION_ALLOWLIST) {
  requireProxyAuth(clientSocket);   // the 407, never sent
  return;
}
```

Chromium is launched with `--proxy-server=http://...-egress-proxy:3128` and no embedded credentials (confirmed in `/proc/*/cmdline` on a dev worker); Playwright supplies the HMAC only when challenged. No challenge means no credentials, so `resolveSessionId()` returns `null` for every request and every session-scoped lookup silently stops applying:

- per-session allowlists fall back to `defaultAllowlist`
- **residential egress never applies**, because `shouldRouteResidential()` short-circuits on the null `sessionId`

What made this hard to see is that *everything else looks correct* while it happens: the session carries `residential_proxy_enabled: true`, the controller pushes `residential: true`, the proxy reports `residential_effective: true` and a valid upstream, and the browser still egresses from the cluster's own NAT address.

## Evidence from dev

Same worker, same session, same proxy URL. The only difference is the `Proxy-Authorization` header:

| CONNECT | result | exit IP | residential logged |
|---|---|---|---|
| **without** auth (what Chromium sends first) | `200 Connection Established` | `48.223.242.66` (Azure, the cluster NAT) | none |
| **with** auth | `200` | `73.226.133.50` (**AS7922 Comcast Cable**, a real residential ISP) | `residential CONNECT established` + `tunnel closed` |

So Oxylabs, the upstream secret, the sticky session, the controller push and the allowlist sync were all correct on dev the whole time. Only the request identity was missing.

This also explains why it worked locally: `values-local.yaml` leaves the flag at its default `false`, so the proxy does challenge and the browser does authenticate.

## Validation

Ran the proxy both ways with an unauthenticated CONNECT:

| config | unauthenticated CONNECT | warnings |
|---|---|---|
| `insecure=true` (today's dev) | `200 Connection Established` (bug reproduced) | both fire, with exact cause |
| `insecure=false` (this PR) | **`407 Proxy Authentication Required`** | correctly absent |

`server.test.js` 10/10 pass, `helm lint` clean, pre-commit build green across 7 projects.

## Safety

The startup guard `if (!SESSION_KEY && !ALLOW_INSECURE_SESSION_ALLOWLIST) exit(1)` means a missing session key would make the proxy **refuse to start**, so I verified the live state before changing this:

| deployment | `EGRESS_PROXY_SESSION_KEY` | `ALLOW_INSECURE_SESSION_ALLOWLIST` |
|---|---|---|
| dev | present (65 bytes) | `true` (the bug) |
| `adopt-tabby-prod` | present (51 bytes) | unset, already effectively false |
| `adopt-tabbyv3` | present (65 bytes) | unset, already effectively false |

The key is present everywhere, and the currently deployed prod proxies already run effectively fail-closed and authenticate normally. This aligns dev with prod rather than introducing new behaviour.

**Expected behaviour change:** any client relying on unauthenticated egress will begin receiving 407s. Workers authenticate automatically via Playwright. `allowInsecureAdmin` is deliberately left unchanged.

## Observability added

A declined residential decision previously produced no log line at all, which is why this took several rounds to find:

- a **startup warning** when insecure session mode is on, naming the consequence rather than just the setting
- a **counted warning** (1st occurrence, then every 100th) when a CONNECT has no resolvable session identity, distinguishing "no `Proxy-Authorization` sent" from "`EGRESS_PROXY_SESSION_KEY` missing"

## Related / follow-ups

- #141 - the egress-proxy pod is never recycled on deploy, so `server.js` changes never reach a cluster without a manual restart. Independent bug, same silent-degradation signature.
- **Prod has no `EGRESS_UPSTREAM_PROXY_URL` at all** (0 bytes on both `adopt-tabby-prod` and `adopt-tabbyv3`). Residential cannot work on prod until that secret is set, independently of this PR.
- `allowInsecureAdmin: true` remains on dev/prod and deserves its own review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
