### PR TITLE
fix(egress): require session identity so residential egress applies

### DIFF
--- a/charts/browser-hitl/Chart.yaml
+++ b/charts/browser-hitl/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: browser-hitl
 description: Browser Human-in-the-Loop MVP - Kubernetes-native service stack
 type: application
-version: 1.19.8
-appVersion: "1.19.8"
+version: 1.19.9
+appVersion: "1.19.9"
 keywords:
   - browser
   - hitl

--- a/charts/browser-hitl/files/egress-proxy/server.js
+++ b/charts/browser-hitl/files/egress-proxy/server.js
@@ -141,6 +141,28 @@ function isInfraOrInternal(hostname) {
 // configured, so the warning lands once per session instead of once per request.
 const residentialMisconfigWarned = new Set();
 
+// Unidentified CONNECTs are counted rather than logged individually: with
+// insecure mode on, EVERY browser request lands here, so per-request logging
+// would bury the signal. First occurrence plus every 100th keeps it visible
+// without flooding.
+let unidentifiedConnectCount = 0;
+const UNIDENTIFIED_LOG_INTERVAL = 100;
+
+function logUnidentifiedConnect(hostname, port) {
+  unidentifiedConnectCount += 1;
+  if (unidentifiedConnectCount !== 1 && unidentifiedConnectCount % UNIDENTIFIED_LOG_INTERVAL !== 0) {
+    return;
+  }
+  log('WARNING CONNECT has NO resolved session identity — per-session allowlist AND residential egress are both bypassed', {
+    target: `${hostname}:${port}`,
+    occurrences: unidentifiedConnectCount,
+    cause: SESSION_KEY
+      ? 'no valid Proxy-Authorization on the request; note that clients only send it in response to a 407, which EGRESS_PROXY_ALLOW_INSECURE_SESSION_ALLOWLIST=true suppresses'
+      : 'EGRESS_PROXY_SESSION_KEY is not set, so no request can ever be identified',
+    fix: 'set EGRESS_PROXY_ALLOW_INSECURE_SESSION_ALLOWLIST=false so the proxy challenges clients with 407',
+  });
+}
+
 // A session routes residential only when: an upstream is configured, the session
 // is flagged residential, and the target is an external (non-infra) host.
 function shouldRouteResidential(hostname, sessionId) {
@@ -578,6 +600,15 @@ function proxyConnect(req, clientSocket, head) {
     return;
   }
 
+  // An unidentified CONNECT that is nonetheless allowed through (insecure mode)
+  // silently loses BOTH the per-session allowlist and residential egress, since
+  // every session-scoped lookup below is keyed on sessionId. Browsers only send
+  // Proxy-Authorization in response to a 407, and insecure mode never issues
+  // one — so this is the normal case whenever the flag is on, not an edge case.
+  if (!sessionId) {
+    logUnidentifiedConnect(hostname, port);
+  }
+
   if (!isHostAllowed(hostname, sessionId)) {
     denyConnect(clientSocket, hostname);
     return;
@@ -809,6 +840,18 @@ if (require.main === module) {
   }
 
   logResidentialConfig();
+
+  // Insecure session mode is not merely "less strict": because it suppresses the
+  // 407 challenge, clients never send Proxy-Authorization, so no request can be
+  // attributed to a session. Per-session allowlists and residential egress both
+  // silently stop applying while still looking correctly configured everywhere
+  // else. Say so at boot.
+  if (ALLOW_INSECURE_SESSION_ALLOWLIST) {
+    log('WARNING EGRESS_PROXY_ALLOW_INSECURE_SESSION_ALLOWLIST=true — no 407 challenge is issued', {
+      effect: 'requests cannot be attributed to a session: per-session allowlists fall back to the default allowlist and residential egress NEVER applies',
+      recommendation: 'set it to false (EGRESS_PROXY_SESSION_KEY is ' + (SESSION_KEY ? 'present, so clients will authenticate)' : 'MISSING — set it first, or the proxy will refuse to start)'),
+    });
+  }
 
   proxyServer.listen(PROXY_PORT, '0.0.0.0', () => {
     log(`Proxy listening on 0.0.0.0:${PROXY_PORT}`);

--- a/infra/tfy/deploy.yaml
+++ b/infra/tfy/deploy.yaml
@@ -229,7 +229,13 @@ values:
   egressProxy:
     enabled: true
     allowInsecureAdmin: true
-    allowInsecureSessionAllowlist: true
+    # MUST stay false. When true the proxy never issues a 407, and browsers only
+    # send Proxy-Authorization in response to one — so no request can be attributed
+    # to a session. Per-session allowlists silently fall back to defaultAllowlist
+    # and residential egress never applies, while every other signal (session flag,
+    # controller sync, upstream config) still looks correct. Requires
+    # EGRESS_PROXY_SESSION_KEY to be set, or the proxy refuses to start.
+    allowInsecureSessionAllowlist: false
     resources:
       requests:
         cpu: "${EGRESS_CPU_REQUEST}"


### PR DESCRIPTION
## Summary

Promotes fix from dev → main. 2 files changed.

Root cause of residential proxy not working on dev/prod: `allowInsecureSessionAllowlist: true` suppressed the 407 challenge, so browsers never sent Proxy-Authorization, and every session-scoped lookup (allowlist + residential routing) silently failed. Sets it to `false` and adds boot + per-request warnings.

## Test plan

- [x] 10/10 server.test.js pass
- [x] CI green on dev
- [x] Verified EGRESS_PROXY_SESSION_KEY present on dev + prod
- [ ] deploy-production triggers on merge
- [ ] ⚠️ **MERGE WITH MERGE COMMIT**