### PR TITLE
release: sync dev to main

### DIFF
--- a/apps/controller/src/pod-manager.service.spec.ts
+++ b/apps/controller/src/pod-manager.service.spec.ts
@@ -68,6 +68,35 @@ describe('PodManagerService egress allowlist sync', () => {
     });
   });
 
+  it('includes pod_ip so the proxy can identify requests that carry no Proxy-Authorization', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({ ok: true, status: 200 });
+    global.fetch = fetchMock as any;
+
+    process.env.EGRESS_PROXY_ALLOWLIST_URL = 'http://egress-proxy:8095/allowlist';
+
+    const service = new PodManagerService();
+    jest.spyOn(service, 'getPodIp').mockResolvedValue('10.244.0.7');
+    await service.syncEgressAllowlist('session-1', ['https://example.com/login']);
+
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as any).body);
+    expect(body.pod_ip).toBe('10.244.0.7');
+  });
+
+  it('omits pod_ip while the pod is unscheduled, so the sync still succeeds', async () => {
+    const fetchMock = jest.fn().mockResolvedValue({ ok: true, status: 200 });
+    global.fetch = fetchMock as any;
+
+    process.env.EGRESS_PROXY_ALLOWLIST_URL = 'http://egress-proxy:8095/allowlist';
+
+    const service = new PodManagerService();
+    jest.spyOn(service, 'getPodIp').mockResolvedValue(null);
+    await service.syncEgressAllowlist('session-1', ['https://example.com/login']);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = JSON.parse((fetchMock.mock.calls[0][1] as any).body);
+    expect('pod_ip' in body).toBe(false);
+  });
+
   it('defaults extra_allowlist to [] and allow_all to false', async () => {
     const fetchMock = jest.fn().mockResolvedValue({ ok: true, status: 200 });
     global.fetch = fetchMock as any;

--- a/apps/controller/src/pod-manager.service.ts
+++ b/apps/controller/src/pod-manager.service.ts
@@ -256,6 +256,12 @@ export class PodManagerService {
       return;
     }
 
+    // The worker's pod IP lets the proxy attribute requests that carry no
+    // Proxy-Authorization — browsers only send that in response to a 407, and
+    // only Playwright-managed requests get the challenge answered. Best-effort:
+    // a just-created pod has no IP yet, and the next reconcile pass fills it in.
+    const podIp = await this.getPodIp(this.buildPodName(sessionId));
+
     const response = await fetch(allowlistEndpoint, {
       method: 'PUT',
       headers: this.buildAllowlistHeaders(),
@@ -265,6 +271,7 @@ export class PodManagerService {
         extra_allowlist: extraAllowlist,
         allow_all: allowAll,
         residential,
+        ...(podIp ? { pod_ip: podIp } : {}),
       }),
     });
 
@@ -304,6 +311,34 @@ export class PodManagerService {
       }
     } catch (error) {
       this.logger.warn(`Failed to clear egress allowlist for session ${sessionId}: ${error}`);
+    }
+  }
+
+  /**
+   * Current pod IP, or null when the pod is missing or not yet scheduled.
+   *
+   * Never throws: this only enriches the egress allowlist sync, so a transient
+   * API error must not fail the sync (which is fail-closed for the caller).
+   */
+  async getPodIp(podName: string): Promise<string | null> {
+    const api: any = this.coreApi as any;
+    if (!api || typeof api.readNamespacedPod !== 'function') {
+      return null; // no API client (unit tests) — nothing to enrich with
+    }
+    try {
+      let result: any;
+      try {
+        result = await api.readNamespacedPod(podName, this.namespace);
+      } catch {
+        result = await api.readNamespacedPod({ name: podName, namespace: this.namespace });
+      }
+      const podIp = result?.body?.status?.podIP ?? result?.status?.podIP ?? null;
+      return typeof podIp === 'string' && podIp.length > 0 ? podIp : null;
+    } catch (error: any) {
+      if (!this.isNotFoundError(error)) {
+        this.logger.warn(`Could not read pod IP for ${podName}: ${error}`);
+      }
+      return null;
     }
   }
 

--- a/charts/browser-hitl/Chart.yaml
+++ b/charts/browser-hitl/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: browser-hitl
 description: Browser Human-in-the-Loop MVP - Kubernetes-native service stack
 type: application
-version: 1.19.9
-appVersion: "1.19.9"
+version: 1.19.10
+appVersion: "1.19.10"
 keywords:
   - browser
   - hitl

--- a/charts/browser-hitl/files/egress-proxy/server.js
+++ b/charts/browser-hitl/files/egress-proxy/server.js
@@ -42,6 +42,36 @@ const sessionAllowlist = new Map();
 // the residential upstream proxy. Populated alongside the allowlist by the
 // controller's PUT /allowlist. In-memory (same volatility as sessionAllowlist).
 const sessionResidential = new Map();
+// podIp → sessionId, pushed by the controller alongside the allowlist. Lets a
+// request be attributed to a session even when it carries no
+// Proxy-Authorization, which is the normal case for browser-process traffic.
+// Kept 1:1 in both directions: pod IPs are recycled by the CNI, so a stale
+// mapping would misattribute a later pod's egress to a dead session.
+const sessionByPodIp = new Map();
+
+// Point podIp at sessionId, dropping any previous binding on either side so the
+// map can never hold two claims on one IP or one session.
+function bindPodIp(podIp, sessionId) {
+  const ip = normalizeIp(podIp);
+  if (!ip) {
+    return false;
+  }
+  for (const [knownIp, knownSession] of sessionByPodIp.entries()) {
+    if (knownSession === sessionId && knownIp !== ip) {
+      sessionByPodIp.delete(knownIp);
+    }
+  }
+  sessionByPodIp.set(ip, sessionId);
+  return true;
+}
+
+function unbindSession(sessionId) {
+  for (const [knownIp, knownSession] of sessionByPodIp.entries()) {
+    if (knownSession === sessionId) {
+      sessionByPodIp.delete(knownIp);
+    }
+  }
+}
 
 function log(message, extra) {
   if (typeof extra === 'undefined') {
@@ -215,7 +245,48 @@ function safeEqual(left, right) {
   return crypto.timingSafeEqual(leftBuffer, rightBuffer);
 }
 
+// Strip the IPv4-mapped IPv6 prefix Node reports on dual-stack sockets
+// (`::ffff:10.244.0.7`) so pod IPs compare equal to what Kubernetes reports.
+function normalizeIp(address) {
+  const raw = (address || '').toString().trim().toLowerCase();
+  if (!raw) {
+    return '';
+  }
+  return raw.startsWith('::ffff:') ? raw.slice('::ffff:'.length) : raw;
+}
+
+// Identify the session from the connecting worker pod's source IP.
+//
+// Proxy-Authorization alone is not sufficient in practice: the browser only
+// sends it in response to a 407, and only requests Playwright manages get that
+// answered. Anything else (Chromium's own browser-process traffic, a page
+// Playwright did not create) is challenged with no handler, and Chromium falls
+// back to prompting the human with a modal proxy login — which blocks the whole
+// session. Source IP is available on every connection, so it covers the requests
+// the header cannot.
+//
+// Trustworthy here because pod IPs are assigned by the CNI, and the deny-all
+// NetworkPolicy forces worker egress through this proxy: a workload cannot
+// present another pod's source address without cluster-level privileges.
+function resolveSessionIdByPodIp(req) {
+  const ip = normalizeIp(req.socket && req.socket.remoteAddress);
+  if (!ip) {
+    return null;
+  }
+  return sessionByPodIp.get(ip) || null;
+}
+
 function resolveSessionId(req) {
+  // Proxy-Authorization stays authoritative: it is per-session and unforgeable,
+  // so an explicitly authenticated request always wins over the IP mapping.
+  const fromHeader = resolveSessionIdFromAuth(req);
+  if (fromHeader) {
+    return fromHeader;
+  }
+  return resolveSessionIdByPodIp(req);
+}
+
+function resolveSessionIdFromAuth(req) {
   if (!SESSION_KEY) {
     return null;
   }
@@ -722,6 +793,10 @@ async function handleAdmin(req, res) {
 
       sessionAllowlist.set(sessionId, domains);
       sessionResidential.set(sessionId, residential);
+      // pod_ip is optional: a freshly created pod has no IP assigned yet, so the
+      // controller sends it on a later reconcile pass once Kubernetes reports it.
+      const podIp = normalizeIp(body.pod_ip);
+      const podIpBound = podIp ? bindPodIp(podIp, sessionId) : false;
       // Proves what the controller actually asked for. No line at all for a
       // session means the controller never synced it; `residential_effective`
       // is the one to read — it is only true when the flag AND an upstream exist.
@@ -731,12 +806,16 @@ async function handleAdmin(req, res) {
         residential_effective: residential && Boolean(UPSTREAM_PROXY),
         domains: domains.size,
         allow_all: allowAll,
+        // Without a pod_ip binding, only requests carrying a valid
+        // Proxy-Authorization can be attributed to this session.
+        pod_ip_bound: podIpBound,
       });
       writeJson(res, 200, {
         updated: true,
         session_id: sessionId,
         domains: Array.from(domains).sort(),
         residential,
+        pod_ip_bound: podIpBound,
       });
       return;
     } catch (error) {
@@ -756,6 +835,10 @@ async function handleAdmin(req, res) {
     }
     const removed = sessionAllowlist.delete(sessionId);
     sessionResidential.delete(sessionId);
+    // Drop the IP binding too, or a recycled pod IP would keep resolving to this
+    // dead session and inherit its allowlist and residential flag.
+    unbindSession(sessionId);
+    residentialMisconfigWarned.delete(sessionId);
     writeJson(res, 200, { removed, session_id: sessionId });
     return;
   }
@@ -867,6 +950,11 @@ module.exports = {
   adminServer,
   sessionAllowlist,
   sessionResidential,
+  sessionByPodIp,
+  normalizeIp,
+  bindPodIp,
+  unbindSession,
+  resolveSessionId,
   UPSTREAM_PROXY,
   parseUpstreamProxy,
   hostMatchesList,

--- a/charts/browser-hitl/files/egress-proxy/server.test.js
+++ b/charts/browser-hitl/files/egress-proxy/server.test.js
@@ -99,7 +99,46 @@ test.beforeEach(() => {
   lastUpstreamConnectLine = null;
   server.sessionAllowlist.clear();
   server.sessionResidential.clear();
+  server.sessionByPodIp.clear();
 });
+
+// Drive a CONNECT with NO Proxy-Authorization — exactly what Chromium sends on
+// its first attempt, and what browser-process traffic sends always.
+function connectWithoutAuth(host, port, { timeoutMs = 3000 } = {}) {
+  return new Promise((resolve, reject) => {
+    const sock = net.connect(proxyPort, '127.0.0.1');
+    let buf = Buffer.alloc(0);
+    let status = null;
+    const finish = (extra = {}) => {
+      resolve({ status, body: buf.toString('utf8'), ...extra });
+      sock.destroy();
+    };
+    const timer = setTimeout(() => finish({ timedOut: true }), timeoutMs);
+    sock.on('connect', () => {
+      sock.write(`CONNECT ${host}:${port} HTTP/1.1\r\nHost: ${host}:${port}\r\n\r\n`);
+    });
+    sock.on('data', (chunk) => {
+      buf = Buffer.concat([buf, chunk]);
+      if (status === null) {
+        const idx = buf.indexOf('\r\n\r\n');
+        if (idx !== -1) {
+          const line = buf.slice(0, buf.indexOf('\r\n')).toString('utf8');
+          const m = line.match(/HTTP\/\d\.\d\s+(\d{3})/);
+          status = m ? parseInt(m[1], 10) : 0;
+          buf = buf.slice(idx + 4);
+          if (status === 200) {
+            sock.write(`GET / HTTP/1.1\r\nHost: ${host}\r\nConnection: close\r\n\r\n`);
+          } else {
+            clearTimeout(timer);
+            finish();
+          }
+        }
+      }
+    });
+    sock.on('close', () => { clearTimeout(timer); finish(); });
+    sock.on('error', (e) => { clearTimeout(timer); reject(e); });
+  });
+}
 
 // Drive a CONNECT through the proxy using a valid session Proxy-Authorization.
 function connectThroughProxy(host, port, { sendGet = true, timeoutMs = 3000 } = {}) {
@@ -246,4 +285,77 @@ test('buildUpstreamAuth: strips non-alphanumerics from the session id for the st
   const header = server.buildUpstreamAuth('a1b2-c3d4-e5');
   const decoded = Buffer.from(header.replace(/^Basic\s+/, ''), 'base64').toString('utf8');
   assert.ok(decoded.startsWith('user-sessid-a1b2c3d4e5:'), decoded);
+});
+
+// --- pod-IP session identity ---------------------------------------------
+// Proxy-Authorization only covers requests Playwright manages: the browser
+// sends it in response to a 407, and unmanaged traffic (Chromium's own
+// browser-process requests) never gets that challenge answered, which surfaced
+// as a modal proxy-login prompt that froze the session. Source IP is present on
+// every connection, so it covers what the header cannot.
+
+test('pod-IP identity: unauthenticated CONNECT is attributed to the session and routes residential', async () => {
+  server.sessionAllowlist.set(SESSION_ID, new Set(['127.0.0.1']));
+  server.sessionResidential.set(SESSION_ID, true);
+  server.bindPodIp('127.0.0.1', SESSION_ID); // the test client's source IP
+
+  const res = await connectWithoutAuth('127.0.0.1', originPort);
+
+  assert.strictEqual(res.status, 200, 'no 407 — identity came from the pod IP');
+  assert.match(res.body, /OK-ORIGIN/, 'origin reached through the tunnel');
+  assert.strictEqual(upstreamConnects, 1, 'residential upstream was used');
+});
+
+test('pod-IP identity: without a binding an unauthenticated CONNECT still gets 407', async () => {
+  server.sessionAllowlist.set(SESSION_ID, new Set(['127.0.0.1']));
+  server.sessionResidential.set(SESSION_ID, true);
+  // no bindPodIp — fail-closed must be preserved
+
+  const res = await connectWithoutAuth('127.0.0.1', originPort);
+
+  assert.strictEqual(res.status, 407, 'unidentified request is still challenged');
+  assert.strictEqual(upstreamConnects, 0, 'never reached the upstream');
+});
+
+test('pod-IP identity: Proxy-Authorization wins over a conflicting IP binding', async () => {
+  server.sessionAllowlist.set(SESSION_ID, new Set(['127.0.0.1']));
+  server.sessionResidential.set(SESSION_ID, true);
+  // IP claims a DIFFERENT session that is not allowed to reach the origin
+  server.sessionByPodIp.set('127.0.0.1', 'other-session');
+  server.sessionAllowlist.set('other-session', new Set(['blocked.example']));
+  server.sessionResidential.set('other-session', false);
+
+  const res = await connectThroughProxy('127.0.0.1', originPort);
+
+  assert.strictEqual(res.status, 200, 'header-identified session was used, not the IP one');
+  assert.strictEqual(upstreamConnects, 1, 'residential flag came from the header session');
+});
+
+test('bindPodIp keeps the mapping 1:1 in both directions (pod IPs get recycled)', () => {
+  server.sessionByPodIp.clear();
+
+  // same session moves to a new IP → old IP must not linger
+  server.bindPodIp('10.0.0.1', 'session-a');
+  server.bindPodIp('10.0.0.2', 'session-a');
+  assert.strictEqual(server.sessionByPodIp.get('10.0.0.1'), undefined, 'stale IP released');
+  assert.strictEqual(server.sessionByPodIp.get('10.0.0.2'), 'session-a');
+
+  // recycled IP reassigned to a new session → newest claim wins
+  server.bindPodIp('10.0.0.2', 'session-b');
+  assert.strictEqual(server.sessionByPodIp.get('10.0.0.2'), 'session-b', 'recycled IP re-pointed');
+  assert.strictEqual(server.sessionByPodIp.size, 1, 'no duplicate claims left behind');
+
+  server.unbindSession('session-b');
+  assert.strictEqual(server.sessionByPodIp.size, 0, 'unbind removes every IP for the session');
+});
+
+test('normalizeIp strips the IPv4-mapped IPv6 prefix Node reports on dual-stack sockets', () => {
+  assert.strictEqual(server.normalizeIp('::ffff:10.244.0.7'), '10.244.0.7');
+  assert.strictEqual(server.normalizeIp('10.244.0.7'), '10.244.0.7');
+  assert.strictEqual(server.normalizeIp(''), '');
+  assert.strictEqual(server.normalizeIp(undefined), '');
+  // a mapped address must resolve to the same session as its bare form
+  server.sessionByPodIp.clear();
+  server.bindPodIp('::ffff:10.244.0.9', 'session-c');
+  assert.strictEqual(server.sessionByPodIp.get('10.244.0.9'), 'session-c');
 });


### PR DESCRIPTION
## Summary
- fix(chart): roll egress-proxy when its ConfigMap changes (#141)
- fix(egress): require session identity so residential egress applies (#143)
- feat(egress): identify sessions by worker pod IP, not only proxy auth (#145)

## Context
Residential proxy was silently broken on dev/prod due to two stacked bugs: ConfigMap changes never reached the running pod (#141), and `allowInsecureSessionAllowlist=true` suppressed the 407 challenge so browsers never sent credentials (#143). Fixing #143 exposed a third issue — Chromium's non-Playwright traffic gets the 407 with no handler, causing a modal proxy login dialog. #145 resolves this by identifying sessions via pod source IP as a fallback.