### PR TITLE
fix(recording): capture logins that CSP and shadow DOM were silently hiding

### DIFF
--- a/apps/api/src/modules/credentials/credentials.service.ts
+++ b/apps/api/src/modules/credentials/credentials.service.ts
@@ -48,6 +48,59 @@ const CACHE_TTL_MS = 60_000; // 60 seconds
 const CACHE_MAX_ENTRIES = 1000;
 
 /**
+ * `target_urls` for an app cloned from an App Template.
+ *
+ * These are not just an egress allowlist. The worker's artifact extractor
+ * (`buildUrlMatcher`) compiles each entry into a FULLY-ANCHORED regex
+ * (`^...$`, with `*` → `.*`) and uses it to decide which requests and
+ * responses to harvest credentials from. A bare origin like
+ * `https://api.example.com` therefore matches that exact string and nothing
+ * else — never `https://api.example.com/v1/thing` — so a glob suffix is
+ * mandatory for any real request path to be seen.
+ *
+ * This used to derive the list solely from `export_policy.target_domains`,
+ * mapped to bare `https://{domain}` origins, which silently discarded the
+ * globbed patterns the template already carried in
+ * `export_policy.target_urls`. The consequence was invisible: request-header
+ * capture ran but matched zero URLs, so `/credentials/request` served a
+ * declared `authorization` header with an EMPTY value and every downstream
+ * call 401'd — against a session reporting HEALTHY, on a profile whose
+ * `credential_types` looked completely correct. It hit every user of every
+ * template-provisioned app, since each member's first request clones a fresh
+ * one through here.
+ *
+ * The union is deliberate and strictly additive: the template's globbed
+ * patterns are what make capture work, while the login URL and bare
+ * per-domain origins are preserved so nothing that relied on the previous
+ * shape changes. Extra patterns are harmless to both consumers — the matcher
+ * ORs them, and the egress proxy reduces each entry to `new URL(...).hostname`
+ * and ignores the path entirely.
+ */
+export function cloneTargetUrls(template: {
+  login_config?: unknown;
+  export_policy?: unknown;
+}): string[] {
+  const exportPolicy = (template.export_policy ?? {}) as {
+    target_urls?: unknown;
+    target_domains?: unknown;
+  };
+  const loginUrl = (template.login_config as { login_url?: unknown } | undefined)?.login_url;
+
+  const globbed = Array.isArray(exportPolicy.target_urls)
+    ? exportPolicy.target_urls.filter((u): u is string => typeof u === 'string' && u.length > 0)
+    : [];
+  const domains = Array.isArray(exportPolicy.target_domains)
+    ? exportPolicy.target_domains.filter((d): d is string => typeof d === 'string' && d.length > 0)
+    : [];
+
+  return [
+    ...(typeof loginUrl === 'string' && loginUrl ? [loginUrl] : []),
+    ...globbed,
+    ...domains.map((d) => `https://${d}`),
+  ].filter((url, i, all) => all.indexOf(url) === i);
+}
+
+/**
  * Credentials Service (ADR-013 + Sprint 3b).
  *
  * Responsible for:
@@ -352,10 +405,7 @@ export class CredentialsService {
     // 1. Create App via AppsService (full validation + audit)
     const { app_id } = await this.appsService.create({
       name: `${template.name} — ${ownerUserId}`,
-      target_urls: [
-        ...((template.login_config as any)?.login_url ? [(template.login_config as any).login_url] : []),
-        ...((template.export_policy as any)?.target_domains || []).map((d: string) => `https://${d}`),
-      ],
+      target_urls: cloneTargetUrls(template),
       // Carry the template's extra egress domains onto the cloned app so the
       // per-user session's allowlist includes the vendor's auth/CDN hosts.
       extra_egress_allowlist: template.extra_egress_allowlist ?? [],

--- a/apps/api/src/modules/credentials/credentials.spec.ts
+++ b/apps/api/src/modules/credentials/credentials.spec.ts
@@ -21,7 +21,7 @@ jest.mock('ioredis', () => {
   return jest.fn().mockImplementation(() => mockRedis);
 });
 
-import { CredentialsService } from './credentials.service';
+import { CredentialsService, cloneTargetUrls } from './credentials.service';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -1181,6 +1181,80 @@ describe('CredentialsService (ADR-013 + Sprint 3b)', () => {
       await expect(
         service.findHealthySession(TEST_TENANT, TEST_APP_ID, 'user-a'),
       ).rejects.toThrow('No healthy session available');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Auto-provision: target_urls cloned onto the per-user app
+  // -------------------------------------------------------------------------
+  //
+  // Regression: this list is what the worker's artifact extractor compiles into
+  // anchored regexes to decide where to harvest credentials. Deriving it only
+  // from target_domains produced bare origins, which match no real request
+  // path — so request-header capture silently yielded nothing,
+  // /credentials/request served an EMPTY authorization value, and every call
+  // 401'd against a HEALTHY session.
+  describe('cloneTargetUrls', () => {
+    const template = {
+      login_config: { login_url: 'https://app.example.com/' },
+      export_policy: {
+        target_urls: ['https://app.example.com/**', 'https://api.example.com/**'],
+        target_domains: ['app.example.com', 'api.example.com'],
+      },
+    };
+
+    it('carries the globbed patterns from the template', () => {
+      const urls = cloneTargetUrls(template);
+      expect(urls).toContain('https://api.example.com/**');
+      expect(urls).toContain('https://app.example.com/**');
+    });
+
+    it('keeps a glob for every declared target domain', () => {
+      const urls = cloneTargetUrls(template);
+      for (const domain of template.export_policy.target_domains) {
+        expect(urls.some((u) => u === `https://${domain}/**`)).toBe(true);
+      }
+    });
+
+    it('produces patterns that match a real request path', () => {
+      // Mirrors artifact-extractor.ts buildUrlMatcher exactly.
+      const matches = (url: string) =>
+        cloneTargetUrls(template)
+          .map((g) => new RegExp(`^${g.replace(/[.+?^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*')}$`))
+          .some((r) => r.test(url));
+
+      expect(matches('https://api.example.com/v1/end-user/agent-harness/skills')).toBe(true);
+      expect(matches('https://app.example.com/dashboard')).toBe(true);
+      expect(matches('https://evil.example.net/v1/thing')).toBe(false);
+    });
+
+    it('still preserves the login URL and bare origins (additive change)', () => {
+      const urls = cloneTargetUrls(template);
+      expect(urls).toContain('https://app.example.com/');
+      expect(urls).toContain('https://api.example.com');
+    });
+
+    it('falls back to derived origins when the template has no globbed list', () => {
+      const legacy = {
+        login_config: { login_url: 'https://app.example.com/' },
+        export_policy: { target_domains: ['api.example.com'] },
+      };
+      expect(cloneTargetUrls(legacy)).toEqual([
+        'https://app.example.com/',
+        'https://api.example.com',
+      ]);
+    });
+
+    it('de-duplicates and tolerates a template with nothing set', () => {
+      expect(cloneTargetUrls({})).toEqual([]);
+      const dupes = cloneTargetUrls({
+        login_config: { login_url: 'https://a.example.com/' },
+        export_policy: {
+          target_urls: ['https://a.example.com/', 'https://a.example.com/**'],
+          target_domains: [],
+        },
+      });
+      expect(dupes).toEqual(['https://a.example.com/', 'https://a.example.com/**']);
     });
   });
 });

--- a/apps/api/src/modules/streaming/streaming.controller.ts
+++ b/apps/api/src/modules/streaming/streaming.controller.ts
@@ -295,9 +295,18 @@ function renderEmailGatePage(sessionId: string, token: string | undefined, prefi
         })
           .then(function(r) {
             if (r.ok) {
-              var dest = '/' + PREFIX + '/' + SESSION_ID;
-              if (STREAM_TOKEN) dest += '?token=' + encodeURIComponent(STREAM_TOKEN);
-              window.location.href = dest;
+              // Carry the viewer's own query params across the redirect. They
+              // select what the viewer renders — 'mode=recording' gates the
+              // "Finish & export" panel, 'from=mcp' the HITL panel — so
+              // rebuilding a bare URL here silently removed the only control
+              // a recording session has, on every Tabby without a browser-OAuth
+              // IdP (the email gate is the fallback there). The verify-token
+              // path above reload()s and never had this bug.
+              var params = new URLSearchParams(window.location.search);
+              params.delete('token');
+              if (STREAM_TOKEN) params.set('token', STREAM_TOKEN);
+              var qs = params.toString();
+              window.location.href = '/' + PREFIX + '/' + SESSION_ID + (qs ? '?' + qs : '');
             } else {
               r.json().catch(function() { return {}; }).then(function(d) {
                 msg.textContent = d.message || 'Access denied. Please check your email.';
@@ -870,6 +879,16 @@ export class CdpStreamingController {
         if (recordingMode) {
           var recSection = document.getElementById('recording-section');
           if (recSection) recSection.style.display = '';
+          // Open the panel: "Finish & export" is the only way to end a recording,
+          // and behind a collapsed tab it reads as missing entirely.
+          var recPanel = document.getElementById('side-panel');
+          var recToggle = document.getElementById('panel-toggle');
+          var recContent = document.getElementById('panel-content');
+          if (recPanel && recToggle && recContent) {
+            recPanel.setAttribute('aria-expanded', 'true');
+            recToggle.innerHTML = '&#9654;';
+            recContent.removeAttribute('inert');
+          }
         }
 
         var currentStepIndex = null;
@@ -1750,6 +1769,16 @@ export class StreamingController {
         if (recordingMode) {
           var recSection = document.getElementById('recording-section');
           if (recSection) recSection.style.display = '';
+          // Open the panel: "Finish & export" is the only way to end a recording,
+          // and behind a collapsed tab it reads as missing entirely.
+          var recPanel = document.getElementById('side-panel');
+          var recToggle = document.getElementById('panel-toggle');
+          var recContent = document.getElementById('panel-content');
+          if (recPanel && recToggle && recContent) {
+            recPanel.setAttribute('aria-expanded', 'true');
+            recToggle.innerHTML = '&#9654;';
+            recContent.removeAttribute('inert');
+          }
         }
 
         var currentStepIndex = null;

--- a/apps/worker/src/dom-recorder.injected.ts
+++ b/apps/worker/src/dom-recorder.injected.ts
@@ -6,20 +6,47 @@
  * events with rich selector metadata, detects username/password/otp field
  * roles, and REDACTS password/otp values IN-POD before they leave the browser.
  *
- * Event channel: each event is POSTed as a sentinel `fetch()` to a fake host
- * (REC_BEACON). RecordingRunner reads them via page.on('request') + postData —
- * the SAME network-capture path HAR uses, which is the only CDP channel proven
- * to survive CloakBrowser's stealth Chromium (exposeBinding bindings are
- * stripped and console forwarding is suppressed as automation fingerprints).
- * The request never leaves the box: the .local host fails to resolve, but the
- * request-initiation event still fires with the body. Host/paths are inlined as
- * literals because the function body is serialized into the page context.
+ * Event channel: each event is POSTed as a sentinel `fetch()` to a reserved
+ * path. RecordingRunner reads them via page.on('request') + postData — the SAME
+ * network-capture path HAR uses, which is the only CDP channel proven to
+ * survive CloakBrowser's stealth Chromium (exposeBinding bindings are stripped
+ * and console forwarding is suppressed as automation fingerprints).
+ *
+ * The beacon is sent **same-origin** (`location.origin + REC_PATH`), NOT to an
+ * off-origin sentinel host. A page's Content-Security-Policy governs where its
+ * scripts may fetch, and `mode: 'no-cors'` does not exempt it: under a policy
+ * like app.adopt.ai's
+ *
+ *     connect-src 'self' https://*.adopt.ai https://*.frontegg.com …
+ *
+ * every beacon to an off-origin host is refused by the browser *before* a
+ * request is ever initiated, so page.on('request') never fires and the whole
+ * capture comes back with zero interaction events — silently, because the
+ * recorder's own fetch rejection is caught and discarded. Downstream that looks
+ * identical to "the human never typed anything": NoUI's
+ * split.find_login_boundary() finds no credential field, so every *combined*
+ * capture of a CSP-enforcing site degrades to workflow-only and no App Template
+ * is ever registered. Reproduced against the real policy: 3 events without CSP,
+ * 0 with it.
+ *
+ * `'self'` is allowed by essentially every real connect-src (a SPA must reach
+ * its own API), so a same-origin beacon survives. RecordingRunner aborts the
+ * route so nothing reaches the origin server, and filters the path out of the
+ * HAR. Opaque origins (about:blank, sandboxed frames) have no usable
+ * location.origin and fall back to the legacy off-origin host.
+ *
+ * Paths are inlined as literals because the function body is serialized into
+ * the page context.
  */
 
-// Sentinel beacon (kept in sync with the literals inlined in domRecorderScript).
-export const REC_BEACON = 'https://tabby-rec.local/';
-export const REC_EVENT_PATH = 'https://tabby-rec.local/e';
-export const REC_INSTALL_PATH = 'https://tabby-rec.local/i';
+// Reserved beacon path. Matched by suffix, so it works under any origin.
+export const REC_PATH = '/__tabby_rec__/';
+export const REC_EVENT_PATH = '/__tabby_rec__/e';
+export const REC_INSTALL_PATH = '/__tabby_rec__/i';
+/** Playwright route glob used to abort beacons before they leave the box. */
+export const REC_ROUTE_GLOB = '**/__tabby_rec__/**';
+/** Fallback origin for documents with no usable origin (about:blank, sandboxed frames). */
+export const REC_FALLBACK_ORIGIN = 'https://tabby-rec.local';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -47,10 +74,21 @@ export function domRecorderScript(): void {
     }
   })();
 
+  // Same-origin beacon base — see the module docstring: an off-origin host is
+  // refused outright by any page whose CSP declares connect-src.
+  const recBase: string = (() => {
+    try {
+      const o = w.location && w.location.origin;
+      return typeof o === 'string' && /^https?:\/\//.test(o) ? o : 'https://tabby-rec.local';
+    } catch {
+      return 'https://tabby-rec.local';
+    }
+  })();
+
   const emit = (data: any): void => {
     if (!send) return;
     try {
-      send('https://tabby-rec.local/e', JSON.stringify(data));
+      send(recBase + '/__tabby_rec__/e', JSON.stringify(data));
     } catch {
       /* serialization failure on one event must not tear down the recorder */
     }
@@ -247,7 +285,7 @@ export function domRecorderScript(): void {
   // Breadcrumb: proves the recorder actually ran in this document. RecordingRunner
   // logs it; if it never appears, injection itself is blocked and we must launch
   // a non-stealth browser for recording.
-  if (send) send('https://tabby-rec.local/i', w.location ? String(w.location.href) : '');
+  if (send) send(recBase + '/__tabby_rec__/i', w.location ? String(w.location.href) : '');
 
   function cleanup(): void {
     document.removeEventListener('click', handleClick, true);

--- a/apps/worker/src/dom-recorder.injected.ts
+++ b/apps/worker/src/dom-recorder.injected.ts
@@ -155,9 +155,40 @@ export function domRecorderScript(): void {
   const shouldRedact = (fieldRole: string | null): boolean =>
     fieldRole === 'password' || fieldRole === 'otp';
 
+  /**
+   * The element the human actually touched.
+   *
+   * Events that cross a shadow boundary are RETARGETED: a listener on
+   * `document` sees `e.target` as the shadow HOST, not the inner control. Any
+   * login box mounted as a web component (Frontegg's
+   * `#frontegg-login-box-container-default`, and most hosted-login widgets) is
+   * therefore invisible to a naive `e.target` — the input handler's
+   * "is this an <input>?" guard drops every keystroke, so no credential field
+   * is ever recorded and NoUI concludes no login happened.
+   *
+   * `composedPath()[0]` is the true origin of the event and pierces OPEN
+   * shadow roots. Closed roots still report only the host; nothing at this
+   * layer can see inside one.
+   */
+  const realTarget = (e: any): any => {
+    try {
+      if (typeof e.composedPath === 'function') {
+        const path = e.composedPath();
+        if (path && path.length && path[0] && path[0].tagName) return path[0];
+      }
+    } catch {
+      /* fall through to e.target */
+    }
+    return e.target;
+  };
+
   const handleClick = (e: any): void => {
+    const origin = realTarget(e);
+    if (!origin) return;
     const target =
-      e.target.closest('[id], [class], a, button, input, select, textarea, [role]') || e.target;
+      (typeof origin.closest === 'function'
+        ? origin.closest('[id], [class], a, button, input, select, textarea, [role]')
+        : null) || origin;
     if (!target || !target.tagName) return;
     emit({
       event_type: 'click',
@@ -183,7 +214,7 @@ export function domRecorderScript(): void {
   const inputTimers = new WeakMap<any, any>();
 
   const handleInput = (e: any): void => {
-    const target = e.target;
+    const target = realTarget(e);
     if (!target || !target.tagName) return;
     const tag = target.tagName.toLowerCase();
     if (tag !== 'input' && tag !== 'textarea') return;
@@ -222,7 +253,7 @@ export function domRecorderScript(): void {
   };
 
   const handleChange = (e: any): void => {
-    const target = e.target;
+    const target = realTarget(e);
     if (!target || !target.tagName) return;
     const tag = target.tagName.toLowerCase();
     if (tag === 'input' && !['checkbox', 'radio'].includes(target.type)) return;
@@ -258,7 +289,7 @@ export function domRecorderScript(): void {
   };
 
   const handleSubmit = (e: any): void => {
-    const form = e.target;
+    const form = realTarget(e);
     if (!form || (form.tagName && form.tagName.toLowerCase() !== 'form')) return;
     emit({
       event_type: 'submit',

--- a/apps/worker/src/recording-runner.spec.ts
+++ b/apps/worker/src/recording-runner.spec.ts
@@ -31,17 +31,23 @@ function makeFakes(initialUrl: string) {
   const context = {
     addInitScript: jest.fn(async () => undefined),
     cookies: jest.fn(async () => []),
+    route: jest.fn(async () => undefined),
+    unroute: jest.fn(async () => undefined),
   } as unknown as import('playwright').BrowserContext;
 
-  // Simulate the sentinel fetch() beacon the injected recorder would issue.
+  // Simulate the sentinel fetch() beacon the injected recorder would issue. The
+  // recorder posts it SAME-ORIGIN so a connect-src CSP can't refuse it, so the
+  // beacon's host is the page's own host, not a fixed sentinel domain.
   const beaconReq = (url: string, body: string | null) => ({ url: () => url, postData: () => body });
+  const origin = new URL(initialUrl).origin;
 
   return {
     page,
     context,
     emit: (ev: RecordedInteractionEvent) =>
-      requestListener?.(beaconReq('https://tabby-rec.local/e', JSON.stringify(ev))),
-    install: () => requestListener?.(beaconReq('https://tabby-rec.local/i', 'https://example.com/login')),
+      requestListener?.(beaconReq(`${origin}/__tabby_rec__/e`, JSON.stringify(ev))),
+    install: () =>
+      requestListener?.(beaconReq(`${origin}/__tabby_rec__/i`, 'https://example.com/login')),
     navigate: (to: string) => {
       currentUrl = to;
       navListener?.(mainFrame);
@@ -78,6 +84,69 @@ describe('RecordingRunner', () => {
     const bundle = await runner.drain();
     expect(bundle.click_events).toHaveLength(1);
     expect(bundle.click_events[0].selector).toBe('#submit');
+  });
+
+  // Regression: an off-origin beacon is refused by any page declaring a
+  // connect-src CSP, which silently produced captures with zero interaction
+  // events — indistinguishable downstream from "the human never signed in".
+  it('reads the beacon from any origin, not a fixed sentinel host', async () => {
+    const f = makeFakes('https://app.adopt.ai/account/login');
+    const runner = new RecordingRunner(f.page, f.context, 'sess-csp', 'login');
+    await runner.start();
+
+    f.install();
+    f.emit(clickEvent);
+    const bundle = await runner.drain();
+
+    expect(bundle.click_events).toHaveLength(1);
+  });
+
+  it('aborts beacon requests so they never reach the page origin server', async () => {
+    const f = makeFakes('https://app.adopt.ai/account/login');
+    const runner = new RecordingRunner(f.page, f.context, 'sess-csp', 'login');
+    await runner.start();
+
+    expect(f.context.route).toHaveBeenCalledWith('**/__tabby_rec__/**', expect.any(Function));
+
+    const abort = jest.fn(async () => undefined);
+    (f.context.route as jest.Mock).mock.calls[0][1]({ abort });
+    expect(abort).toHaveBeenCalled();
+  });
+
+  it('keeps beacon requests out of the drained HAR', async () => {
+    const f = makeFakes('https://app.adopt.ai/account/login');
+    const runner = new RecordingRunner(f.page, f.context, 'sess-csp', 'login');
+    await runner.start();
+
+    f.emit(clickEvent);
+    const bundle = await runner.drain();
+
+    const urls = (bundle.har.log.entries as Array<{ request?: { url?: string } }>).map(
+      (e) => e.request?.url ?? '',
+    );
+    expect(urls.some((u) => u.includes('/__tabby_rec__/'))).toBe(false);
+  });
+
+  it('warns when traffic was captured but no interaction events were', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    try {
+      const f = makeFakes('https://app.adopt.ai/account/login');
+      const runner = new RecordingRunner(f.page, f.context, 'sess-csp', 'login');
+      await runner.start();
+
+      // Traffic happened (two navigations) but the recorder emitted nothing.
+      f.navigate('https://app.adopt.ai/oauth/callback');
+      f.navigate('https://app.adopt.ai/');
+      const bundle = await runner.drain();
+
+      expect(bundle.click_events).toHaveLength(0);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('NO DOM interaction events captured'),
+      );
+      expect(warn.mock.calls[0][0]).toContain('Content-Security-Policy');
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it('drains a bundle with captured interaction + url events', async () => {

--- a/apps/worker/src/recording-runner.ts
+++ b/apps/worker/src/recording-runner.ts
@@ -6,7 +6,12 @@ import type {
   RecordedUrlEvent,
 } from '@browser-hitl/shared';
 import { startHarCapture, stopHarCapture, cleanupHarListeners } from './har-capture';
-import { REC_BEACON, REC_INSTALL_PATH, domRecorderScript } from './dom-recorder.injected';
+import {
+  REC_PATH,
+  REC_INSTALL_PATH,
+  REC_ROUTE_GLOB,
+  domRecorderScript,
+} from './dom-recorder.injected';
 import { sanitizeHar } from './har-sanitizer';
 
 /**
@@ -30,6 +35,7 @@ export class RecordingRunner {
   private onDomReady: (() => void) | null = null;
   private started = false;
   private installSeen = false;
+  private routed = false;
 
   constructor(
     private readonly page: Page,
@@ -48,11 +54,14 @@ export class RecordingRunner {
     startHarCapture(this.page);
 
     // DOM interaction capture: the injected recorder POSTs each event as a
-    // sentinel fetch() to REC_BEACON. We read them off page.on('request') +
-    // postData() — the same network-capture path HAR uses, which is the only
-    // CDP channel that survives the stealth Chromium build (exposeBinding and
-    // console forwarding are both suppressed). The beacon never reaches the
-    // network (host doesn't resolve); the request-initiation event is enough.
+    // sentinel fetch() to a reserved SAME-ORIGIN path (REC_PATH). We read them
+    // off page.on('request') + postData() — the same network-capture path HAR
+    // uses, which is the only CDP channel that survives the stealth Chromium
+    // build (exposeBinding and console forwarding are both suppressed).
+    //
+    // Same-origin is load-bearing: an off-origin beacon is refused outright by
+    // any page that sets a connect-src CSP, which silently produced captures
+    // with zero interaction events. See dom-recorder.injected.ts.
     this.onRequest = (req: any) => {
       let url: string;
       try {
@@ -60,8 +69,8 @@ export class RecordingRunner {
       } catch {
         return;
       }
-      if (!url.startsWith(REC_BEACON)) return;
-      if (url.startsWith(REC_INSTALL_PATH)) {
+      if (!url.includes(REC_PATH)) return;
+      if (url.endsWith(REC_INSTALL_PATH)) {
         if (!this.installSeen) {
           this.installSeen = true;
           console.log('[Recording] DOM recorder installed in page');
@@ -78,6 +87,20 @@ export class RecordingRunner {
       }
     };
     this.page.on('request', this.onRequest);
+
+    // Abort the beacon so it never reaches the page's real origin server. The
+    // 'request' event above fires before the route handler runs, so the event
+    // is already captured; aborting only stops it going out (and keeps it out
+    // of the HAR, which only records entries that get a response). Best effort:
+    // if interception is unavailable the beacon merely 404s against the origin.
+    try {
+      await this.context.route(REC_ROUTE_GLOB, (route: any) => {
+        route.abort().catch(() => undefined);
+      });
+      this.routed = true;
+    } catch {
+      /* interception unavailable — beacons 404 harmlessly */
+    }
 
     // Inject the recorder two ways for resilience against stealth Chromium:
     //  1. addInitScript — runs at document-start IF the build honors
@@ -162,7 +185,7 @@ export class RecordingRunner {
     // Drop our own sentinel beacon requests so they never reach the bundle.
     if (rawHar.log?.entries?.length) {
       rawHar.log.entries = rawHar.log.entries.filter(
-        (e: any) => !String(e?.request?.url || '').startsWith(REC_BEACON),
+        (e: any) => !String(e?.request?.url || '').includes(REC_PATH),
       );
     }
 
@@ -182,6 +205,21 @@ export class RecordingRunner {
         `har_entries=${har.log.entries.length}, events=${this.events.length}, urls=${this.urlEvents.length}, ` +
         `cookies=${cookies?.length ?? 0}, recorder_installed=${this.installSeen}`,
     );
+
+    // A capture with real traffic but zero interaction events means the beacon
+    // channel was silenced (page CSP, or injection blocked outright) — NOT that
+    // the human sat still. Downstream that is indistinguishable from "no login
+    // happened", which is exactly how it used to slip through unnoticed.
+    if (this.events.length === 0 && (har.log.entries.length > 0 || this.urlEvents.length > 1)) {
+      console.warn(
+        `[Recording] NO DOM interaction events captured for session=${this.sessionId} ` +
+          `despite ${har.log.entries.length} network entries ` +
+          `(recorder_installed=${this.installSeen}). The page most likely blocked the ` +
+          `recorder beacon via Content-Security-Policy. A login in this capture cannot ` +
+          `be detected downstream — treat it as workflow-only or re-import with an ` +
+          `explicit mode.`,
+      );
+    }
 
     return {
       session_id: this.sessionId,
@@ -208,6 +246,12 @@ export class RecordingRunner {
     if (this.onDomReady) {
       this.page.removeListener('domcontentloaded', this.onDomReady);
       this.onDomReady = null;
+    }
+    if (this.routed) {
+      this.routed = false;
+      // Fire-and-forget: detach() is sync, and a failed unroute (context already
+      // closing) must never break the drain.
+      Promise.resolve(this.context.unroute(REC_ROUTE_GLOB)).catch(() => undefined);
     }
     cleanupHarListeners(this.page);
   }


### PR DESCRIPTION
## What

Three defects that together made a login capture of a CSP-enforcing, web-component-based site look like "the human never signed in".

Found while rebuilding the `adopt-ai-skills` NoUI skill against the real `app.adopt.ai`. Every one of them failed silently.

### 1. A page CSP silenced the DOM recorder entirely

The injected recorder POSTs each interaction to a sentinel URL and `RecordingRunner` reads it back off `page.on('request')`. That sentinel was an **off-origin** host (`tabby-rec.local`), and a page's `connect-src` governs where its scripts may fetch — `mode: 'no-cors'` does not exempt it. Under a policy like `app.adopt.ai`'s, the browser refuses the beacon *before* a request is initiated, so no request event fires and the capture arrives with **zero** interaction events. The recorder catches and discards its own fetch rejection, so nothing is logged.

Downstream this is indistinguishable from an idle human: NoUI's `split.find_login_boundary()` sees no credential field, so every *combined* capture degrades to workflow-only and no App Template is registered.

Now posted **same-origin** (`location.origin + /__tabby_rec__/e`). `'self'` is allowed by essentially every real `connect-src` — a SPA must reach its own API. The route is aborted so nothing reaches the origin server, and the reserved path is filtered out of the HAR as before. Opaque origins fall back to the legacy host.

Measured against the real header: **3 events → 0 → 3**.

### 2. Shadow-DOM retargeting hid every credential field

Even with the beacon working, the capture still recorded no credential field. Events crossing a shadow boundary **retarget** `e.target` to the host, so the document-level listeners saw `#frontegg-login-box-container-default` (a `DIV`) instead of the input inside it, and `handleInput`'s "is this an `<input>`?" guard dropped every keystroke.

This affects any hosted login box mounted as a web component — Frontegg's, and most others.

Resolved via `composedPath()[0]`, which pierces open shadow roots. Isolated repro: a shadow-mounted email+password pair went from `[]` to `['username','password']`, with the inner selectors (`#email-shadow`, `#pw-shadow`) rather than the host.

### 3. The email gate made "Finish & export" unreachable

On success the gate rebuilt a bare redirect URL, dropping the viewer's own query params. `mode=recording` gates the Finish & export panel, so **every recording session on a Tabby without a browser-OAuth IdP** lost the only control that ends a recording — the operator simply saw no button. The `verify-token` path `reload()`s and never had this bug.

Params are now carried across the redirect, and the recording panel auto-opens (it was also collapsed behind a toggle tab, which reads as missing).

### 4. Auto-provisioned apps lost the globs that make credential capture work

`autoProvisionFromTemplate` rebuilt a cloned app's `target_urls` from
`export_policy.target_domains` as bare `https://{domain}` origins, discarding the
globbed patterns the template already carried in `export_policy.target_urls`.

Those entries are not just an egress allowlist — `buildUrlMatcher` compiles each into a
fully-anchored regex (`^...$`, `*` → `.*`) and uses it to choose which traffic to harvest
credentials from. A bare origin matches that exact string and nothing else, never a URL
with a path, so request-header capture ran and matched zero URLs.

Invisible end to end: `/credentials/request` served a **declared** `authorization` header
with an **empty** value, and every call 401'd — against a session reporting HEALTHY, on a
profile whose `credential_types` looked entirely correct. It hit every user of every
template-provisioned app, since each member's first request clones a fresh one through
this path; the standing workaround was a manual `PUT /apps/{id}` per user per skill.

The union is **strictly additive** — the login URL and bare per-domain origins are still
emitted, so nothing depending on the previous shape changes. Extra patterns are harmless
to both consumers: the extractor ORs them, and the egress proxy reduces every entry to
`new URL(...).hostname`, ignoring the path.

## Why it matters

Any customer app that sets a `connect-src` CSP (most SPAs) or uses a hosted login widget (most B2B apps) silently produced captures NoUI could not turn into an App Template. The operator's only signal was a calm "No login segment detected", hours before the real failure surfaced at runtime as "no Tabby profile exists".

## Validation

- Playwright against `app.adopt.ai`'s verbatim CSP header: 3 interaction events (`field_role=username`) without the policy, 0 with it, 3 again with this change
- Isolated shadow-DOM repro: 0 credential roles → `['username','password']`
- Live: recorded a real `app.adopt.ai` login on local Kind. Before: 0 interaction events. After: interaction events captured on **both** origins including the cross-origin `auth.adopt.ai` login page
- Auto-provision fix, **verified live on local Kind**: registered a template, triggered a real
  auto-provision, and the cloned app's `target_urls` came out
  `[..., https://app.adopt.ai/**, https://auth.adopt.ai/**, https://api.adopt.ai/**, ...]`
  — 3 globbed patterns where the old code produced bare origins only.
  A unit test also replays `buildUrlMatcher`'s exact regex construction and asserts a real
  request path matches
- `nx test worker` **129/129** (was 125), `nx test api` **607/607** (6 new); both lints clean
- All new tests confirmed non-vacuous against the pre-fix tree

## Risk

- `context.route()` enables CDP `Fetch` for the beacon pattern only. If interception is unavailable on the stealth build the beacon degrades to a same-origin 404 — still captured, just noisier. Not observed locally; unverified on the CloakBrowser build.
- `composedPath()` cannot see into **closed** shadow roots. Nothing at this layer can; such fields remain invisible.
- Apps already provisioned keep their bare `target_urls` until re-provisioned or PUT — the fix applies to new clones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
