### PR TITLE
fix(sessions): allow Editor role to read GET /sessions/:id (fixes false 'session terminated')

### DIFF
--- a/apps/api/src/modules/sessions/sessions.controller.ts
+++ b/apps/api/src/modules/sessions/sessions.controller.ts
@@ -65,7 +65,13 @@ export class SessionsController {
   }
 
   @Get('sessions/:id')
-  @Roles('Admin', 'Operator', 'Viewer', 'Agent')
+  // Editor belongs here too — it's allowed on every sibling session read
+  // (findAll, findInterventions) and on execute/fetch + agent/session-status,
+  // so an Editor member can run call_web_api but previously 403'd reading their
+  // own session. This endpoint backs the tabby-auth card's state poll and the
+  // viewer's liveness check; the 403 surfaced to the FE as a false
+  // "session terminated / poll-for-successor".
+  @Roles('Admin', 'Editor', 'Operator', 'Viewer', 'Agent')
   @ApiOperation({ summary: 'Get session details', description: 'Returns full session entity including state, health result, intervention counts, and timestamps.' })
   @ApiParam({ name: 'id', description: 'Session UUID' })
   @ApiResponse({ status: 200, description: 'Session details' })


### PR DESCRIPTION
## Symptom
On staging, the HSBCnet sign-in card rendered and opened the correct viewer, but the session showed **"Session terminated — polling for successor"** as soon as it opened, and every new turn re-resolved to the same stuck session.

## Root cause
The tabby-auth card polls session state every 4s via the adoptwebui backend → `GET /sessions/{id}`, which returned **403 Forbidden**. `findOne`'s `@Roles` was `Admin, Operator, Viewer, Agent` — **the only session endpoint missing `Editor`**:

| Endpoint | Editor allowed? |
|---|---|
| `execute/fetch`, `agent/session-status` | ✅ (so `call_web_api` works) |
| `sessions` (findAll) | ✅ |
| `sessions/:id/interventions` | ✅ |
| **`sessions/:id` (findOne)** | ❌ → 403 |

The staging member resolves (via token-exchange) to Tabby role `Editor`, so it can run `call_web_api` and list sessions but 403'd reading a single session. The FE reads that 403 as "session gone → terminated → poll for successor."

## Fix
Add `Editor` to `GET /sessions/:id` `@Roles`, matching every sibling session read. One-line, no behavior change for other roles.

## Note (separate, deployment config)
If members shouldn't be `Editor` at all, the staging Frontegg IdP's `default_role`/`editor_role_values` is mapping them to it — worth reviewing independently. This fix is correct regardless (Editor is a valid role allowed everywhere else).

🤖 Generated with [Claude Code](https://claude.com/claude-code)