### PR TITLE
feat(health): detect signed-out-in-a-200 via network_check body_not_contains

### DIFF
--- a/apps/worker/src/health-predicate-runner.spec.ts
+++ b/apps/worker/src/health-predicate-runner.spec.ts
@@ -1,0 +1,59 @@
+import { HealthPredicateRunner } from './health-predicate-runner';
+import { HealthResultType } from '@browser-hitl/shared';
+
+// Minimal Playwright BrowserContext stub: only context.request.get is used by
+// runNetworkCheck. Each test wires the response it wants back.
+function makeContext(resp: { status: number; body: string }) {
+  return {
+    request: {
+      get: jest.fn(async () => ({
+        status: () => resp.status,
+        url: () => 'https://www1.secure.hsbcnet.com/pims/dtc/accounts/balances',
+        text: async () => resp.body,
+      })),
+    },
+  } as any;
+}
+
+const PAGE = {} as any;
+
+function runnerFor(resp: { status: number; body: string }, check: any) {
+  const ctx = makeContext(resp);
+  const runner = new HealthPredicateRunner(PAGE, ctx, {
+    interval_seconds: 60,
+    actions: [],
+    health_checks: [check],
+  });
+  return runner;
+}
+
+describe('network_check body_not_contains (signed-out marker in a 200)', () => {
+  const HSBC_CHECK = {
+    type: 'network_check',
+    url: 'https://www1.secure.hsbcnet.com/pims/dtc/accounts/balances',
+    expect_status: 200,
+    body_not_contains: 'PCS9500',
+  };
+
+  it('AUTH_FAILs when the signed-out marker is present in an otherwise-OK 200', async () => {
+    const body = JSON.stringify({
+      status: { code: 12 },
+      response: { statusMessages: { data: [{ errorCode: 'PCS9500', messageId: 'GENERIC_EXCEPTION' }] } },
+    });
+    const res = await runnerFor({ status: 200, body }, HSBC_CHECK).evaluate();
+    expect(res.overall).toBe(HealthResultType.AUTH_FAIL);
+    expect(res.checks[0].detail).toContain('PCS9500');
+  });
+
+  it('PASSes when the signed-out marker is absent (real account data)', async () => {
+    const body = JSON.stringify({ accounts: [{ id: 'acct-1', balance: 100 }] });
+    const res = await runnerFor({ status: 200, body }, HSBC_CHECK).evaluate();
+    expect(res.overall).toBe(HealthResultType.PASS);
+  });
+
+  it('still enforces body_contains (positive marker) alongside', async () => {
+    const check = { ...HSBC_CHECK, body_contains: 'accounts', body_not_contains: undefined };
+    const res = await runnerFor({ status: 200, body: '{"nope":1}' }, check).evaluate();
+    expect(res.overall).toBe(HealthResultType.AUTH_FAIL);
+  });
+});

--- a/apps/worker/src/health-predicate-runner.ts
+++ b/apps/worker/src/health-predicate-runner.ts
@@ -177,10 +177,15 @@ export class HealthPredicateRunner {
         return { result: HealthResultType.TRANSIENT_FAIL, detail: `HTTP ${response.status()}` };
       }
 
-      if (check.body_contains) {
+      if (check.body_contains || check.body_not_contains) {
         const body = await response.text();
-        if (!body.includes(check.body_contains)) {
+        if (check.body_contains && !body.includes(check.body_contains)) {
           return { result: HealthResultType.AUTH_FAIL, detail: `Body missing: ${check.body_contains}` };
+        }
+        // A signed-out marker in an otherwise-OK response (e.g. HSBCnet PCS9500
+        // inside a 200) means the app session is not authenticated.
+        if (check.body_not_contains && body.includes(check.body_not_contains)) {
+          return { result: HealthResultType.AUTH_FAIL, detail: `Body has signed-out marker: ${check.body_not_contains}` };
         }
       }
 

--- a/packages/shared/src/config.types.ts
+++ b/packages/shared/src/config.types.ts
@@ -43,7 +43,14 @@ export interface NetworkCheck {
   type: 'network_check';
   url: string;
   expect_status: number;
+  // Positive marker: the response body MUST contain this to be considered
+  // signed-in (absence => AUTH_FAIL).
   body_contains?: string;
+  // Negative marker: if the response body CONTAINS this, treat the session as
+  // signed-out (=> AUTH_FAIL), even on the expected status. This is how apps
+  // that report "not authenticated" as a business error inside a 200 (e.g.
+  // HSBCnet's PCS9500) surface as LOGIN_NEEDED instead of a false HEALTHY.
+  body_not_contains?: string;
 }
 
 export type HealthCheck = UrlCheck | DomCheck | NetworkCheck;

--- a/packages/shared/src/dsl.validator.spec.ts
+++ b/packages/shared/src/dsl.validator.spec.ts
@@ -195,6 +195,26 @@ describe('validateKeepaliveConfig', () => {
     expect(result.valid).toBe(false);
   });
 
+  it('accepts network_check with body_not_contains (signed-out marker)', () => {
+    const result = validateKeepaliveConfig({
+      ...validConfig,
+      health_checks: [
+        { type: 'network_check', url: 'https://api.example.com/session', expect_status: 200, body_not_contains: 'PCS9500' },
+      ],
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects non-string body_not_contains', () => {
+    const result = validateKeepaliveConfig({
+      ...validConfig,
+      health_checks: [
+        { type: 'network_check', url: 'https://api.example.com/session', expect_status: 200, body_not_contains: 123 as any },
+      ],
+    });
+    expect(result.valid).toBe(false);
+  });
+
   it('requires quorum_n when policy is quorum', () => {
     const result = validateKeepaliveConfig({ ...validConfig, policy: 'quorum' });
     expect(result.valid).toBe(false);

--- a/packages/shared/src/dsl.validator.ts
+++ b/packages/shared/src/dsl.validator.ts
@@ -252,6 +252,15 @@ export function validateKeepaliveConfig(config: KeepaliveConfig): ValidationResu
         }
       }
 
+      if (check.type === 'network_check') {
+        if (check.body_contains !== undefined && typeof check.body_contains !== 'string') {
+          errors.push({ path: `${path}.body_contains`, message: 'network_check body_contains must be a string' });
+        }
+        if (check.body_not_contains !== undefined && typeof check.body_not_contains !== 'string') {
+          errors.push({ path: `${path}.body_not_contains`, message: 'network_check body_not_contains must be a string' });
+        }
+      }
+
       if (check.type === 'dom_check') {
         if (!check.selector || typeof check.selector !== 'string') {
           errors.push({ path: `${path}.selector`, message: 'dom_check requires a selector' });


### PR DESCRIPTION
## Problem
Banks/SPAs like **HSBCnet** report "session not authenticated" as a **business error inside an HTTP 200** (`PCS9500` / `GENERIC_EXCEPTION`), not a 401. So the Tabby session stayed **HEALTHY**, `call_web_api` ran the fetch and got the 200-error body (`status: "ok"`), and the `login_required` link-minting path never ran. The user got a `tabby-auth` card with **no real session_id/link** (dead "Connect" button) or a **raw third-party URL** — no working sign-in.

## Fix (uses the session state machine the right way)
Add a **negative** body matcher to `network_check`: `body_not_contains`. If the response body **contains** it, the check returns `AUTH_FAIL`.

Wired through the existing chain, this is the whole fix — no new dispatch logic:
- `handleStarting`: `AUTH_FAIL` → **`LOGIN_NEEDED`** (a logged-out session **never becomes HEALTHY**).
- `executeFetch` → `findHealthySession` → no HEALTHY session → **404** → `call_web_api` returns **`login_required`** → mints a real Tabby login link → `tabby-auth` card with a valid `session_id` + `login_url` that auto-advances on sign-in.

**One sign-in, first go.** No race (HEALTHY is only reached on a PASS). No client CORS — `network_check` runs `context.request` server-side with the session cookies.

## Per-app config (data, not code)
Set on the app's `keepalive_config.health_checks`, e.g. HSBCnet:
```json
{ "type": "network_check",
  "url": "https://www1.secure.hsbcnet.com/pims/dtc/accounts/balances",
  "expect_status": 200,
  "body_not_contains": "PCS9500" }
```

## Changes
- `shared/config.types.ts` — `body_not_contains?: string` on `NetworkCheck` (+ doc).
- `shared/dsl.validator.ts` — validate it's a string (+ test).
- `worker/health-predicate-runner.ts` — single body read handles both markers; signed-out marker → `AUTH_FAIL` (+ new spec, 3 cases).

## Follow-up
NoUI compiler should emit `keepalive_config.health_checks` (incl. `body_not_contains`) so session skills declare their signed-out signal at compile time. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)