### PR TITLE
feat: browser-driven skill reliability and bank-portal hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ docs/zero-to-hero-test-workflow.md
 docs/zero-to-hero-tabby-platform-setup.md
 docs/adopt-org-templates-backup.json
 docs/tabby-platform-setup-consolidation.md
+
+# Local-only Kind secrets override (never commit — real credentials)
+charts/browser-hitl/values-local.secret.yaml

--- a/Makefile
+++ b/Makefile
@@ -260,19 +260,45 @@ kind-guard:
 
 .PHONY: kind-fix-mtu
 kind-fix-mtu: kind-guard ## Fix Kind pod MTU from 65535 to 1500 (prevents TLS failures to external sites)
-	@echo "Patching kindnet MTU to 1500 on all nodes of '$(KIND_CLUSTER)'..."
-	@# kindnet rewrites its conflist on startup, so restart the daemonset FIRST,
-	@# then patch every node's conflist, so the patch is what survives.
+	@echo "Patching kindnet pod MTU to 1500 on all nodes of '$(KIND_CLUSTER)'..."
+	@# Patch ONLY the CNI conflist (pod veth MTU). Do NOT touch the node's own eth0:
+	@# it must keep matching the Docker bridge (`docker network inspect kind` ->
+	@# com.docker.network.driver.mtu, 65535 on Docker Desktop). Lowering the node
+	@# interface while the bridge stays 65535 makes the bridge emit frames the node
+	@# drops, which wedges kubectl port-forward with
+	@#   'error creating error stream ...: Timeout occurred'
+	@# and takes the API/VNC tunnels down with it.
+	@#
+	@# kindnet rewrites the conflist on startup, and does so a moment AFTER the
+	@# daemonset reports Ready — so a patch applied immediately gets clobbered.
+	@# Restart first, then patch, then RE-verify once kindnet has settled, retrying
+	@# before giving up. The previous version verified instantly and printed success
+	@# against a file that was about to be overwritten.
 	kubectl --context $(KIND_CONTEXT) rollout restart daemonset/kindnet -n kube-system
-	kubectl --context $(KIND_CONTEXT) rollout status daemonset/kindnet -n kube-system --timeout=30s
-	@for node in $$(kind get nodes --name $(KIND_CLUSTER)); do \
-		docker exec $$node sh -c '\
-			CNI=/etc/cni/net.d/10-kindnet.conflist; \
-			[ -s "$$CNI" ] && sed -i "s/\"mtu\": *[0-9]*/\"mtu\": 1500/g" "$$CNI"; \
-			grep -q "\"mtu\": 1500" "$$CNI"' \
-			|| { echo "MTU patch did not land on $$node (no \"mtu\" key? kindnet variant changed)"; exit 1; }; \
-	done
-	@echo "MTU set to 1500 on all nodes (verified). Restart pods to pick it up."
+	kubectl --context $(KIND_CONTEXT) rollout status daemonset/kindnet -n kube-system --timeout=60s
+	@ok=0; \
+	for attempt in 1 2 3 4 5; do \
+		for node in $$(kind get nodes --name $(KIND_CLUSTER)); do \
+			docker exec $$node sh -c '\
+				CNI=/etc/cni/net.d/10-kindnet.conflist; \
+				[ -s "$$CNI" ] && sed -i "s/\"mtu\": *[0-9]*/\"mtu\": 1500/g" "$$CNI"; \
+				grep -q "\"mtu\": 1500" "$$CNI"' \
+				|| { echo "MTU patch did not land on $$node (no \"mtu\" key? kindnet variant changed)"; exit 1; }; \
+		done; \
+		sleep 20; \
+		stable=1; \
+		for node in $$(kind get nodes --name $(KIND_CLUSTER)); do \
+			docker exec $$node sh -c 'grep -q "\"mtu\": 1500" /etc/cni/net.d/10-kindnet.conflist' || stable=0; \
+		done; \
+		if [ "$$stable" = "1" ]; then \
+			echo "Pod MTU 1500 verified stable on all nodes (attempt $$attempt)."; ok=1; break; \
+		fi; \
+		echo "kindnet reverted the patch (attempt $$attempt) — retrying..."; \
+	done; \
+	if [ "$$ok" != "1" ]; then echo "MTU patch keeps being reverted by kindnet; aborting."; exit 1; fi
+	@echo "NOTE: kindnet rewrites this on every restart — re-run after one."
+	@echo "Existing pods keep their old MTU — recreate them to pick this up:"
+	@echo "  kubectl --context $(KIND_CONTEXT) rollout restart deploy -n $(HELM_NAMESPACE)"
 
 .PHONY: kind-fix-dns
 kind-fix-dns: kind-guard ## Point CoreDNS at public resolvers (fixes AAAA SERVFAIL from Docker Desktop embedded DNS)
@@ -306,10 +332,10 @@ kind-load-images: ## Load all Docker images into the Kind cluster
 	@echo "Images loaded into Kind cluster '$(KIND_CLUSTER)'"
 
 .PHONY: kind-deploy
-kind-deploy: ## Full local deploy: load images + helm install with local values
+kind-deploy: kind-guard ## Full local deploy: load images + helm install with local values
 	$(MAKE) kind-load-images
-	kubectl create namespace $(HELM_NAMESPACE) --dry-run=client -o yaml | kubectl apply -f -
-	helm upgrade --install $(HELM_RELEASE) charts/browser-hitl/ \
+	kubectl --context $(KIND_CONTEXT) create namespace $(HELM_NAMESPACE) --dry-run=client -o yaml | kubectl --context $(KIND_CONTEXT) apply -f -
+	helm upgrade --install $(HELM_RELEASE) charts/browser-hitl/ --kube-context $(KIND_CONTEXT) \
 		-f charts/browser-hitl/values-local.yaml \
 		--namespace $(HELM_NAMESPACE) \
 		--wait --timeout 5m
@@ -318,36 +344,36 @@ kind-deploy: ## Full local deploy: load images + helm install with local values
 # --- Kind reload shortcuts: build + load + restart a single service ----------
 
 .PHONY: kind-reload-api
-kind-reload-api: docker-build-api ## Rebuild API and reload into Kind
+kind-reload-api: kind-guard docker-build-api ## Rebuild API and reload into Kind
 	kind load docker-image $(IMG_API) --name $(KIND_CLUSTER)
-	helm upgrade $(HELM_RELEASE) charts/browser-hitl/ \
+	helm upgrade $(HELM_RELEASE) charts/browser-hitl/ --kube-context $(KIND_CONTEXT) \
 		-f charts/browser-hitl/values-local.yaml \
 		--namespace $(HELM_NAMESPACE) --reuse-values \
 		--wait --timeout 5m
 	@echo "API reloaded."
 
 .PHONY: kind-reload-controller
-kind-reload-controller: docker-build-controller ## Rebuild controller and reload into Kind
+kind-reload-controller: kind-guard docker-build-controller ## Rebuild controller and reload into Kind
 	kind load docker-image $(IMG_CONTROLLER) --name $(KIND_CLUSTER)
-	helm upgrade $(HELM_RELEASE) charts/browser-hitl/ \
+	helm upgrade $(HELM_RELEASE) charts/browser-hitl/ --kube-context $(KIND_CONTEXT) \
 		-f charts/browser-hitl/values-local.yaml \
 		--namespace $(HELM_NAMESPACE) --reuse-values \
 		--wait --timeout 5m
 	@echo "Controller reloaded."
 
 .PHONY: kind-reload-worker
-kind-reload-worker: docker-build-worker ## Rebuild worker and reload into Kind
+kind-reload-worker: kind-guard docker-build-worker ## Rebuild worker and reload into Kind
 	kind load docker-image $(IMG_WORKER) --name $(KIND_CLUSTER)
-	helm upgrade $(HELM_RELEASE) charts/browser-hitl/ \
+	helm upgrade $(HELM_RELEASE) charts/browser-hitl/ --kube-context $(KIND_CONTEXT) \
 		-f charts/browser-hitl/values-local.yaml \
 		--namespace $(HELM_NAMESPACE) --reuse-values \
 		--wait --timeout 5m
 	@echo "Worker reloaded."
 
 .PHONY: kind-reload-admin-ui
-kind-reload-admin-ui: docker-build-admin-ui ## Rebuild admin-ui and reload into Kind
+kind-reload-admin-ui: kind-guard docker-build-admin-ui ## Rebuild admin-ui and reload into Kind
 	kind load docker-image $(IMG_ADMIN_UI) --name $(KIND_CLUSTER)
-	helm upgrade $(HELM_RELEASE) charts/browser-hitl/ \
+	helm upgrade $(HELM_RELEASE) charts/browser-hitl/ --kube-context $(KIND_CONTEXT) \
 		-f charts/browser-hitl/values-local.yaml \
 		--namespace $(HELM_NAMESPACE) --reuse-values \
 		--wait --timeout 5m
@@ -359,33 +385,33 @@ kind-reload-novnc: docker-build-novnc ## Rebuild noVNC and reload into Kind
 	@echo "noVNC reloaded (sidecar — new worker pods will pick it up)."
 
 .PHONY: kind-reload-all
-kind-reload-all: clean build docker-build ## Clean + build source + images, load into Kind, and upgrade Helm release
+kind-reload-all: kind-guard clean build docker-build ## Clean + build source + images, load into Kind, and upgrade Helm release
 	$(MAKE) kind-load-images
-	helm upgrade --install $(HELM_RELEASE) charts/browser-hitl/ \
+	helm upgrade --install $(HELM_RELEASE) charts/browser-hitl/ --kube-context $(KIND_CONTEXT) \
 		-f charts/browser-hitl/values-local.yaml \
 		--namespace $(HELM_NAMESPACE) --create-namespace \
 		$(HELM_DOTENV_SETS) \
 		--wait --timeout 5m
 	@echo "Force-restarting deployments (image tag :dev never changes, so pods must be bounced)..."
-	kubectl rollout restart deployment \
+	kubectl --context $(KIND_CONTEXT) rollout restart deployment \
 		-l app.kubernetes.io/instance=$(HELM_RELEASE) \
 		-n $(HELM_NAMESPACE)
-	kubectl rollout status deployment \
+	kubectl --context $(KIND_CONTEXT) rollout status deployment \
 		-l app.kubernetes.io/instance=$(HELM_RELEASE) \
 		-n $(HELM_NAMESPACE) \
 		--timeout 3m
 	@echo "All services rebuilt and deployed with local images."
 
 .PHONY: kind-stop
-kind-stop: ## Scale all deployments and statefulsets to 0 replicas (stop pods without deleting)
-	kubectl scale deployment --all --replicas=0 -n $(HELM_NAMESPACE)
-	kubectl scale statefulset --all --replicas=0 -n $(HELM_NAMESPACE)
+kind-stop: kind-guard ## Scale all deployments and statefulsets to 0 replicas (stop pods without deleting)
+	kubectl --context $(KIND_CONTEXT) scale deployment --all --replicas=0 -n $(HELM_NAMESPACE)
+	kubectl --context $(KIND_CONTEXT) scale statefulset --all --replicas=0 -n $(HELM_NAMESPACE)
 	@echo "All pods scaled to 0 in namespace '$(HELM_NAMESPACE)'."
 
 .PHONY: kind-start
-kind-start: ## Scale all deployments and statefulsets back to 1 replica
-	kubectl scale deployment --all --replicas=1 -n $(HELM_NAMESPACE)
-	kubectl scale statefulset --all --replicas=1 -n $(HELM_NAMESPACE)
+kind-start: kind-guard ## Scale all deployments and statefulsets back to 1 replica
+	kubectl --context $(KIND_CONTEXT) scale deployment --all --replicas=1 -n $(HELM_NAMESPACE)
+	kubectl --context $(KIND_CONTEXT) scale statefulset --all --replicas=1 -n $(HELM_NAMESPACE)
 	@echo "All pods scaled to 1 in namespace '$(HELM_NAMESPACE)'."
 
 .PHONY: kind-delete

--- a/Makefile
+++ b/Makefile
@@ -232,6 +232,13 @@ ifneq (,$(wildcard $(DOTENV_FILE)))
   HELM_DOTENV_SETS := $(shell ./scripts/dotenv-to-helm-sets.sh $(DOTENV_FILE))
 endif
 
+# Optional gitignored local secrets override, auto-included in every local helm
+# upgrade when present. A values FILE (not --set) so credentials with dots/braces
+# — e.g. the residential EGRESS_UPSTREAM_PROXY_URL Oxylabs URL with its
+# {sessionId} template — don't trip helm's --set parser. Copy the committed
+# values-local.secret.yaml.example to values-local.secret.yaml and fill it in.
+LOCAL_SECRET_VALUES := $(if $(wildcard charts/browser-hitl/values-local.secret.yaml),-f charts/browser-hitl/values-local.secret.yaml)
+
 KIND_CLUSTER ?= tabby-dev
 
 .PHONY: tilt
@@ -337,6 +344,7 @@ kind-deploy: kind-guard ## Full local deploy: load images + helm install with lo
 	kubectl --context $(KIND_CONTEXT) create namespace $(HELM_NAMESPACE) --dry-run=client -o yaml | kubectl --context $(KIND_CONTEXT) apply -f -
 	helm upgrade --install $(HELM_RELEASE) charts/browser-hitl/ --kube-context $(KIND_CONTEXT) \
 		-f charts/browser-hitl/values-local.yaml \
+		$(LOCAL_SECRET_VALUES) \
 		--namespace $(HELM_NAMESPACE) \
 		--wait --timeout 5m
 	@echo "Stack deployed. Run: kubectl port-forward -n $(HELM_NAMESPACE) svc/$(HELM_RELEASE)-api 18080:8080"
@@ -348,6 +356,7 @@ kind-reload-api: kind-guard docker-build-api ## Rebuild API and reload into Kind
 	kind load docker-image $(IMG_API) --name $(KIND_CLUSTER)
 	helm upgrade $(HELM_RELEASE) charts/browser-hitl/ --kube-context $(KIND_CONTEXT) \
 		-f charts/browser-hitl/values-local.yaml \
+		$(LOCAL_SECRET_VALUES) \
 		--namespace $(HELM_NAMESPACE) --reuse-values \
 		--wait --timeout 5m
 	@echo "API reloaded."
@@ -357,6 +366,7 @@ kind-reload-controller: kind-guard docker-build-controller ## Rebuild controller
 	kind load docker-image $(IMG_CONTROLLER) --name $(KIND_CLUSTER)
 	helm upgrade $(HELM_RELEASE) charts/browser-hitl/ --kube-context $(KIND_CONTEXT) \
 		-f charts/browser-hitl/values-local.yaml \
+		$(LOCAL_SECRET_VALUES) \
 		--namespace $(HELM_NAMESPACE) --reuse-values \
 		--wait --timeout 5m
 	@echo "Controller reloaded."
@@ -366,6 +376,7 @@ kind-reload-worker: kind-guard docker-build-worker ## Rebuild worker and reload 
 	kind load docker-image $(IMG_WORKER) --name $(KIND_CLUSTER)
 	helm upgrade $(HELM_RELEASE) charts/browser-hitl/ --kube-context $(KIND_CONTEXT) \
 		-f charts/browser-hitl/values-local.yaml \
+		$(LOCAL_SECRET_VALUES) \
 		--namespace $(HELM_NAMESPACE) --reuse-values \
 		--wait --timeout 5m
 	@echo "Worker reloaded."
@@ -375,6 +386,7 @@ kind-reload-admin-ui: kind-guard docker-build-admin-ui ## Rebuild admin-ui and r
 	kind load docker-image $(IMG_ADMIN_UI) --name $(KIND_CLUSTER)
 	helm upgrade $(HELM_RELEASE) charts/browser-hitl/ --kube-context $(KIND_CONTEXT) \
 		-f charts/browser-hitl/values-local.yaml \
+		$(LOCAL_SECRET_VALUES) \
 		--namespace $(HELM_NAMESPACE) --reuse-values \
 		--wait --timeout 5m
 	@echo "Admin UI reloaded."
@@ -389,6 +401,7 @@ kind-reload-all: kind-guard clean build docker-build ## Clean + build source + i
 	$(MAKE) kind-load-images
 	helm upgrade --install $(HELM_RELEASE) charts/browser-hitl/ --kube-context $(KIND_CONTEXT) \
 		-f charts/browser-hitl/values-local.yaml \
+		$(LOCAL_SECRET_VALUES) \
 		--namespace $(HELM_NAMESPACE) --create-namespace \
 		$(HELM_DOTENV_SETS) \
 		--wait --timeout 5m

--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ k8s-logs-controller: ## Tail controller logs
 	kubectl logs -n $(HELM_NAMESPACE) -l app.kubernetes.io/component=controller -f --tail=100
 
 .PHONY: k8s-port-forward
-k8s-port-forward: ## Port-forward all services for local development
+k8s-port-forward: kind-guard ## Port-forward all services for local development
 	@echo "API:        http://localhost:18080        (Swagger: http://localhost:18080/api/docs)"
 	@echo "Admin UI:   http://localhost:13000"
 	@echo "PostgreSQL: localhost:25432"
@@ -214,12 +214,12 @@ k8s-port-forward: ## Port-forward all services for local development
 	@echo ""
 	@echo "Stop all: pkill -f 'kubectl port-forward'"
 	@echo ""
-	kubectl port-forward -n $(HELM_NAMESPACE) svc/$(HELM_RELEASE)-api 18080:8000 &
-	kubectl port-forward -n $(HELM_NAMESPACE) svc/$(HELM_RELEASE)-admin-ui 13000:8000 &
-	kubectl port-forward -n $(HELM_NAMESPACE) svc/$(HELM_RELEASE)-postgres 25432:5432 &
-	kubectl port-forward -n $(HELM_NAMESPACE) svc/$(HELM_RELEASE)-redis 16379:6379 &
-	kubectl port-forward -n $(HELM_NAMESPACE) svc/$(HELM_RELEASE)-minio 19000:9000 &
-	kubectl port-forward -n $(HELM_NAMESPACE) svc/$(HELM_RELEASE)-nats 4222:4222 &
+	kubectl --context $(KIND_CONTEXT) port-forward -n $(HELM_NAMESPACE) svc/$(HELM_RELEASE)-api 18080:8000 &
+	kubectl --context $(KIND_CONTEXT) port-forward -n $(HELM_NAMESPACE) svc/$(HELM_RELEASE)-admin-ui 13000:8000 &
+	kubectl --context $(KIND_CONTEXT) port-forward -n $(HELM_NAMESPACE) svc/$(HELM_RELEASE)-postgres 25432:5432 &
+	kubectl --context $(KIND_CONTEXT) port-forward -n $(HELM_NAMESPACE) svc/$(HELM_RELEASE)-redis 16379:6379 &
+	kubectl --context $(KIND_CONTEXT) port-forward -n $(HELM_NAMESPACE) svc/$(HELM_RELEASE)-minio 19000:9000 &
+	kubectl --context $(KIND_CONTEXT) port-forward -n $(HELM_NAMESPACE) svc/$(HELM_RELEASE)-nats 4222:4222 &
 	@wait
 
 # ============================================================

--- a/apps/api/src/modules/agent/agent.service.spec.ts
+++ b/apps/api/src/modules/agent/agent.service.spec.ts
@@ -225,6 +225,28 @@ describe('AgentService', () => {
       });
     });
 
+    it('excludes TERMINATED/FAILED sessions and 404s so the caller provisions fresh', async () => {
+      // Regression: returning the newest session regardless of state handed a
+      // just-expired TERMINATED session back as "current", so the harness minted
+      // a sign-in card pointing at a dead session (the recurring ICICI failure).
+      const credentialsService = createMockCredentialsService();
+      credentialsService.resolveActiveProfile.mockResolvedValue({ app_id: 'app-1' });
+
+      const sessionRepo = createMockSessionRepo();
+      // With the state filter applied, no LIVE session matches → findOne returns null.
+      sessionRepo.findOne.mockResolvedValue(null);
+
+      const { service } = buildService({ sessionRepo, credentialsService });
+
+      await expect(
+        service.getSessionStatus('profile-1', 'tenant-1', [], 'Operator'),
+      ).rejects.toThrow(/No live session/);
+
+      // and the query must carry a state exclusion, not just an order-by.
+      const call = sessionRepo.findOne.mock.calls[0][0];
+      expect(call.where.state).toBeDefined();
+    });
+
     it('falls back to session.pending_input_request when no intervention exists', async () => {
       const credentialsService = createMockCredentialsService();
       credentialsService.resolveActiveProfile.mockResolvedValue({ app_id: 'app-1' });
@@ -362,7 +384,7 @@ describe('AgentService', () => {
 
       await expect(
         service.getSessionStatus(PROFILE_ID, TENANT, [PROFILE_ID], 'Agent', 'user-a'),
-      ).rejects.toThrow('No session found for profile');
+      ).rejects.toThrow(/No .*session found for profile/);
     });
   });
 });

--- a/apps/api/src/modules/agent/agent.service.ts
+++ b/apps/api/src/modules/agent/agent.service.ts
@@ -10,7 +10,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { SessionState, requireEnv, REDIS_KEYS } from '@browser-hitl/shared';
-import { Repository } from 'typeorm';
+import { Repository, Not, In } from 'typeorm';
 import Redis from 'ioredis';
 import { createHash } from 'crypto';
 import { SessionEntity, InterventionEntity } from '../../entities';
@@ -91,14 +91,22 @@ export class AgentService implements OnModuleDestroy {
     if (ownerUserId) {
       where.owner_user_id = ownerUserId;
     }
+    // Prefer a LIVE session. Ordering by started_at alone returns the newest row
+    // regardless of state, so a just-expired TERMINATED/FAILED session is handed
+    // back as "current" — and the harness then mints a sign-in card pointing at a
+    // dead session, so the user clicks the link and lands on "session terminated"
+    // (a recurring ICICI failure). A terminal session is not a usable session:
+    // exclude it so the caller sees "none" and provisions a fresh one instead.
     const session = await this.sessionRepo.findOne({
-      where,
+      where: { ...where, state: Not(In([SessionState.TERMINATED, SessionState.FAILED])) },
       order: { started_at: 'DESC' },
       relations: ['application'],
     });
 
     if (!session) {
-      throw new NotFoundException('No session found for profile');
+      // No live session — the only rows are terminal. Report "none" so the agent
+      // path provisions fresh, rather than surfacing a dead session id.
+      throw new NotFoundException('No live session found for profile');
     }
 
     const hitlActive = session.state === 'LOGIN_IN_PROGRESS' || session.state === 'LOGIN_NEEDED';

--- a/apps/api/src/modules/app-templates/app-templates.service.spec.ts
+++ b/apps/api/src/modules/app-templates/app-templates.service.spec.ts
@@ -77,6 +77,7 @@ function buildService(overrides: {
 } = {}) {
   const templateRepo = overrides.templateRepo ?? {
     findOne: jest.fn().mockResolvedValue(null),
+    findOneOrFail: jest.fn().mockResolvedValue(null),
     find: jest.fn().mockResolvedValue([]),
     create: jest.fn().mockImplementation((d: any) => d),
     save: jest.fn().mockImplementation((d: any) => Promise.resolve({ id: 'tpl-uuid-1', ...d })),
@@ -127,6 +128,7 @@ describe('AppTemplatesService — propagation', () => {
       const { service, templateRepo, appRepo } = buildService({
         templateRepo: {
           findOne: jest.fn().mockResolvedValue(template),
+          findOneOrFail: jest.fn().mockResolvedValue(template),
           save: jest.fn().mockResolvedValue(template),
         },
         appRepo: {
@@ -159,6 +161,7 @@ describe('AppTemplatesService — propagation', () => {
       const { service, appRepo } = buildService({
         templateRepo: {
           findOne: jest.fn().mockResolvedValue(template),
+          findOneOrFail: jest.fn().mockResolvedValue(template),
           save: jest.fn().mockResolvedValue(template),
         },
         appRepo: {
@@ -183,6 +186,7 @@ describe('AppTemplatesService — propagation', () => {
       const { service, appRepo } = buildService({
         templateRepo: {
           findOne: jest.fn().mockResolvedValue(template),
+          findOneOrFail: jest.fn().mockResolvedValue(template),
           save: jest.fn().mockResolvedValue(template),
         },
         appRepo: {
@@ -202,6 +206,7 @@ describe('AppTemplatesService — propagation', () => {
       const { service } = buildService({
         templateRepo: {
           findOne: jest.fn().mockResolvedValue(template),
+          findOneOrFail: jest.fn().mockResolvedValue(template),
           save: jest.fn().mockResolvedValue(template),
         },
         appRepo: {
@@ -230,6 +235,7 @@ describe('AppTemplatesService — propagation', () => {
       const { service } = buildService({
         templateRepo: {
           findOne: jest.fn().mockResolvedValue(template),
+          findOneOrFail: jest.fn().mockResolvedValue(template),
           save: jest.fn().mockResolvedValue(template),
         },
         appRepo: {
@@ -253,6 +259,7 @@ describe('AppTemplatesService — propagation', () => {
       const { service } = buildService({
         templateRepo: {
           findOne: jest.fn().mockResolvedValue(template),
+          findOneOrFail: jest.fn().mockResolvedValue(template),
           save: jest.fn().mockResolvedValue(template),
         },
         appRepo: {
@@ -274,6 +281,7 @@ describe('AppTemplatesService — propagation', () => {
       const { service } = buildService({
         templateRepo: {
           findOne: jest.fn().mockResolvedValue(template),
+          findOneOrFail: jest.fn().mockResolvedValue(template),
           save: jest.fn().mockResolvedValue(template),
         },
         appRepo: {
@@ -313,6 +321,7 @@ describe('AppTemplatesService — propagation', () => {
       const { service } = buildService({
         templateRepo: {
           findOne: jest.fn().mockResolvedValue(template),
+          findOneOrFail: jest.fn().mockResolvedValue(template),
           save: jest.fn().mockResolvedValue(template),
         },
         appRepo: {
@@ -348,6 +357,64 @@ describe('AppTemplatesService — propagation', () => {
       );
     });
 
+    it('propagates full config on a PATCH even though save() returns only the patched fields', async () => {
+      // Regression: repo.save() resolves to an object carrying only the properties it was
+      // handed. On a PATCH that is just the patched field, so propagating from save()'s
+      // return value read login_config as undefined and inserted a profile row with a NULL
+      // login_config — a NOT NULL violation that 500'd the request after appRepo.update()
+      // had already written. The service must propagate from a fresh read instead.
+      const newExportPolicy = {
+        target_domains: ['salesforce.com'],
+        credential_types: { token: 'VOLATILE', headers: ['x-xsrf-token'] },
+      };
+      const template = makeTemplate({ export_policy: newExportPolicy });
+      const existingProfile = makeProfile();
+
+      let managerSave: jest.Mock;
+      const dataSource = {
+        transaction: jest.fn().mockImplementation(async (cb: any) => {
+          managerSave = jest.fn().mockResolvedValue({});
+          return cb({ update: jest.fn().mockResolvedValue(undefined), save: managerSave });
+        }),
+      };
+
+      const appRepo = {
+        find: jest.fn().mockResolvedValue([{ id: 'app-1' }]),
+        update: jest.fn().mockResolvedValue(undefined),
+      };
+
+      const { service } = buildService({
+        templateRepo: {
+          findOne: jest.fn().mockResolvedValue(template),
+          // Fresh read after save — carries every column.
+          findOneOrFail: jest.fn().mockResolvedValue(template),
+          // Mimics real TypeORM: resolves to just what the PATCH handed it.
+          save: jest.fn().mockResolvedValue({ export_policy: newExportPolicy }),
+        },
+        appRepo,
+        profileRepo: { find: jest.fn().mockResolvedValue([existingProfile]) },
+        dataSource,
+      });
+
+      await service.update('tenant-1', 'tpl-uuid-1', { export_policy: newExportPolicy }, 'actor-1');
+
+      // The new profile row must carry the template's real login_config, never undefined.
+      expect(managerSave!).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({
+          login_config: template.login_config,
+          credential_types: newExportPolicy.credential_types,
+          target_domains: newExportPolicy.target_domains,
+        }),
+      );
+
+      // And the linked app must not be handed an undefined login_config either.
+      expect(appRepo.update).toHaveBeenCalledWith(
+        'app-1',
+        expect.objectContaining({ login_config: template.login_config }),
+      );
+    });
+
     it('does not create a new profile version when only browser_policy changes', async () => {
       const template = makeTemplate({ browser_policy: { downloads: true, clipboard: false, file_chooser: false } });
       // Profile fields match the template exactly
@@ -362,6 +429,7 @@ describe('AppTemplatesService — propagation', () => {
       const { service } = buildService({
         templateRepo: {
           findOne: jest.fn().mockResolvedValue(template),
+          findOneOrFail: jest.fn().mockResolvedValue(template),
           save: jest.fn().mockResolvedValue(template),
         },
         appRepo: {
@@ -388,6 +456,7 @@ describe('AppTemplatesService — propagation', () => {
       const { service } = buildService({
         templateRepo: {
           findOne: jest.fn().mockResolvedValue(template),
+          findOneOrFail: jest.fn().mockResolvedValue(template),
           save: jest.fn().mockResolvedValue(template),
         },
         appRepo: {
@@ -430,6 +499,7 @@ describe('AppTemplatesService — propagation', () => {
       const { service } = buildService({
         templateRepo: {
           findOne: jest.fn().mockResolvedValue(template),
+          findOneOrFail: jest.fn().mockResolvedValue(template),
           save: jest.fn().mockResolvedValue(template),
         },
         appRepo: {
@@ -467,6 +537,7 @@ describe('AppTemplatesService — propagation', () => {
       const { service } = buildService({
         templateRepo: {
           findOne: jest.fn().mockResolvedValue(template),
+          findOneOrFail: jest.fn().mockResolvedValue(template),
           save: jest.fn().mockResolvedValue(template),
         },
         appRepo: {
@@ -497,6 +568,7 @@ describe('AppTemplatesService — propagation', () => {
       const { service } = buildService({
         templateRepo: {
           findOne: jest.fn().mockResolvedValue(template),
+          findOneOrFail: jest.fn().mockResolvedValue(template),
           save: jest.fn().mockResolvedValue(template),
         },
         appRepo: {
@@ -529,6 +601,7 @@ describe('AppTemplatesService — propagation', () => {
       const { service } = buildService({
         templateRepo: {
           findOne: jest.fn().mockResolvedValue(template),
+          findOneOrFail: jest.fn().mockResolvedValue(template),
           save: jest.fn().mockResolvedValue(template),
         },
         appRepo: {

--- a/apps/api/src/modules/app-templates/app-templates.service.ts
+++ b/apps/api/src/modules/app-templates/app-templates.service.ts
@@ -69,7 +69,16 @@ export class AppTemplatesService {
   async update(tenantId: string | undefined, id: string, data: Partial<AppTemplateEntity>, actorId: string) {
     const template = await this.findOne(tenantId, id);
     Object.assign(template, data);
-    const saved = await this.templateRepo.save(template);
+    await this.templateRepo.save(template);
+
+    // Re-read the persisted row instead of propagating from save()'s return value.
+    // save() resolves to an object carrying only the properties it was handed, so on a
+    // PATCH it comes back holding just the patched fields. Propagation then reads
+    // template.login_config as undefined and inserts a profile row with a NULL
+    // login_config, which trips the NOT NULL constraint and 500s the whole request —
+    // after appRepo.update() has already written, leaving a partial update behind.
+    // A fresh read guarantees every PROPAGATED_FIELD is present regardless of payload shape.
+    const saved = await this.templateRepo.findOneOrFail({ where: { id: template.id } });
 
     await this.auditService.log({
       tenant_id: template.tenant_id,

--- a/apps/api/src/modules/artifacts/minio-orphan-sweep.service.spec.ts
+++ b/apps/api/src/modules/artifacts/minio-orphan-sweep.service.spec.ts
@@ -176,4 +176,39 @@ describe('MinioOrphanSweepService', () => {
     expect(minioClient.bucketExists).not.toHaveBeenCalled();
     expect(minioClient.removeObjects).not.toHaveBeenCalled();
   });
+
+  it('never deletes recording bundles, even with no DB row and well past the cutoff', async () => {
+    // Recordings share the bucket but are not artifact bundles: RecordingStore
+    // writes them with no artifact_bundles row, so without the prefix skip the
+    // DB-row check classifies every recording as an orphan and deletes it after
+    // ~2h — which silently GC'd captured logins before capture_import ran.
+    const oldDate = new Date(Date.now() - 48 * 60 * 60 * 1000); // 2 days ago
+    const objects = [
+      { name: 'recordings/sess-abc.json.enc', lastModified: oldDate },
+      { name: 'some-real-orphan', lastModified: oldDate },
+    ];
+    const minioClient = makeMockMinioClient({ objects });
+    const tenantRepo = makeMockTenantRepo([{ id: 'tenant-1' }]);
+    const artifactRepo = makeMockArtifactRepo(null); // no rows for anything
+    const provisioner = makeMockProvisioner(minioClient);
+
+    const service = new MinioOrphanSweepService(
+      provisioner as any,
+      artifactRepo as any,
+      tenantRepo as any,
+    );
+
+    await service.sweepOrphans();
+
+    // The real orphan is removed; the recording is spared.
+    expect(minioClient.removeObjects).toHaveBeenCalledWith('artifact-bundles-tenant-1', [
+      'some-real-orphan',
+    ]);
+    // And the recording key was never even DB-checked (skipped before the query).
+    expect(artifactRepo.findOne).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ encrypted_payload_ref: 'recordings/sess-abc.json.enc' }),
+      }),
+    );
+  });
 });

--- a/apps/api/src/modules/artifacts/minio-orphan-sweep.service.ts
+++ b/apps/api/src/modules/artifacts/minio-orphan-sweep.service.ts
@@ -40,6 +40,14 @@ export class MinioOrphanSweepService {
 
         for await (const obj of stream) {
           if (!obj.lastModified || obj.lastModified >= cutoff) continue;
+          // Recording bundles share this bucket but are NOT artifact bundles:
+          // RecordingStore writes them via a bare putObject and creates no
+          // artifact_bundles row, so the DB-row check below would classify every
+          // recording as an orphan and delete it after MINIO_ORPHAN_MAX_AGE_HOURS
+          // (default 2h). That silently GC'd captured login recordings before
+          // capture_import could compile them. The sweep only owns credential
+          // artifact bundles; skip the recordings/ prefix entirely.
+          if ((obj.name as string).startsWith('recordings/')) continue;
           // Check if DB row exists
           const dbRow = await this.artifactRepo.findOne({
             where: { encrypted_payload_ref: obj.name, tenant_id: tenant.id },

--- a/apps/api/src/modules/streaming/streaming.controller.spec.ts
+++ b/apps/api/src/modules/streaming/streaming.controller.spec.ts
@@ -112,6 +112,20 @@ describe('StreamingController — panel-state', () => {
     expect(result.app_id).toBe('app-1');
   });
 
+  it('viewer panels render a human health label, never the raw enum', () => {
+    // AUTH_FAIL on a fresh session is EXPECTED (it drives STARTING ->
+    // LOGIN_NEEDED), so showing the raw enum made a normal sign-in look like a
+    // failure. Both viewers (VNC + CDP) must go through healthLabel().
+    const source = require('fs').readFileSync(
+      require('path').join(__dirname, 'streaming.controller.ts'),
+      'utf-8',
+    );
+    expect(source).not.toContain("stHealth.textContent = data.health_result_type");
+    const calls = source.split('stHealth.textContent = healthLabel(data.state, data.health_result_type)').length - 1;
+    expect(calls).toBe(2); // VNC + CDP viewers
+    expect(source).toContain("'Awaiting sign-in'");
+  });
+
   it('throws UnauthorizedException when token is missing', async () => {
     await expect(controller.getPanelState('sess-1', undefined)).rejects.toThrow(UnauthorizedException);
   });

--- a/apps/api/src/modules/streaming/streaming.controller.spec.ts
+++ b/apps/api/src/modules/streaming/streaming.controller.spec.ts
@@ -121,9 +121,57 @@ describe('StreamingController — panel-state', () => {
       'utf-8',
     );
     expect(source).not.toContain("stHealth.textContent = data.health_result_type");
-    const calls = source.split('stHealth.textContent = healthLabel(data.state, data.health_result_type)').length - 1;
+    const calls = source.split(
+      'stHealth.textContent = healthLabel(data.state, data.health_result_type, recordingMode)',
+    ).length - 1;
     expect(calls).toBe(2); // VNC + CDP viewers
     expect(source).toContain("'Awaiting sign-in'");
+  });
+
+  it('does not claim "Signed in" for a recording session', () => {
+    // Recording sessions suppress health predicates and the worker stamps PASS once
+    // the browser is up, so PASS carries no auth meaning there. Reporting it as
+    // "Signed in" told users they were authenticated before they had typed anything —
+    // on a page that had not even loaded. Both viewers must pass their recordingMode
+    // flag through so the label can say so.
+    const source = require('fs').readFileSync(
+      require('path').join(__dirname, 'streaming.controller.ts'),
+      'utf-8',
+    );
+
+    // The guard must precede the unconditional PASS branch, or it never runs.
+    const recordingBranch = source.indexOf("if (recording && health === 'PASS')");
+    const passBranch = source.indexOf("if (health === 'PASS') return 'Signed in';");
+    expect(recordingBranch).toBeGreaterThan(-1);
+    expect(passBranch).toBeGreaterThan(-1);
+    expect(recordingBranch).toBeLessThan(passBranch);
+
+    // Both viewers must actually declare the flag they pass in.
+    const decls = source.split(
+      "var recordingMode = new URLSearchParams(window.location.search).get('mode') === 'recording';",
+    ).length - 1;
+    expect(decls).toBe(2);
+  });
+
+  it('healthLabel reports recording sessions as unchecked, not signed in', () => {
+    // Execute the real injected helper rather than asserting on source text, so a
+    // future edit to the branch logic is caught behaviourally.
+    const source = require('fs').readFileSync(
+      require('path').join(__dirname, 'streaming.controller.ts'),
+      'utf-8',
+    );
+    const body = source.match(/function healthLabel\(state, health, recording\) \{[\s\S]*?\n {8}\}/);
+    expect(body).not.toBeNull();
+    // eslint-disable-next-line no-new-func
+    const healthLabel = new Function(`${body![0]}; return healthLabel;`)() as
+      (state: string, health: string | null, recording?: boolean) => string;
+
+    expect(healthLabel('HEALTHY', 'PASS', true)).toBe('Not checked');
+    expect(healthLabel('HEALTHY', 'PASS', false)).toBe('Signed in');
+    expect(healthLabel('HEALTHY', 'PASS')).toBe('Signed in'); // non-recording viewers unchanged
+    // Real failures still surface while recording.
+    expect(healthLabel('LOGIN_NEEDED', 'AUTH_FAIL', true)).toBe('Awaiting sign-in');
+    expect(healthLabel('HEALTHY', 'AUTH_FAIL', true)).toBe('Sign-in required');
   });
 
   it('throws UnauthorizedException when token is missing', async () => {

--- a/apps/api/src/modules/streaming/streaming.controller.ts
+++ b/apps/api/src/modules/streaming/streaming.controller.ts
@@ -28,7 +28,7 @@ import { RecordingStore } from '../recording/recording.store';
 import { AppsService } from '../apps/apps.service';
 import { Request, Response } from 'express';
 import { readFile } from 'node:fs/promises';
-import { resolve as resolvePath } from 'node:path';
+import { resolve as resolvePath, relative as relativePath, isAbsolute } from 'node:path';
 import { randomUUID, randomBytes } from 'crypto';
 import { Not, IsNull, MoreThan } from 'typeorm';
 import { Throttle, SkipThrottle } from '@nestjs/throttler';
@@ -2100,10 +2100,15 @@ ${HEALTH_LABEL_JS}
       // @novnc/novnc dependency is therefore not usable here.
       //
       // assetPath is validated by normalizeNoVncAssetPath (no '..', restricted charset)
-      // before it reaches this join.
-      const vendoredPath = resolvePath(
-        StreamingController.noVncVendorRoot, section, assetPath,
-      );
+      // before it reaches this join. Defense-in-depth: confirm the resolved file
+      // stays under the vendored root/section before reading it, so a future change
+      // to the validator can't reopen a path-traversal read.
+      const base = resolvePath(StreamingController.noVncVendorRoot, section);
+      const vendoredPath = resolvePath(base, assetPath);
+      const rel = relativePath(base, vendoredPath);
+      if (rel.startsWith('..') || isAbsolute(rel)) {
+        throw new NotFoundException('Invalid noVNC asset path');
+      }
       const body = await readFile(vendoredPath, 'utf8');
       return {
         body,

--- a/apps/api/src/modules/streaming/streaming.controller.ts
+++ b/apps/api/src/modules/streaming/streaming.controller.ts
@@ -28,6 +28,7 @@ import { RecordingStore } from '../recording/recording.store';
 import { AppsService } from '../apps/apps.service';
 import { Request, Response } from 'express';
 import { readFile } from 'node:fs/promises';
+import { resolve as resolvePath } from 'node:path';
 import { randomUUID, randomBytes } from 'crypto';
 import { Not, IsNull, MoreThan } from 'typeorm';
 import { Throttle, SkipThrottle } from '@nestjs/throttler';
@@ -49,13 +50,24 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
  * like a failure. Map the enum to plain language, using the session state for
  * context so AUTH_FAIL only reads as a problem when it genuinely is one.
  *
+ * `recording` is required for the same reason in reverse: a recording session
+ * never runs a health check, so its PASS is not evidence of anything and must
+ * not be dressed up as "Signed in".
+ *
  * Written as a JS string interpolated into the templates so the two viewers
  * cannot drift apart. Must not contain `${` — the templates are TS template
  * literals.
  */
 const HEALTH_LABEL_JS = `
-        function healthLabel(state, health) {
+        function healthLabel(state, health, recording) {
           if (!health) return state === 'STARTING' ? 'Starting…' : '—';
+          // Recording sessions suppress keepalive actions and health predicates while a
+          // human drives, and the worker stamps PASS once the browser is up (see
+          // apps/worker/src/main.ts, recording branch). That PASS says "recorder
+          // attached", NOT "authenticated" — reporting it as "Signed in" told the user
+          // they were logged in before they had typed anything, on a page that had not
+          // even loaded. Nothing is evaluated here, so say exactly that.
+          if (recording && health === 'PASS') return 'Not checked';
           if (health === 'PASS') return 'Signed in';
           if (health === 'TRANSIENT_FAIL') return 'Checking…';
           if (health === 'AUTH_FAIL') {
@@ -928,7 +940,7 @@ ${HEALTH_LABEL_JS}
             .then(function(data) {
               if (!data) return;
               stState.textContent = data.state || '—';
-              stHealth.textContent = healthLabel(data.state, data.health_result_type);
+              stHealth.textContent = healthLabel(data.state, data.health_result_type, recordingMode);
               stInterventions.textContent = data.intervention_count != null ? String(data.intervention_count) : '—';
               stRetries.textContent = data.retry_count != null ? String(data.retry_count) : '—';
               if (data.started_at) {
@@ -1080,6 +1092,16 @@ ${HEALTH_LABEL_JS}
 @Controller('vnc')
 export class StreamingController {
   private static readonly noVncAssetCache = new Map<string, { body: string; contentType: string }>();
+  /**
+   * Where the noVNC ES-module tree lives inside the image. Dockerfile.api vendors
+   * GitHub's `core/` + `vendor/` here at build time so the viewer does not need
+   * outbound internet to load its client. Absent (e.g. running from a source
+   * checkout), asset loads fall back to the CDN below.
+   */
+  private static readonly noVncVendorRoot =
+    process.env.NOVNC_VENDOR_ROOT || resolvePath(process.cwd(), 'vendor/novnc');
+
+  /** Fallback only — see noVncVendorRoot. Keep the version in step with Dockerfile.api. */
   private static readonly noVncRootBaseUrl = 'https://cdn.jsdelivr.net/gh/novnc/noVNC@v1.5.0';
 
   constructor(
@@ -1820,7 +1842,7 @@ ${HEALTH_LABEL_JS}
             .then(function(data) {
               if (!data) return;
               stState.textContent = data.state || '—';
-              stHealth.textContent = healthLabel(data.state, data.health_result_type);
+              stHealth.textContent = healthLabel(data.state, data.health_result_type, recordingMode);
               stInterventions.textContent = data.intervention_count != null ? String(data.intervention_count) : '—';
               stRetries.textContent = data.retry_count != null ? String(data.retry_count) : '—';
               if (data.started_at) {
@@ -2067,8 +2089,22 @@ ${HEALTH_LABEL_JS}
     assetPath: string,
   ): Promise<{ body: string; contentType: string }> {
     try {
-      const modulePath = require.resolve(`@novnc/novnc/${section}/${assetPath}`);
-      const body = await readFile(modulePath, 'utf8');
+      // Serve the copy vendored into the image at build time (Dockerfile.api pulls the
+      // GitHub tree, which is what noVncRootBaseUrl points at).
+      //
+      // Do NOT swap this for `require.resolve('@novnc/novnc/...')`. The npm package
+      // publishes only `lib/`, and that build is CommonJS — Babel-transpiled, with
+      // `require()` and no `import`/`export`. The viewer loads the client with
+      // `import RFB from '/vnc/assets/rfb.js'`, so a browser ES-module import of those
+      // files fails outright; only the GitHub `core/` tree is ESM. The declared
+      // @novnc/novnc dependency is therefore not usable here.
+      //
+      // assetPath is validated by normalizeNoVncAssetPath (no '..', restricted charset)
+      // before it reaches this join.
+      const vendoredPath = resolvePath(
+        StreamingController.noVncVendorRoot, section, assetPath,
+      );
+      const body = await readFile(vendoredPath, 'utf8');
       return {
         body,
         contentType: this.resolveNoVncAssetContentType(assetPath),

--- a/apps/api/src/modules/streaming/streaming.controller.ts
+++ b/apps/api/src/modules/streaming/streaming.controller.ts
@@ -2088,6 +2088,16 @@ ${HEALTH_LABEL_JS}
     section: 'core' | 'vendor',
     assetPath: string,
   ): Promise<{ body: string; contentType: string }> {
+    // Resolve + contain BEFORE the try. Inside it, the bare `catch` below would
+    // swallow the rejection and then fetch the same unvalidated path from the
+    // public CDN — the guard would re-route rather than deny.
+    const base = resolvePath(StreamingController.noVncVendorRoot, section);
+    const vendoredPath = resolvePath(base, assetPath);
+    const rel = relativePath(base, vendoredPath);
+    if (rel.startsWith('..') || isAbsolute(rel)) {
+      throw new NotFoundException('Invalid noVNC asset path');
+    }
+
     try {
       // Serve the copy vendored into the image at build time (Dockerfile.api pulls the
       // GitHub tree, which is what noVncRootBaseUrl points at).
@@ -2103,18 +2113,17 @@ ${HEALTH_LABEL_JS}
       // before it reaches this join. Defense-in-depth: confirm the resolved file
       // stays under the vendored root/section before reading it, so a future change
       // to the validator can't reopen a path-traversal read.
-      const base = resolvePath(StreamingController.noVncVendorRoot, section);
-      const vendoredPath = resolvePath(base, assetPath);
-      const rel = relativePath(base, vendoredPath);
-      if (rel.startsWith('..') || isAbsolute(rel)) {
-        throw new NotFoundException('Invalid noVNC asset path');
-      }
       const body = await readFile(vendoredPath, 'utf8');
       return {
         body,
         contentType: this.resolveNoVncAssetContentType(assetPath),
       };
     } catch {
+      // The Dockerfile vendors noVNC so the viewer needs no outbound internet;
+      // falling back to the CDN silently defeats that, so say it happened.
+      console.warn(
+        `noVNC asset ${section}/${assetPath} not in the vendored tree — falling back to the CDN`,
+      );
       const upstream = await fetch(`${StreamingController.noVncRootBaseUrl}/${section}/${assetPath}`);
       if (!upstream.ok) {
         if (upstream.status === 404) {

--- a/apps/api/src/modules/streaming/streaming.controller.ts
+++ b/apps/api/src/modules/streaming/streaming.controller.ts
@@ -40,6 +40,36 @@ const PUBLIC_BASE_URL = (process.env.PUBLIC_BASE_URL || 'http://localhost:18080'
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
+ * Browser-side helper injected into both viewer templates (VNC + CDP).
+ *
+ * The status panel used to print the raw `health_result_type` enum. That reads
+ * as an error to a human — but AUTH_FAIL on a fresh session is the EXPECTED
+ * signal (it is what drives STARTING -> LOGIN_NEEDED, i.e. "not signed in
+ * yet"), so users opening the viewer to sign in were greeted by what looked
+ * like a failure. Map the enum to plain language, using the session state for
+ * context so AUTH_FAIL only reads as a problem when it genuinely is one.
+ *
+ * Written as a JS string interpolated into the templates so the two viewers
+ * cannot drift apart. Must not contain `${` — the templates are TS template
+ * literals.
+ */
+const HEALTH_LABEL_JS = `
+        function healthLabel(state, health) {
+          if (!health) return state === 'STARTING' ? 'Starting…' : '—';
+          if (health === 'PASS') return 'Signed in';
+          if (health === 'TRANSIENT_FAIL') return 'Checking…';
+          if (health === 'AUTH_FAIL') {
+            // Expected while the human is being asked to sign in.
+            if (state === 'LOGIN_NEEDED' || state === 'LOGIN_IN_PROGRESS' || state === 'STARTING') {
+              return 'Awaiting sign-in';
+            }
+            return 'Sign-in required';
+          }
+          return health;
+        }
+`;
+
+/**
  * Resolve the email the gate should match for a session owner.
  *
  * owner_user_id is a users.id uuid for password/OAuth users, but
@@ -887,7 +917,7 @@ export class CdpStreamingController {
         var restartConfirm = document.getElementById('restart-confirm');
         var restartYes = document.getElementById('restart-yes');
         var tokenExpired = false;
-
+${HEALTH_LABEL_JS}
         function poll() {
           if (sessionTerminated || tokenExpired || !TOKEN) return;
           fetch('/vnc/' + SESSION_ID + '/panel-state?token=' + encodeURIComponent(TOKEN))
@@ -898,7 +928,7 @@ export class CdpStreamingController {
             .then(function(data) {
               if (!data) return;
               stState.textContent = data.state || '—';
-              stHealth.textContent = data.health_result_type || '—';
+              stHealth.textContent = healthLabel(data.state, data.health_result_type);
               stInterventions.textContent = data.intervention_count != null ? String(data.intervention_count) : '—';
               stRetries.textContent = data.retry_count != null ? String(data.retry_count) : '—';
               if (data.started_at) {
@@ -1779,6 +1809,7 @@ export class StreamingController {
         var tokenExpired = false;
 
         // ── Poll panel-state ──────────────────────────────────────────────────
+${HEALTH_LABEL_JS}
         function poll() {
           if (sessionTerminated || tokenExpired || !TOKEN) return;
           fetch('/vnc/' + SESSION_ID + '/panel-state?token=' + encodeURIComponent(TOKEN))
@@ -1789,7 +1820,7 @@ export class StreamingController {
             .then(function(data) {
               if (!data) return;
               stState.textContent = data.state || '—';
-              stHealth.textContent = data.health_result_type || '—';
+              stHealth.textContent = healthLabel(data.state, data.health_result_type);
               stInterventions.textContent = data.intervention_count != null ? String(data.intervention_count) : '—';
               stRetries.textContent = data.retry_count != null ? String(data.retry_count) : '—';
               if (data.started_at) {

--- a/apps/controller/src/reconcile.service.spec.ts
+++ b/apps/controller/src/reconcile.service.spec.ts
@@ -395,6 +395,77 @@ describe('ReconcileService DISABLE_NETWORK_POLICY', () => {
 });
 
 // ---------------------------------------------------------------------------
+// reconcileApp capacity — FAILED sessions must not occupy the app's slot
+// ---------------------------------------------------------------------------
+
+describe('ReconcileService reconcileApp capacity', () => {
+  const originalEnv = { ...process.env };
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  function makeApp(overrides: Record<string, any> = {}) {
+    return {
+      id: 'app-1',
+      tenant_id: 'tenant-1',
+      name: 'some-app',
+      target_urls: ['https://example.com'],
+      desired_session_count: 1,
+      browser_policy: {},
+      extra_egress_allowlist: [],
+      ...overrides,
+    };
+  }
+
+  it('creates a replacement when the only session is FAILED (FAILED is not live capacity)', async () => {
+    // The core of the incident: desired=1 with a single FAILED session. The old
+    // code counted FAILED as occupying the slot (actual=1==desired) and never
+    // provisioned a replacement, so on-demand provisioning silently no-op'd for
+    // the whole cleanup window. FAILED must not count → a fresh session is made.
+    const failed = {
+      id: 'failed-1', app_id: 'app-1', tenant_id: 'tenant-1',
+      state: 'FAILED', pod_name: null, started_at: new Date(),
+    };
+    const sessionRepo = {
+      find: jest.fn().mockResolvedValue([failed]),
+      count: jest.fn().mockResolvedValue(0),
+      update: jest.fn(),
+    };
+    const service = buildService({ sessionRepo });
+    jest.spyOn(service as any, 'isProvisioningCircuitOpen').mockResolvedValue(false);
+    const createSpy = jest
+      .spyOn(service as any, 'createSession')
+      .mockResolvedValue(undefined);
+
+    await (service as any).reconcileApp(makeApp());
+
+    expect(createSpy).toHaveBeenCalledTimes(1); // one replacement for the dead slot
+  });
+
+  it('does NOT create when the circuit breaker is open, even with only a FAILED session', async () => {
+    // Fix A relies on the breaker to bound retries when replacements keep failing.
+    const failed = {
+      id: 'failed-1', app_id: 'app-1', tenant_id: 'tenant-1',
+      state: 'FAILED', pod_name: null, started_at: new Date(),
+    };
+    const sessionRepo = {
+      find: jest.fn().mockResolvedValue([failed]),
+      count: jest.fn().mockResolvedValue(0),
+      update: jest.fn(),
+    };
+    const service = buildService({ sessionRepo });
+    jest.spyOn(service as any, 'isProvisioningCircuitOpen').mockResolvedValue(true);
+    const createSpy = jest
+      .spyOn(service as any, 'createSession')
+      .mockResolvedValue(undefined);
+
+    await (service as any).reconcileApp(makeApp());
+
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // checkRecycling — idle shutdown + FAILED session cleanup
 // ---------------------------------------------------------------------------
 
@@ -424,7 +495,7 @@ describe('ReconcileService checkRecycling', () => {
   function buildForRecycling() {
     const sessionRepo = {
       find: jest.fn(),
-      count: jest.fn(),
+      count: jest.fn().mockResolvedValue(0), // default: no other live session for the app
       update: jest.fn(),
     };
     const appRepo = { update: jest.fn(), find: jest.fn(), findByIds: jest.fn().mockResolvedValue([]) };
@@ -443,23 +514,73 @@ describe('ReconcileService checkRecycling', () => {
     return { service, sessionRepo, appRepo, stateMachine, podManager };
   }
 
-  it('terminates FAILED sessions older than half the idle TTL and zeroes desired_session_count', async () => {
+  it('terminates FAILED sessions older than half the idle TTL and, when the app is idle, zeroes desired_session_count', async () => {
     process.env = { ...originalEnv, IDLE_SHUTDOWN_SECONDS: '120', MAX_SESSION_AGE_HOURS: '24' };
     const { service, sessionRepo, appRepo, stateMachine } = buildForRecycling();
 
     const failed = makeSession({
       id: 'failed-1',
       state: 'FAILED',
-      started_at: new Date(Date.now() - 120_000),
+      started_at: new Date(Date.now() - 120_000), // last used 120s ago >= idle threshold → idle
     });
     sessionRepo.find
       .mockResolvedValueOnce([])       // HEALTHY
       .mockResolvedValueOnce([failed]); // FAILED
+    sessionRepo.count.mockResolvedValue(0); // no other live session for the app
 
     await (service as any).checkRecycling();
 
     expect(appRepo.update).toHaveBeenCalledWith('app-1', { desired_session_count: 0 });
     expect(stateMachine.transition).toHaveBeenCalledWith(failed, expect.anything());
+  });
+
+  it('reaps a FAILED session WITHOUT zeroing desired when the app has recent demand', async () => {
+    // The incident this fixes: a user is actively driving the app, its session
+    // fails (e.g. bank session expired), and the old code zeroed desired on
+    // cleanup — so the user's next call found no session and no way to make one.
+    // With recent activity, cleanup must reap the corpse but leave desired so
+    // reconcile provisions a fresh session for the waiting user.
+    process.env = { ...originalEnv, IDLE_SHUTDOWN_SECONDS: '600', MAX_SESSION_AGE_HOURS: '24' };
+    const { service, sessionRepo, appRepo, stateMachine } = buildForRecycling();
+
+    const failed = makeSession({
+      id: 'failed-active',
+      state: 'FAILED',
+      started_at: new Date(Date.now() - 400_000), // old enough to reap (> 300s half-TTL)
+      last_activity_at: new Date(Date.now() - 5_000), // but used 5s ago → recent demand
+    });
+    sessionRepo.find
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([failed]);
+    sessionRepo.count.mockResolvedValue(0);
+
+    await (service as any).checkRecycling();
+
+    expect(stateMachine.transition).toHaveBeenCalledWith(failed, expect.anything()); // corpse reaped
+    expect(appRepo.update).not.toHaveBeenCalled(); // but desired preserved
+  });
+
+  it('reaps a FAILED session WITHOUT zeroing desired when the app still has a live session', async () => {
+    // A replacement session already came up (reconcile created it because FAILED
+    // no longer counts as capacity). Reaping the old corpse must not scale the
+    // app to 0 — that would kill the live replacement.
+    process.env = { ...originalEnv, IDLE_SHUTDOWN_SECONDS: '120', MAX_SESSION_AGE_HOURS: '24' };
+    const { service, sessionRepo, appRepo, stateMachine } = buildForRecycling();
+
+    const failed = makeSession({
+      id: 'failed-with-replacement',
+      state: 'FAILED',
+      started_at: new Date(Date.now() - 120_000), // idle by activity, but…
+    });
+    sessionRepo.find
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([failed]);
+    sessionRepo.count.mockResolvedValue(1); // …a live replacement exists
+
+    await (service as any).checkRecycling();
+
+    expect(stateMachine.transition).toHaveBeenCalledWith(failed, expect.anything());
+    expect(appRepo.update).not.toHaveBeenCalled();
   });
 
   it('leaves FAILED sessions younger than half TTL alone', async () => {

--- a/apps/controller/src/reconcile.service.spec.ts
+++ b/apps/controller/src/reconcile.service.spec.ts
@@ -660,3 +660,145 @@ describe('ReconcileService checkRecycling', () => {
     expect(stateMachine.transition).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// FAILED sessions must give their pod back immediately
+// ---------------------------------------------------------------------------
+
+describe('ReconcileService FAILED session runtime reap', () => {
+  const originalEnv = { ...process.env };
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  function makeFailedApp() {
+    return {
+      id: 'app-f',
+      tenant_id: 'tenant-f',
+      desired_session_count: 1,
+      target_urls: ['https://example.com'],
+      extra_egress_allowlist: [],
+      execute_enabled: false,
+      residential_proxy_enabled: false,
+      browser_policy: {},
+      export_policy: {},
+    };
+  }
+
+  function podManagerMock() {
+    return {
+      createWorkerPod: jest.fn().mockResolvedValue('pod-new'),
+      createNoVncService: jest.fn().mockResolvedValue(undefined),
+      createCdpService: jest.fn().mockResolvedValue(undefined),
+      createWorkerService: jest.fn().mockResolvedValue(undefined),
+      createNetworkPolicy: jest.fn().mockResolvedValue(undefined),
+      syncEgressAllowlist: jest.fn().mockResolvedValue(undefined),
+      deleteWorkerPod: jest.fn().mockResolvedValue(undefined),
+      deleteNoVncService: jest.fn().mockResolvedValue(undefined),
+      deleteCdpService: jest.fn().mockResolvedValue(undefined),
+      deleteWorkerService: jest.fn().mockResolvedValue(undefined),
+      deleteNetworkPolicy: jest.fn().mockResolvedValue(undefined),
+      listWorkerPods: jest.fn().mockResolvedValue([]),
+      podExists: jest.fn().mockResolvedValue(true),
+      resolveStreamingMode: jest.fn().mockReturnValue('vnc'),
+    };
+  }
+
+  it('deletes the pod of a FAILED session with IDLE_SHUTDOWN disabled (the default)', async () => {
+    // The FAILED-cleanup pass is gated on IDLE_SHUTDOWN_SECONDS, which defaults
+    // to 0 — so without this reap the pod outlives the session forever while
+    // reconcile creates replacements on top of it (one leaked pod per failure).
+    process.env = { ...originalEnv, IDLE_SHUTDOWN_SECONDS: '0' };
+
+    const failed = {
+      id: 'sess-failed',
+      tenant_id: 'tenant-f',
+      app_id: 'app-f',
+      state: 'FAILED',
+      pod_name: 'worker-sess-failed',
+      started_at: new Date(),
+    };
+    const sessionRepo = {
+      find: jest.fn().mockResolvedValue([failed]),
+      count: jest.fn().mockResolvedValue(0),
+      update: jest.fn().mockResolvedValue(undefined),
+      create: jest.fn().mockImplementation((v: any) => v),
+      save: jest.fn().mockImplementation(async (v: any) => ({ id: 'sess-new', ...v })),
+    };
+    const podManager = podManagerMock();
+    const batonRepo = {
+      create: jest.fn().mockImplementation((v: any) => v),
+      save: jest.fn().mockResolvedValue({}),
+    };
+    const service = buildService({ sessionRepo, podManager, batonRepo });
+
+    await (service as any).reconcileApp(makeFailedApp());
+
+    expect(podManager.deleteWorkerPod).toHaveBeenCalledWith('worker-sess-failed');
+    expect(podManager.deleteNetworkPolicy).toHaveBeenCalledWith('sess-failed');
+    // pod_name cleared so the reap is idempotent across ticks
+    expect(sessionRepo.update).toHaveBeenCalledWith('sess-failed', { pod_name: null });
+  });
+
+  it('still provisions a replacement — the FAILED session must not hold capacity', async () => {
+    process.env = { ...originalEnv, IDLE_SHUTDOWN_SECONDS: '0' };
+
+    const failed = {
+      id: 'sess-failed-2',
+      tenant_id: 'tenant-f',
+      app_id: 'app-f',
+      state: 'FAILED',
+      pod_name: 'worker-sess-failed-2',
+      started_at: new Date(),
+    };
+    const sessionRepo = {
+      find: jest.fn().mockResolvedValue([failed]),
+      count: jest.fn().mockResolvedValue(0),
+      update: jest.fn().mockResolvedValue(undefined),
+      create: jest.fn().mockImplementation((v: any) => v),
+      save: jest.fn().mockImplementation(async (v: any) => ({ id: 'sess-new', ...v })),
+    };
+    const podManager = podManagerMock();
+    const batonRepo = {
+      create: jest.fn().mockImplementation((v: any) => v),
+      save: jest.fn().mockResolvedValue({}),
+    };
+    const service = buildService({ sessionRepo, podManager, batonRepo });
+
+    await (service as any).reconcileApp(makeFailedApp());
+
+    expect(podManager.deleteWorkerPod).toHaveBeenCalledWith('worker-sess-failed-2');
+    expect(sessionRepo.save).toHaveBeenCalled(); // a fresh session was created
+  });
+
+  it('does not touch a FAILED session whose runtime was already released', async () => {
+    process.env = { ...originalEnv, IDLE_SHUTDOWN_SECONDS: '0' };
+
+    const failed = {
+      id: 'sess-failed-3',
+      tenant_id: 'tenant-f',
+      app_id: 'app-f',
+      state: 'FAILED',
+      pod_name: null, // already reaped on an earlier tick
+      started_at: new Date(),
+    };
+    const sessionRepo = {
+      find: jest.fn().mockResolvedValue([failed]),
+      count: jest.fn().mockResolvedValue(0),
+      update: jest.fn().mockResolvedValue(undefined),
+      create: jest.fn().mockImplementation((v: any) => v),
+      save: jest.fn().mockImplementation(async (v: any) => ({ id: 'sess-new', ...v })),
+    };
+    const podManager = podManagerMock();
+    const batonRepo = {
+      create: jest.fn().mockImplementation((v: any) => v),
+      save: jest.fn().mockResolvedValue({}),
+    };
+    const service = buildService({ sessionRepo, podManager, batonRepo });
+
+    await (service as any).reconcileApp(makeFailedApp());
+
+    expect(podManager.deleteWorkerPod).not.toHaveBeenCalled();
+    expect(sessionRepo.update).not.toHaveBeenCalledWith('sess-failed-3', { pod_name: null });
+  });
+});

--- a/apps/controller/src/reconcile.service.ts
+++ b/apps/controller/src/reconcile.service.ts
@@ -609,9 +609,12 @@ export class ReconcileService implements OnModuleInit, OnModuleDestroy {
           // otherwise leave desired alone so reconcile provisions a fresh session
           // for the waiting user. A WARM pool spare never stands its (shared) pool
           // app down — that would drain the pool (mirrors the max-age path above).
-          const app = appById.get(session.app_id);
-          const template = app?.template_id ? templateById.get(app.template_id) : undefined;
-          const idleSeconds = template?.idle_shutdown_seconds ?? globalIdleShutdownSeconds;
+          // The global value, deliberately: appById/templateById are built only
+          // from the apps of HEALTHY sessions, and this branch only acts when the
+          // app has NO live session — so the per-template lookup always missed and
+          // silently fell back here anyway. Say what it does instead of implying a
+          // per-template override that never applied.
+          const idleSeconds = globalIdleShutdownSeconds;
           const idleMs = idleSeconds * 1000;
           const lastUsed =
             session.last_activity_at || session.last_credential_request_at || session.started_at;

--- a/apps/controller/src/reconcile.service.ts
+++ b/apps/controller/src/reconcile.service.ts
@@ -215,14 +215,43 @@ export class ReconcileService implements OnModuleInit, OnModuleDestroy {
       s => s.state !== SessionState.TERMINATED
     );
 
-    // FAILED sessions hold no live pod and are swept by the FAILED-cleanup pass
-    // below, but that runs only after a grace TTL (up to IDLE_SHUTDOWN/2). Until
-    // then a FAILED session must NOT count toward the app's session capacity —
+    // A FAILED session must NOT count toward the app's session capacity —
     // otherwise it blocks its own replacement and the app cannot provision on
     // demand for the whole cleanup window (a user requesting credentials just
     // waits and gets "no session"). Provisioning counts only sessions that are
     // live or on their way up; the circuit breaker (Step 3) bounds retries if
     // the replacements keep failing.
+    //
+    // Because it no longer holds capacity, its pod MUST be released here rather
+    // than waiting for the FAILED-cleanup pass: that pass is gated on
+    // IDLE_SHUTDOWN_SECONDS, which defaults to 0 (disabled), so on a default
+    // deployment it never runs at all — the pod would outlive the session
+    // forever while reconcile kept creating replacements on top of it, leaking
+    // one pod per failure. reconcileRuntimeDrift doesn't cover this either (it
+    // only reaps pods whose session is missing or TERMINATED).
+    //
+    // State-driven rather than hooked to the FAILED transition, so it self-heals
+    // no matter who marked the session failed (controller, worker, or API), and
+    // idempotent: pod_name is cleared once the runtime is gone.
+    for (const session of activeSessions) {
+      if (session.state !== SessionState.FAILED || !session.pod_name) {
+        continue;
+      }
+      try {
+        this.logger.log(
+          `Releasing runtime for FAILED session ${session.id} (pod ${session.pod_name})`,
+        );
+        await this.releaseSessionRuntime(session);
+        await this.sessionRepo.update(session.id, { pod_name: null as any });
+        session.pod_name = null as any;
+      } catch (error) {
+        // Never let a stuck reap block provisioning — the next tick retries.
+        this.logger.warn(
+          `Failed to release runtime for FAILED session ${session.id}: ${error}`,
+        );
+      }
+    }
+
     const liveSessions = activeSessions.filter(
       s => s.state !== SessionState.FAILED
     );
@@ -459,7 +488,17 @@ export class ReconcileService implements OnModuleInit, OnModuleDestroy {
     // Transition to TERMINATED
     await this.stateMachine.transition(session, SessionState.TERMINATED);
 
-    // Delete pod and NetworkPolicy
+    await this.releaseSessionRuntime(session);
+
+    this.logger.log(`Terminated session ${session.id}`);
+  }
+
+  /**
+   * Delete a session's Kubernetes runtime (pod, streaming services, NetworkPolicy)
+   * WITHOUT changing its state. Split out of terminateSession so a FAILED session
+   * can give its pod back while its row stays FAILED for the grace TTL.
+   */
+  private async releaseSessionRuntime(session: SessionEntity): Promise<void> {
     if (session.pod_name) {
       await this.podManager.deleteWorkerPod(session.pod_name);
     }
@@ -468,8 +507,6 @@ export class ReconcileService implements OnModuleInit, OnModuleDestroy {
     await this.podManager.deleteCdpService(session.id, session.pod_name || undefined);
     await this.podManager.deleteWorkerService(session.id, session.pod_name || undefined);
     await this.podManager.deleteNetworkPolicy(session.id);
-
-    this.logger.log(`Terminated session ${session.id}`);
   }
 
   /**

--- a/apps/controller/src/reconcile.service.ts
+++ b/apps/controller/src/reconcile.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import * as Sentry from '@sentry/node';
 import { InjectRepository } from '@nestjs/typeorm';
-import { MoreThan, Repository, DataSource } from 'typeorm';
+import { MoreThan, Not, In, Repository, DataSource } from 'typeorm';
 import { SessionState, StreamingMode, RECORDING_POOL } from '@browser-hitl/shared';
 import { ApplicationEntity } from './entities/application.entity';
 import { SessionEntity } from './entities/session.entity';
@@ -215,8 +215,20 @@ export class ReconcileService implements OnModuleInit, OnModuleDestroy {
       s => s.state !== SessionState.TERMINATED
     );
 
+    // FAILED sessions hold no live pod and are swept by the FAILED-cleanup pass
+    // below, but that runs only after a grace TTL (up to IDLE_SHUTDOWN/2). Until
+    // then a FAILED session must NOT count toward the app's session capacity —
+    // otherwise it blocks its own replacement and the app cannot provision on
+    // demand for the whole cleanup window (a user requesting credentials just
+    // waits and gets "no session"). Provisioning counts only sessions that are
+    // live or on their way up; the circuit breaker (Step 3) bounds retries if
+    // the replacements keep failing.
+    const liveSessions = activeSessions.filter(
+      s => s.state !== SessionState.FAILED
+    );
+
     const desired = app.desired_session_count;
-    const actual = activeSessions.length;
+    const actual = liveSessions.length;
 
     // Keep egress allowlist synced for all currently active runtime sessions.
     const { extraAllowlist, allowAll } = this.resolveEgressOptions(app);
@@ -268,10 +280,12 @@ export class ReconcileService implements OnModuleInit, OnModuleDestroy {
       }
     }
 
-    // Step 4: Terminate excess sessions (oldest first)
+    // Step 4: Terminate excess LIVE sessions (oldest first). FAILED sessions are
+    // excluded from `actual` above and reaped by the dedicated FAILED-cleanup
+    // pass, so they must not be treated as excess capacity here.
     if (actual > desired) {
       const toTerminate = actual - desired;
-      const sorted = activeSessions.sort(
+      const sorted = liveSessions.sort(
         (a, b) => new Date(a.started_at).getTime() - new Date(b.started_at).getTime()
       );
 
@@ -547,7 +561,38 @@ export class ReconcileService implements OnModuleInit, OnModuleDestroy {
           this.logger.log(
             `Cleaning up FAILED session ${session.id} (age: ${Math.round(age / 60000)}min, threshold: ${Math.round(failedTtlMs / 60000)}min)`,
           );
-          await this.appRepo.update(session.app_id, { desired_session_count: 0 });
+
+          // Decide whether reaping this corpse should also stand the app down.
+          // Historically cleanup ALWAYS scaled desired→0. That is correct for an
+          // abandoned app, but wrong for one a user is actively driving: it wiped
+          // provisioning intent, so the next credential request found no session
+          // and no way to make one (the failed session had already blocked its
+          // replacement — see the liveSessions count in reconcileApp). Only stand
+          // down when the app has no other live session AND no recent demand;
+          // otherwise leave desired alone so reconcile provisions a fresh session
+          // for the waiting user. A WARM pool spare never stands its (shared) pool
+          // app down — that would drain the pool (mirrors the max-age path above).
+          const app = appById.get(session.app_id);
+          const template = app?.template_id ? templateById.get(app.template_id) : undefined;
+          const idleSeconds = template?.idle_shutdown_seconds ?? globalIdleShutdownSeconds;
+          const idleMs = idleSeconds * 1000;
+          const lastUsed =
+            session.last_activity_at || session.last_credential_request_at || session.started_at;
+          const appHasRecentDemand = idleMs > 0 && now - new Date(lastUsed).getTime() < idleMs;
+          const liveCount = await this.sessionRepo.count({
+            where: {
+              app_id: session.app_id,
+              state: Not(In([SessionState.TERMINATED, SessionState.FAILED])),
+            },
+          });
+
+          const isWarmPoolSpare = session.pool_state === RECORDING_POOL.WARM;
+          if (liveCount === 0 && !appHasRecentDemand && !isWarmPoolSpare) {
+            this.logger.log(
+              `App ${session.app_id}: no live session and idle (last used ${Math.round((now - new Date(lastUsed).getTime()) / 60000)}min ago, threshold ${idleSeconds}s) — scaling to 0 after failed-session cleanup`,
+            );
+            await this.appRepo.update(session.app_id, { desired_session_count: 0 });
+          }
           await this.terminateSession(session);
         }
       }

--- a/apps/worker/src/download-capture.spec.ts
+++ b/apps/worker/src/download-capture.spec.ts
@@ -1,0 +1,78 @@
+import * as fs from 'fs/promises';
+import { enableDownloadCapture, listDownloads, getDownload } from './download-capture';
+
+// Drive the module with a mock Playwright context/page/download. enableDownloadCapture
+// attaches page.on('download'); we capture that handler and fire it with a fake
+// Download whose saveAs writes real bytes to the temp path the module chose.
+function setup() {
+  let dlHandler: (d: any) => Promise<void>;
+  const ctx: any = {
+    on: () => {},
+    pages: () => [page],
+  };
+  const page: any = {
+    on: (ev: string, cb: any) => {
+      if (ev === 'download') dlHandler = cb;
+    },
+    context: () => ctx,
+  };
+  enableDownloadCapture(ctx);
+  return { page, fire: (d: any) => dlHandler(d) };
+}
+
+function fakeDownload(name: string, bytes: Buffer) {
+  return {
+    suggestedFilename: () => name,
+    url: () => `https://bank.test/${name}`,
+    saveAs: async (dest: string) => {
+      await fs.writeFile(dest, bytes);
+    },
+  };
+}
+
+describe('download-capture', () => {
+  it('captures a download, lists it (path-free), and returns base64 bytes', async () => {
+    const { page, fire } = setup();
+    const bytes = Buffer.from('%PDF-1.4 fake statement body');
+    await fire(fakeDownload('statement.pdf', bytes));
+
+    const list = listDownloads(page);
+    expect(list.downloads).toHaveLength(1);
+    const meta = list.downloads[0];
+    expect(meta.suggested_filename).toBe('statement.pdf');
+    expect(meta.state).toBe('completed');
+    expect(meta.mime_type).toBe('application/pdf');
+    expect(meta.size_bytes).toBe(bytes.length);
+    expect((meta as any).path).toBeUndefined(); // never leak the on-disk path
+
+    const got = await getDownload(page); // latest completed
+    expect(got.filename).toBe('statement.pdf');
+    expect(got.mime_type).toBe('application/pdf');
+    expect(Buffer.from(got.base64, 'base64').equals(bytes)).toBe(true);
+  });
+
+  it('get_download returns a specific id and defaults to the newest completed', async () => {
+    const { page, fire } = setup();
+    await fire(fakeDownload('a.csv', Buffer.from('col1,col2')));
+    await fire(fakeDownload('b.pdf', Buffer.from('%PDF b')));
+
+    const first = listDownloads(page).downloads[0];
+    const byId = await getDownload(page, first.id);
+    expect(byId.filename).toBe('a.csv');
+    expect(byId.mime_type).toBe('text/csv');
+
+    const latest = await getDownload(page); // newest
+    expect(latest.filename).toBe('b.pdf');
+  });
+
+  it('throws a clear error when no completed download exists', async () => {
+    const { page } = setup();
+    await expect(getDownload(page)).rejects.toThrow(/no completed download/);
+  });
+
+  it('throws for an unknown id', async () => {
+    const { page, fire } = setup();
+    await fire(fakeDownload('x.pdf', Buffer.from('x')));
+    await expect(getDownload(page, 'dl-nope')).rejects.toThrow(/no download with id/);
+  });
+});

--- a/apps/worker/src/download-capture.ts
+++ b/apps/worker/src/download-capture.ts
@@ -36,6 +36,11 @@ const downloadsByContext = new WeakMap<BrowserContext, DownloadRecord[]>();
 const MAX_DOWNLOADS = 20; // keep only the most recent N per context
 // Every captured file is saved under this dir; get_download reads only from here.
 const DOWNLOADS_DIR = path.join(os.tmpdir(), 'tabby-downloads');
+// Monotonic so ids stay unique once the index caps: `records.length` is read
+// BEFORE the push, so past MAX_DOWNLOADS it is always the cap and two downloads
+// in the same millisecond collided — get_download(id) then returned whichever
+// find() hit first.
+let downloadSeq = 0;
 
 function mimeFromName(name: string): string {
   const ext = path.extname(name || '').toLowerCase();
@@ -80,7 +85,7 @@ export function enableDownloadCapture(context: BrowserContext): void {
     page.on('download', async (download: Download) => {
       const suggested = download.suggestedFilename() || 'download';
       const rec: DownloadRecord = {
-        id: `dl-${Date.now()}-${records.length}`,
+        id: `dl-${Date.now()}-${++downloadSeq}`,
         suggested_filename: suggested,
         url: download.url(),
         mime_type: mimeFromName(suggested),
@@ -91,7 +96,15 @@ export function enableDownloadCapture(context: BrowserContext): void {
       };
       records.push(rec);
       if (records.length > MAX_DOWNLOADS) {
-        records.splice(0, records.length - MAX_DOWNLOADS);
+        // Delete the evicted files too. Dropping only the index entry leaked the
+        // bytes: nothing else unlinks them, so a long-lived worker with downloads
+        // enabled accumulated every export on the pod's ephemeral disk until the
+        // kubelet evicted it.
+        for (const dropped of records.splice(0, records.length - MAX_DOWNLOADS)) {
+          if (dropped.path) {
+            fs.unlink(dropped.path).catch(() => undefined);
+          }
+        }
       }
       try {
         await fs.mkdir(dir, { recursive: true });

--- a/apps/worker/src/download-capture.ts
+++ b/apps/worker/src/download-capture.ts
@@ -1,0 +1,159 @@
+import { BrowserContext, Download, Page } from 'playwright';
+import { EXECUTE_LIMITS } from '@browser-hitl/shared';
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+
+/**
+ * Server-side download capture via Playwright `download` events.
+ *
+ * By default the worker cancels every download (browser_policy.downloads=false
+ * in main.ts). When an app opts in (browser_policy.downloads=true), the context
+ * is created with acceptDownloads and this module saves each download to a temp
+ * file and keeps a small in-memory index. The `/execute/browser` commands
+ * `list_downloads` and `get_download` expose them — `get_download` returns the
+ * bytes as base64 (mirroring `screenshot`) so the harness can write the file to
+ * its OUTPUTS. Bounded to EXECUTE_LIMITS.MAX_RESPONSE_BODY_BYTES; larger exports
+ * would need an out-of-band artifact path.
+ */
+
+export interface DownloadRecord {
+  id: string;
+  suggested_filename: string;
+  url: string;
+  mime_type: string;
+  state: 'in_progress' | 'completed' | 'failed';
+  size_bytes: number | null;
+  path: string | null;
+  created_at: string;
+  error?: string;
+}
+
+/** Public (path-free) view returned by list_downloads. */
+export type DownloadMeta = Omit<DownloadRecord, 'path'>;
+
+const downloadsByContext = new WeakMap<BrowserContext, DownloadRecord[]>();
+const MAX_DOWNLOADS = 20; // keep only the most recent N per context
+
+function mimeFromName(name: string): string {
+  const ext = path.extname(name || '').toLowerCase();
+  switch (ext) {
+    case '.pdf':
+      return 'application/pdf';
+    case '.csv':
+      return 'text/csv';
+    case '.xlsx':
+      return 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+    case '.xls':
+      return 'application/vnd.ms-excel';
+    case '.json':
+      return 'application/json';
+    case '.txt':
+      return 'text/plain';
+    case '.zip':
+      return 'application/zip';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+function sanitize(name: string): string {
+  return (name || 'download').replace(/[^a-zA-Z0-9._-]+/g, '_').slice(0, 128) || 'download';
+}
+
+/**
+ * Attach download capture to a context (idempotent). Saves each download to a
+ * temp file and indexes it. Call only when browser_policy.downloads is enabled;
+ * the context must have been created with acceptDownloads: true.
+ */
+export function enableDownloadCapture(context: BrowserContext): void {
+  if (downloadsByContext.has(context)) {
+    return;
+  }
+  const records: DownloadRecord[] = [];
+  downloadsByContext.set(context, records);
+  const dir = path.join(os.tmpdir(), 'tabby-downloads');
+
+  const attach = (page: Page) => {
+    page.on('download', async (download: Download) => {
+      const suggested = download.suggestedFilename() || 'download';
+      const rec: DownloadRecord = {
+        id: `dl-${Date.now()}-${records.length}`,
+        suggested_filename: suggested,
+        url: download.url(),
+        mime_type: mimeFromName(suggested),
+        state: 'in_progress',
+        size_bytes: null,
+        path: null,
+        created_at: new Date().toISOString(),
+      };
+      records.push(rec);
+      if (records.length > MAX_DOWNLOADS) {
+        records.splice(0, records.length - MAX_DOWNLOADS);
+      }
+      try {
+        await fs.mkdir(dir, { recursive: true });
+        const dest = path.join(dir, `${rec.id}-${sanitize(suggested)}`);
+        await download.saveAs(dest);
+        const stat = await fs.stat(dest);
+        rec.path = dest;
+        rec.size_bytes = stat.size;
+        rec.state = 'completed';
+      } catch (err) {
+        rec.state = 'failed';
+        rec.error = err instanceof Error ? err.message : String(err);
+      }
+    });
+  };
+
+  context.on('page', attach);
+  for (const p of context.pages()) {
+    attach(p);
+  }
+}
+
+/** Metadata for every captured download on this page's context (newest last). */
+export function listDownloads(page: Page): { downloads: DownloadMeta[] } {
+  const records = downloadsByContext.get(page.context()) || [];
+  return { downloads: records.map(({ path: _p, ...meta }) => meta) };
+}
+
+/**
+ * Return a captured download's bytes as base64. Without `id`, returns the most
+ * recent COMPLETED download. Throws if none, if the target is not completed, or
+ * if it exceeds the inline size cap.
+ */
+export async function getDownload(
+  page: Page,
+  id?: string,
+): Promise<{ id: string; filename: string; mime_type: string; size_bytes: number; base64: string }> {
+  const records = downloadsByContext.get(page.context()) || [];
+  const completed = records.filter((r) => r.state === 'completed');
+  const rec = id
+    ? records.find((r) => r.id === id)
+    : completed[completed.length - 1];
+
+  if (!rec) {
+    throw new Error(
+      id
+        ? `get_download: no download with id "${id}"`
+        : 'get_download: no completed download available (trigger the download first, then retry)',
+    );
+  }
+  if (rec.state !== 'completed' || !rec.path) {
+    throw new Error(`get_download: download "${rec.suggested_filename}" is ${rec.state}${rec.error ? ` (${rec.error})` : ''}`);
+  }
+  if (rec.size_bytes !== null && rec.size_bytes > EXECUTE_LIMITS.MAX_RESPONSE_BODY_BYTES) {
+    throw new Error(
+      `get_download: "${rec.suggested_filename}" is ${rec.size_bytes} bytes, over the ${EXECUTE_LIMITS.MAX_RESPONSE_BODY_BYTES}-byte inline limit`,
+    );
+  }
+  const buf = await fs.readFile(rec.path);
+  return {
+    id: rec.id,
+    filename: rec.suggested_filename,
+    mime_type: rec.mime_type,
+    size_bytes: buf.length,
+    base64: buf.toString('base64'),
+  };
+}

--- a/apps/worker/src/download-capture.ts
+++ b/apps/worker/src/download-capture.ts
@@ -34,6 +34,8 @@ export type DownloadMeta = Omit<DownloadRecord, 'path'>;
 
 const downloadsByContext = new WeakMap<BrowserContext, DownloadRecord[]>();
 const MAX_DOWNLOADS = 20; // keep only the most recent N per context
+// Every captured file is saved under this dir; get_download reads only from here.
+const DOWNLOADS_DIR = path.join(os.tmpdir(), 'tabby-downloads');
 
 function mimeFromName(name: string): string {
   const ext = path.extname(name || '').toLowerCase();
@@ -72,7 +74,7 @@ export function enableDownloadCapture(context: BrowserContext): void {
   }
   const records: DownloadRecord[] = [];
   downloadsByContext.set(context, records);
-  const dir = path.join(os.tmpdir(), 'tabby-downloads');
+  const dir = DOWNLOADS_DIR;
 
   const attach = (page: Page) => {
     page.on('download', async (download: Download) => {
@@ -147,6 +149,13 @@ export async function getDownload(
     throw new Error(
       `get_download: "${rec.suggested_filename}" is ${rec.size_bytes} bytes, over the ${EXECUTE_LIMITS.MAX_RESPONSE_BODY_BYTES}-byte inline limit`,
     );
+  }
+  // Defense-in-depth: rec.path is always a saveAs() destination we built under
+  // DOWNLOADS_DIR from a generated id + sanitize()-d name, but confirm it stays
+  // inside that dir before reading (path-traversal containment).
+  const rel = path.relative(DOWNLOADS_DIR, rec.path);
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    throw new Error('get_download: refusing to read a path outside the download directory');
   }
   const buf = await fs.readFile(rec.path);
   return {

--- a/apps/worker/src/execute-browser-handler.spec.ts
+++ b/apps/worker/src/execute-browser-handler.spec.ts
@@ -82,6 +82,7 @@ describe('execute-browser-handler validation', () => {
         'get_page_summary', 'get_page_info', 'screenshot',
         'wait_for_selector', 'scroll_page',
         'har_start', 'har_stop', 'har_status',
+        'list_downloads', 'get_download',
       ];
       for (const cmd of expectedCommands) {
         expect(BROWSER_COMMANDS.includes(cmd as any)).toBe(true);

--- a/apps/worker/src/execute-browser-handler.spec.ts
+++ b/apps/worker/src/execute-browser-handler.spec.ts
@@ -10,6 +10,8 @@ function makeLocator(overrides: Record<string, any> = {}): any {
     filter: jest.fn(),
     nth: jest.fn(),
     getByText: jest.fn(),
+    scrollIntoViewIfNeeded: jest.fn().mockResolvedValue(undefined),
+    dispatchEvent: jest.fn().mockResolvedValue(undefined),
   };
   loc.filter.mockImplementation((opts: any) => {
     loc._lastFilter = opts;
@@ -70,6 +72,54 @@ describe('execute-browser-handler click_by_text resolution', () => {
 
     expect(matches.nth).toHaveBeenCalledWith(0); // fell back to the raw matches
     expect(matches.click).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to a DOM-dispatched click when a real click is intercepted by an overlay', async () => {
+    // Regression for the HSBCnet statement "Download": a sticky news/service-update
+    // banner obscured the link's click point, so Playwright refused the real click
+    // ("intercepts pointer events") and no download ever fired. The DOM-level
+    // dispatch bypasses the overlay hit-test, mirroring a manual click.
+    const visible = makeLocator({ count: 1 });
+    visible.click.mockRejectedValueOnce(
+      new Error('locator.click: Timeout 30000ms exceeded.\n<div class="newsNotification"> intercepts pointer events'),
+    );
+    const matches = makeLocator({ count: 3, filtered: visible });
+    const page: any = { getByText: jest.fn().mockReturnValue(matches) };
+
+    await dispatchCommand(page, 'click_by_text', { text: 'Download' }, 30000);
+
+    expect(visible.click).toHaveBeenCalledTimes(1);
+    expect(visible.scrollIntoViewIfNeeded).toHaveBeenCalledTimes(1);
+    expect(visible.dispatchEvent).toHaveBeenCalledWith('click');
+  });
+
+  it('rethrows a non-interception click error instead of dispatching (a genuine failure still surfaces)', async () => {
+    const visible = makeLocator({ count: 1 });
+    visible.click.mockRejectedValueOnce(new Error('locator.click: strict mode violation'));
+    const matches = makeLocator({ count: 1, filtered: visible });
+    const page: any = { getByText: jest.fn().mockReturnValue(matches) };
+
+    await expect(dispatchCommand(page, 'click_by_text', { text: 'Download' }, 30000)).rejects.toThrow(
+      /strict mode violation/,
+    );
+    expect(visible.dispatchEvent).not.toHaveBeenCalled();
+  });
+
+  it('rethrows a plain not-found timeout without dispatching (wrong label ≠ overlay)', async () => {
+    // A bare "Timeout exceeded" (no "intercepts pointer events") means the target
+    // text simply isn't on the page (e.g. a wrong recorded label). A DOM dispatch
+    // can't help and would just burn a second 30s — so it must re-throw fast.
+    const visible = makeLocator({ count: 1 });
+    visible.click.mockRejectedValueOnce(
+      new Error('locator.click: Timeout 30000ms exceeded.\nwaiting for getByText(\'Last Month Statement\')'),
+    );
+    const matches = makeLocator({ count: 1, filtered: visible });
+    const page: any = { getByText: jest.fn().mockReturnValue(matches) };
+
+    await expect(dispatchCommand(page, 'click_by_text', { text: 'Last Month Statement' }, 30000)).rejects.toThrow(
+      /Timeout 30000ms exceeded/,
+    );
+    expect(visible.dispatchEvent).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/worker/src/execute-browser-handler.spec.ts
+++ b/apps/worker/src/execute-browser-handler.spec.ts
@@ -1,4 +1,77 @@
 import { BROWSER_COMMANDS, EXECUTE_LIMITS } from '@browser-hitl/shared';
+import { dispatchCommand } from './execute-browser-handler';
+
+// A minimal Playwright Locator/Page mock that records how click_by_text resolves
+// its target. getByText → filter({visible}) → nth → click is the chain we assert.
+function makeLocator(overrides: Record<string, any> = {}): any {
+  const loc: any = {
+    click: jest.fn().mockResolvedValue(undefined),
+    count: jest.fn().mockResolvedValue(overrides.count ?? 1),
+    filter: jest.fn(),
+    nth: jest.fn(),
+    getByText: jest.fn(),
+  };
+  loc.filter.mockImplementation((opts: any) => {
+    loc._lastFilter = opts;
+    return overrides.filtered ?? loc;
+  });
+  loc.nth.mockImplementation((i: number) => {
+    loc._lastNth = i;
+    return loc;
+  });
+  return loc;
+}
+
+describe('execute-browser-handler click_by_text resolution', () => {
+  it('defaults to non-exact matching and clicks the first VISIBLE match', async () => {
+    const visible = makeLocator({ count: 1 });
+    const matches = makeLocator({ count: 3, filtered: visible });
+    const page: any = { getByText: jest.fn().mockReturnValue(matches) };
+
+    await dispatchCommand(page, 'click_by_text', { text: 'Cards' }, 30000);
+
+    // exact defaults to false (Playwright's natural substring match)
+    expect(page.getByText).toHaveBeenCalledWith('Cards', { exact: false });
+    // duplicate matches → filter to visible, take the first, then click
+    expect(matches.filter).toHaveBeenCalledWith({ visible: true });
+    expect(visible.nth).toHaveBeenCalledWith(0);
+    expect(visible.click).toHaveBeenCalledTimes(1);
+  });
+
+  it('honors exact:true, a within-scope, and an nth index', async () => {
+    const visible = makeLocator({ count: 2 });
+    const matches = makeLocator({ count: 2, filtered: visible });
+    const scope = makeLocator();
+    scope.getByText.mockReturnValue(matches);
+    const page: any = {
+      locator: jest.fn().mockReturnValue(scope),
+      getByText: jest.fn(),
+    };
+
+    await dispatchCommand(
+      page,
+      'click_by_text',
+      { text: 'Credit Card', exact: true, within: '#sidenavNew', nth: 1 },
+      30000,
+    );
+
+    expect(page.locator).toHaveBeenCalledWith('#sidenavNew');
+    expect(scope.getByText).toHaveBeenCalledWith('Credit Card', { exact: true });
+    expect(visible.nth).toHaveBeenCalledWith(1);
+    expect(visible.click).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to all matches when none are visible (so a real miss still errors)', async () => {
+    const visible = makeLocator({ count: 0 });
+    const matches = makeLocator({ count: 1, filtered: visible });
+    const page: any = { getByText: jest.fn().mockReturnValue(matches) };
+
+    await dispatchCommand(page, 'click_by_text', { text: 'Ghost' }, 30000);
+
+    expect(matches.nth).toHaveBeenCalledWith(0); // fell back to the raw matches
+    expect(matches.click).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe('execute-browser-handler validation', () => {
   describe('command validation', () => {

--- a/apps/worker/src/execute-browser-handler.spec.ts
+++ b/apps/worker/src/execute-browser-handler.spec.ts
@@ -10,6 +10,7 @@ function makeLocator(overrides: Record<string, any> = {}): any {
     filter: jest.fn(),
     nth: jest.fn(),
     getByText: jest.fn(),
+    first: jest.fn(),
     scrollIntoViewIfNeeded: jest.fn().mockResolvedValue(undefined),
     dispatchEvent: jest.fn().mockResolvedValue(undefined),
   };
@@ -17,6 +18,7 @@ function makeLocator(overrides: Record<string, any> = {}): any {
     loc._lastFilter = opts;
     return overrides.filtered ?? loc;
   });
+  loc.first.mockImplementation(() => loc);
   loc.nth.mockImplementation((i: number) => {
     loc._lastNth = i;
     return loc;
@@ -25,19 +27,55 @@ function makeLocator(overrides: Record<string, any> = {}): any {
 }
 
 describe('execute-browser-handler click_by_text resolution', () => {
-  it('defaults to non-exact matching and clicks the first VISIBLE match', async () => {
+  it('prefers an EXACT match by default, and clicks the first VISIBLE one', async () => {
+    // Defaulting straight to substring silently widened every already-compiled
+    // skill that omits `exact`: a sidebar with "Log out" and "Log out of all
+    // devices" made click_by_text('Log out') ambiguous, and nth(0) then picks DOM
+    // order. Exact is tried first; substring is only a rescue (below).
     const visible = makeLocator({ count: 1 });
     const matches = makeLocator({ count: 3, filtered: visible });
     const page: any = { getByText: jest.fn().mockReturnValue(matches) };
 
     await dispatchCommand(page, 'click_by_text', { text: 'Cards' }, 30000);
 
-    // exact defaults to false (Playwright's natural substring match)
-    expect(page.getByText).toHaveBeenCalledWith('Cards', { exact: false });
+    expect(page.getByText).toHaveBeenCalledWith('Cards', { exact: true });
     // duplicate matches → filter to visible, take the first, then click
     expect(matches.filter).toHaveBeenCalledWith({ visible: true });
     expect(visible.nth).toHaveBeenCalledWith(0);
     expect(visible.click).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to substring when no exact match exists (near-miss labels)', async () => {
+    // The reason substring matching exists: a skill records "Credit Cards" but
+    // the DOM says "Credit Card".
+    const visible = makeLocator({ count: 1 });
+    const exactMatches = makeLocator({ count: 0 });
+    const looseMatches = makeLocator({ count: 2, filtered: visible });
+    const page: any = {
+      getByText: jest.fn().mockImplementation((_t: string, opts: any) =>
+        opts?.exact ? exactMatches : looseMatches,
+      ),
+    };
+
+    await dispatchCommand(page, 'click_by_text', { text: 'Credit Cards' }, 30000);
+
+    expect(page.getByText).toHaveBeenCalledWith('Credit Cards', { exact: true });
+    expect(page.getByText).toHaveBeenCalledWith('Credit Cards', { exact: false });
+    expect(visible.click).toHaveBeenCalledTimes(1);
+  });
+
+  it('click_element prefers visible matches and clicks through an overlay', async () => {
+    const visible = makeLocator({ count: 1 });
+    visible.click.mockRejectedValueOnce(
+      new Error('locator.click: Timeout 30000ms exceeded.\n<div class="newsNotification"> intercepts pointer events'),
+    );
+    const all = makeLocator({ count: 3, filtered: visible });
+    const page: any = { locator: jest.fn().mockReturnValue(all) };
+
+    await dispatchCommand(page, 'click_element', { selector: '.stmt a.dl' }, 30000);
+
+    expect(all.filter).toHaveBeenCalledWith({ visible: true });
+    expect(visible.dispatchEvent).toHaveBeenCalledWith('click');
   });
 
   it('honors exact:true, a within-scope, and an nth index', async () => {

--- a/apps/worker/src/execute-browser-handler.ts
+++ b/apps/worker/src/execute-browser-handler.ts
@@ -7,6 +7,7 @@ import {
   type ExecuteBrowserResponse,
 } from '@browser-hitl/shared';
 import { startHarCapture, stopHarCapture, getHarStatus, cleanupHarListeners } from './har-capture';
+import { listDownloads, getDownload } from './download-capture';
 
 export { cleanupHarListeners };
 
@@ -160,6 +161,15 @@ export async function dispatchCommand(
 
     case 'har_status': {
       return getHarStatus(page);
+    }
+
+    case 'list_downloads': {
+      return listDownloads(page);
+    }
+
+    case 'get_download': {
+      const id = typeof params.id === 'string' && params.id ? params.id : undefined;
+      return getDownload(page, id);
     }
 
     default:

--- a/apps/worker/src/execute-browser-handler.ts
+++ b/apps/worker/src/execute-browser-handler.ts
@@ -65,7 +65,13 @@ export async function dispatchCommand(
 
     case 'click_element': {
       const selector = requireParam(params, 'selector', 'string');
-      await page.locator(selector).click({ timeout: timeoutMs });
+      // Same visible-first + overlay handling as click_by_text: a selector can
+      // match hidden analytics/off-screen copies (strict-mode violation), and the
+      // sticky-banner interception is not text-specific.
+      const all = page.locator(selector);
+      const vis = all.filter({ visible: true });
+      const el = (await vis.count()) > 0 ? vis.first() : all.first();
+      await clickThroughOverlays(el, timeoutMs);
       return {};
     }
 
@@ -222,6 +228,39 @@ export async function dispatchCommand(
 }
 
 /**
+ * Click a resolved locator, falling back to a DOM-dispatched click when a real
+ * mouse click cannot be delivered.
+ *
+ * Real SPA/bank portals overlay sticky banners (news / service-update
+ * notifications, cookie notices) that cover a target's click point. Playwright
+ * correctly refuses a click it cannot deliver ("<div …> intercepts pointer
+ * events") and times out — even though THIS is the right, visible element and a
+ * human clicking it directly works (observed on HSBCnet: a `newsNotification`
+ * widget obscured the per-row statement "Download" link, so the click never
+ * landed and no download fired). The DOM dispatch bypasses the pointer-event
+ * hit-test, the same effect as the manual click.
+ *
+ * Only for a genuine OVERLAY interception — Playwright always includes
+ * "intercepts pointer events" in that error. A plain "Timeout exceeded" means
+ * the element was never found/actionable (e.g. a wrong selector or label), where
+ * a DOM dispatch cannot help and would just burn a second timeout, so those
+ * re-throw unchanged.
+ */
+async function clickThroughOverlays(target: any, timeoutMs: number): Promise<void> {
+  try {
+    await target.click({ timeout: timeoutMs });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (/intercepts pointer events/i.test(msg)) {
+      await target.scrollIntoViewIfNeeded({ timeout: timeoutMs }).catch(() => undefined);
+      await target.dispatchEvent('click');
+    } else {
+      throw err;
+    }
+  }
+}
+
+/**
  * Click an element by its visible text, tolerant of the two things that make a
  * naive `getByText(text, { exact: true }).click()` fail on real SPA portals:
  *
@@ -245,45 +284,35 @@ async function clickByText(
   text: string,
   timeoutMs: number,
 ): Promise<void> {
-  const exact = params.exact === true;
+  const explicitExact = typeof params.exact === 'boolean' ? params.exact : undefined;
   const within = typeof params.within === 'string' && params.within ? params.within : '';
   const nth = Number.isInteger(params.nth) ? params.nth : 0;
 
   const scope = within ? page.locator(within) : page;
-  const matches = scope.getByText(text, { exact });
 
   // Prefer visible matches so the hidden analytics/off-screen copies never cause
   // a strict-mode violation. Only fall back to all matches when nothing is
   // currently visible, so a genuinely-missing target still errors clearly.
-  const visible = matches.filter({ visible: true });
-  const target = (await visible.count()) > 0 ? visible.nth(nth) : matches.nth(nth);
-  try {
-    await target.click({ timeout: timeoutMs });
-  } catch (err) {
-    // Real SPA/bank portals overlay sticky banners (news / service-update
-    // notifications, cookie notices) that cover a target's click point.
-    // Playwright correctly refuses a real mouse click it cannot deliver
-    // ("<div …> intercepts pointer events") and times out — even though THIS is
-    // the right, visible element and a human clicking the link directly works
-    // (observed on HSBCnet: a `newsNotification` widget obscured the per-row
-    // statement "Download" link, so the click never landed and no download
-    // fired). Fall back to a DOM-level click dispatched straight to the element,
-    // which bypasses the pointer-event hit-test — the same effect as the manual
-    // click. Only for interception/stability timeouts; a genuinely missing or
-    // detached target still surfaces its original error.
-    // Only fall back for a genuine OVERLAY interception — Playwright always
-    // includes "intercepts pointer events" in that error. A plain "Timeout
-    // exceeded" instead means the element was never found/actionable (e.g. a
-    // wrong text label), where a DOM dispatch can't help and would just burn a
-    // second timeout — so re-throw those unchanged.
-    const msg = err instanceof Error ? err.message : String(err);
-    if (/intercepts pointer events/i.test(msg)) {
-      await target.scrollIntoViewIfNeeded({ timeout: timeoutMs }).catch(() => undefined);
-      await target.dispatchEvent('click');
-    } else {
-      throw err;
-    }
+  const resolve = async (exact: boolean) => {
+    const matches = scope.getByText(text, { exact });
+    const visible = matches.filter({ visible: true });
+    return (await visible.count()) > 0 ? visible.nth(nth) : matches.nth(nth);
+  };
+
+  // Default is EXACT-first, substring only as a rescue. Defaulting straight to
+  // substring silently widened every already-compiled skill that omits `exact`:
+  // a sidebar with "Log out" and "Log out of all devices" made click_by_text
+  // "Log out" ambiguous, and nth(0) then picks DOM order. Trying exact first
+  // keeps those precise while still rescuing the near-miss labels substring
+  // matching exists for ("Credit Cards" recorded, "Credit Card" in the DOM).
+  let target;
+  if (explicitExact !== undefined) {
+    target = await resolve(explicitExact);
+  } else {
+    const exactCount = await scope.getByText(text, { exact: true }).count();
+    target = await resolve(exactCount > 0);
   }
+  await clickThroughOverlays(target, timeoutMs);
 }
 
 function requireParam(params: Record<string, any>, name: string, type: string): any {

--- a/apps/worker/src/execute-browser-handler.ts
+++ b/apps/worker/src/execute-browser-handler.ts
@@ -104,15 +104,58 @@ export async function dispatchCommand(
 
     case 'get_page_summary': {
       const summary = await page.evaluate(() => {
+        // Only report what the USER can actually see. The raw DOM keeps
+        // display:none / aria-hidden / zero-size leftovers — e.g. a modal from
+        // an earlier navigation that was closed but not removed. Feeding those
+        // to the model makes it "see" phantom UI (blocking modals, stale
+        // overlays) that isn't on screen and chase it. Mirror click_by_text,
+        // which already prefers visible matches, so summary and clicks agree.
+        const isVisible = (el: Element): boolean => {
+          const e = el as HTMLElement;
+          try {
+            // checkVisibility() covers display:none, visibility:hidden/collapse,
+            // content-visibility, and (with the flag) opacity:0. It is TRUE for
+            // elements merely scrolled out of view, which is what we want —
+            // "rendered", not "in the current viewport".
+            const cv = (e as unknown as {
+              checkVisibility?: (opts?: Record<string, boolean>) => boolean;
+            }).checkVisibility;
+            if (typeof cv === 'function') {
+              if (!cv.call(e, { checkVisibilityCSS: true, checkOpacity: true, contentVisibilityAuto: true })) {
+                return false;
+              }
+            } else {
+              const s = window.getComputedStyle(e);
+              if (
+                s.display === 'none' ||
+                s.visibility === 'hidden' ||
+                s.visibility === 'collapse' ||
+                parseFloat(s.opacity || '1') === 0
+              ) {
+                return false;
+              }
+              if (!(e.offsetWidth || e.offsetHeight || e.getClientRects().length)) return false;
+            }
+            // aria-hidden subtree = intentionally removed from the accessibility
+            // tree; treat as not-shown so hidden dialogs don't leak through.
+            if (e.closest('[aria-hidden="true"]')) return false;
+            return true;
+          } catch {
+            return true; // never let a visibility probe drop a real element
+          }
+        };
         const title = document.title;
         const url = window.location.href;
         const links = Array.from(document.querySelectorAll('a[href]'))
+          .filter(isVisible)
           .slice(0, 50)
           .map(a => ({ text: (a as HTMLAnchorElement).textContent?.trim() || '', href: (a as HTMLAnchorElement).href }));
         const buttons = Array.from(document.querySelectorAll('button, [role="button"], input[type="submit"]'))
+          .filter(isVisible)
           .slice(0, 50)
           .map(b => ({ text: (b as HTMLElement).textContent?.trim() || '', tag: b.tagName.toLowerCase() }));
         const inputs = Array.from(document.querySelectorAll('input, textarea, select'))
+          .filter(isVisible)
           .slice(0, 50)
           .map(i => ({
             tag: i.tagName.toLowerCase(),
@@ -122,6 +165,7 @@ export async function dispatchCommand(
             placeholder: (i as HTMLInputElement).placeholder || '',
           }));
         const headings = Array.from(document.querySelectorAll('h1, h2, h3'))
+          .filter(isVisible)
           .slice(0, 20)
           .map(h => ({ level: h.tagName, text: (h as HTMLElement).textContent?.trim() || '' }));
         return { title, url, links, buttons, inputs, headings };
@@ -213,7 +257,33 @@ async function clickByText(
   // currently visible, so a genuinely-missing target still errors clearly.
   const visible = matches.filter({ visible: true });
   const target = (await visible.count()) > 0 ? visible.nth(nth) : matches.nth(nth);
-  await target.click({ timeout: timeoutMs });
+  try {
+    await target.click({ timeout: timeoutMs });
+  } catch (err) {
+    // Real SPA/bank portals overlay sticky banners (news / service-update
+    // notifications, cookie notices) that cover a target's click point.
+    // Playwright correctly refuses a real mouse click it cannot deliver
+    // ("<div …> intercepts pointer events") and times out — even though THIS is
+    // the right, visible element and a human clicking the link directly works
+    // (observed on HSBCnet: a `newsNotification` widget obscured the per-row
+    // statement "Download" link, so the click never landed and no download
+    // fired). Fall back to a DOM-level click dispatched straight to the element,
+    // which bypasses the pointer-event hit-test — the same effect as the manual
+    // click. Only for interception/stability timeouts; a genuinely missing or
+    // detached target still surfaces its original error.
+    // Only fall back for a genuine OVERLAY interception — Playwright always
+    // includes "intercepts pointer events" in that error. A plain "Timeout
+    // exceeded" instead means the element was never found/actionable (e.g. a
+    // wrong text label), where a DOM dispatch can't help and would just burn a
+    // second timeout — so re-throw those unchanged.
+    const msg = err instanceof Error ? err.message : String(err);
+    if (/intercepts pointer events/i.test(msg)) {
+      await target.scrollIntoViewIfNeeded({ timeout: timeoutMs }).catch(() => undefined);
+      await target.dispatchEvent('click');
+    } else {
+      throw err;
+    }
+  }
 }
 
 function requireParam(params: Record<string, any>, name: string, type: string): any {

--- a/apps/worker/src/execute-browser-handler.ts
+++ b/apps/worker/src/execute-browser-handler.ts
@@ -45,7 +45,7 @@ export function registerBrowserHandler(app: Express, page: Page): void {
   });
 }
 
-async function dispatchCommand(
+export async function dispatchCommand(
   page: Page,
   command: string,
   params: Record<string, any>,
@@ -70,8 +70,7 @@ async function dispatchCommand(
 
     case 'click_by_text': {
       const text = requireParam(params, 'text', 'string');
-      const exact = params.exact !== false;
-      await page.getByText(text, { exact }).click({ timeout: timeoutMs });
+      await clickByText(page, params, text, timeoutMs);
       return {};
     }
 
@@ -166,6 +165,45 @@ async function dispatchCommand(
     default:
       throw new Error(`Unhandled command: ${command}`);
   }
+}
+
+/**
+ * Click an element by its visible text, tolerant of the two things that make a
+ * naive `getByText(text, { exact: true }).click()` fail on real SPA portals:
+ *
+ *  1. Duplicate text. A nav label like "Cards" is rendered in several nodes —
+ *     the visible sidebar item plus hidden copies (analytics/telemetry trackers,
+ *     off-screen scroll clones). A plain locator click throws a Playwright
+ *     strict-mode violation on >1 match. We prefer the VISIBLE match(es) and
+ *     click the nth (first by default), which is what a human does.
+ *  2. Near-miss labels. The exact text a skill recorded ("Credit Cards") often
+ *     differs slightly from the DOM ("Credit Card"); exact matching then times
+ *     out. We default to Playwright's natural substring + normalized-whitespace
+ *     matching. Callers can still force exact with `exact: true`.
+ *
+ * Optional params: `exact` (default false), `within` (CSS selector to scope the
+ * search to a container — e.g. a specific sidenav), `nth` (0-based index among
+ * the visible matches, default 0).
+ */
+async function clickByText(
+  page: Page,
+  params: Record<string, any>,
+  text: string,
+  timeoutMs: number,
+): Promise<void> {
+  const exact = params.exact === true;
+  const within = typeof params.within === 'string' && params.within ? params.within : '';
+  const nth = Number.isInteger(params.nth) ? params.nth : 0;
+
+  const scope = within ? page.locator(within) : page;
+  const matches = scope.getByText(text, { exact });
+
+  // Prefer visible matches so the hidden analytics/off-screen copies never cause
+  // a strict-mode violation. Only fall back to all matches when nothing is
+  // currently visible, so a genuinely-missing target still errors clearly.
+  const visible = matches.filter({ visible: true });
+  const target = (await visible.count()) > 0 ? visible.nth(nth) : matches.nth(nth);
+  await target.click({ timeout: timeoutMs });
 }
 
 function requireParam(params: Record<string, any>, name: string, type: string): any {

--- a/apps/worker/src/execute-handler.ts
+++ b/apps/worker/src/execute-handler.ts
@@ -75,7 +75,18 @@ export function registerExecuteHandler(app: Express, page: Page): void {
       // context (interceptors that mint per-request tokens still run).
       const context = page.context();
       const pageOrigin = (() => {
-        try { return new URL(page.url()).origin; } catch { return null; }
+        try {
+          const origin = new URL(page.url()).origin;
+          // about:blank and other opaque origins serialize to the STRING "null"
+          // rather than throwing, so this used to be "cross-origin" only by
+          // accident (the string never equals a real origin). Keep that routing —
+          // an in-page fetch from an opaque origin cannot pass CORS anyway — but
+          // say so explicitly. Note the consequence: while the page sits on
+          // about:blank (worker boot, warm-pool spare, post-crash) every fetch
+          // goes off-page, and off-page traffic never fires page.on('request'),
+          // so har_start/har_stop records nothing for it.
+          return origin === 'null' ? null : origin;
+        } catch { return null; }
       })();
       const isCrossOrigin = pageOrigin === null || pageOrigin !== parsed.origin;
 

--- a/apps/worker/src/execute-handler.ts
+++ b/apps/worker/src/execute-handler.ts
@@ -57,6 +57,83 @@ export function registerExecuteHandler(app: Express, page: Page): void {
       const fetchBody = body.body ?? null;
       const maxResponseBytes = EXECUTE_LIMITS.MAX_RESPONSE_BODY_BYTES;
 
+      // An in-page fetch() is bound by the page's origin and the target's CORS
+      // policy. Multi-origin apps therefore cannot be driven from a single page:
+      // ICICI, for example, serves its dashboard from retailnetbanking.icici.bank.in
+      // but its statement APIs from infinity.icici.bank.in, which sends no CORS
+      // headers — the call dies as "TypeError: Failed to fetch" even though the
+      // session is perfectly valid. That shape (auth portal + separate core-banking
+      // host) is the norm for bank portals, not an ICICI quirk.
+      //
+      // Playwright's APIRequestContext is the way out: it shares the BrowserContext's
+      // cookie jar and proxy (same primitive health-predicate-runner uses) but is not
+      // a page fetch, so no origin is attached and CORS never applies. It also lifts
+      // the browser's forbidden-header rules, so a captured Cookie/Authorization can
+      // be sent explicitly.
+      //
+      // Same-origin calls keep using the in-page fetch, which preserves the page's JS
+      // context (interceptors that mint per-request tokens still run).
+      const context = page.context();
+      const pageOrigin = (() => {
+        try { return new URL(page.url()).origin; } catch { return null; }
+      })();
+      const isCrossOrigin = pageOrigin === null || pageOrigin !== parsed.origin;
+
+      const fetchViaContext = async (): Promise<ExecuteFetchResponse> => {
+        const resp = await context.request.fetch(fetchUrl, {
+          method,
+          headers,
+          ...(fetchBody !== null && method !== 'GET' && method !== 'HEAD'
+            ? { data: fetchBody }
+            : {}),
+          timeout: timeoutMs,
+          maxRedirects: 10,
+          // Report the target's own status rather than throwing on 4xx/5xx — callers
+          // need to see a 401/403 to react to it.
+          failOnStatusCode: false,
+        });
+
+        const respHeaders = resp.headers();
+        const contentType = (respHeaders['content-type'] || '').toLowerCase();
+        const isTextual =
+          contentType === '' ||
+          contentType.startsWith('text/') ||
+          contentType.includes('json') ||
+          contentType.includes('xml') ||
+          contentType.includes('javascript') ||
+          contentType.includes('x-www-form-urlencoded') ||
+          contentType.includes('svg');
+
+        const buf = await resp.body();
+        if (isTextual) {
+          const text = buf.toString('utf-8');
+          const wasTruncated = text.length > maxResponseBytes;
+          return {
+            status: resp.status(),
+            headers: respHeaders,
+            body: wasTruncated ? text.slice(0, maxResponseBytes) : text,
+            encoding: 'utf-8',
+            truncated: wasTruncated,
+          };
+        }
+        const wasTruncated = buf.length > maxResponseBytes;
+        return {
+          status: resp.status(),
+          headers: respHeaders,
+          body: (wasTruncated ? buf.subarray(0, maxResponseBytes) : buf).toString('base64'),
+          encoding: 'base64',
+          truncated: wasTruncated,
+        };
+      };
+
+      if (isCrossOrigin) {
+        const response = await fetchViaContext().catch((err: Error) => {
+          throw new ExecuteError(502, `Cross-origin fetch failed: ${err.message}`);
+        });
+        res.json(response);
+        return;
+      }
+
       const result = await page.evaluate(
         async ({
           url, method: m, headers: h, body: b, maxBytes,
@@ -134,8 +211,15 @@ export function registerExecuteHandler(app: Express, page: Page): void {
           body: fetchBody,
           maxBytes: maxResponseBytes,
         },
-      ).catch((err: Error) => {
-        throw new ExecuteError(502, `Browser fetch failed: ${err.message}`);
+      ).catch(async (err: Error) => {
+        // Same-origin fetches can still be refused by the page — a CSP connect-src
+        // rule, or a service worker. Retry off-page before giving up, for the same
+        // reason cross-origin goes there directly.
+        try {
+          return await fetchViaContext();
+        } catch {
+          throw new ExecuteError(502, `Browser fetch failed: ${err.message}`);
+        }
       });
 
       const response: ExecuteFetchResponse = result;

--- a/apps/worker/src/execute-integration.spec.ts
+++ b/apps/worker/src/execute-integration.spec.ts
@@ -17,9 +17,23 @@ function signToken(claims: Record<string, any> = {}, expiresIn: string = '2m'): 
   );
 }
 
-function mockPage(): any {
+function mockApiResponse(overrides: Record<string, any> = {}) {
+  return {
+    status: jest.fn().mockReturnValue(200),
+    headers: jest.fn().mockReturnValue({ 'content-type': 'application/json' }),
+    body: jest.fn().mockResolvedValue(Buffer.from('{"via":"context"}')),
+    ...overrides,
+  };
+}
+
+function mockPage(overrides: { contextFetch?: jest.Mock } = {}): any {
+  const contextFetch = overrides.contextFetch
+    ?? jest.fn().mockResolvedValue(mockApiResponse());
   return {
     evaluate: jest.fn().mockResolvedValue({ status: 200, headers: {}, body: 'ok' }),
+    // Cross-origin / CSP-refused fetches are served off-page through the
+    // BrowserContext's APIRequestContext, which shares its cookie jar.
+    context: jest.fn().mockReturnValue({ request: { fetch: contextFetch } }),
     goto: jest.fn().mockResolvedValue(undefined),
     url: jest.fn().mockReturnValue('https://example.com'),
     title: jest.fn().mockResolvedValue('Example'),
@@ -188,8 +202,9 @@ describe('execute handlers (integration)', () => {
     });
 
     it('returns 200 with page.evaluate result for valid request', async () => {
+      // Same-origin as page.url() so this still exercises the in-page path.
       const res = await request(server, 'POST', '/execute/fetch', {
-        url: 'https://api.example.com/data',
+        url: 'https://example.com/data',
         method: 'GET',
       }, auth());
       expect(res.status).toBe(200);
@@ -198,10 +213,14 @@ describe('execute handlers (integration)', () => {
       expect(page.evaluate).toHaveBeenCalled();
     });
 
-    it('returns 502 when page.evaluate throws', async () => {
+    it('returns 502 only when both the in-page and off-page fetches fail', async () => {
+      // A failed in-page fetch now retries through the BrowserContext (CSP /
+      // service-worker refusals are recoverable there), so 502 means both failed.
       page.evaluate.mockRejectedValueOnce(new Error('page crashed'));
+      (page.context().request.fetch as jest.Mock)
+        .mockRejectedValueOnce(new Error('context unreachable'));
       const res = await request(server, 'POST', '/execute/fetch', {
-        url: 'https://api.example.com/data',
+        url: 'https://example.com/data',
       }, auth());
       expect(res.status).toBe(502);
       expect(res.body.error).toMatch(/Browser fetch failed/);
@@ -216,7 +235,7 @@ describe('execute handlers (integration)', () => {
         truncated: false,
       });
       const res = await request(server, 'POST', '/execute/fetch', {
-        url: 'https://api.example.com/statement.pdf',
+        url: 'https://example.com/statement.pdf',
       }, auth());
       expect(res.status).toBe(200);
       expect(res.body.encoding).toBe('base64');
@@ -284,6 +303,78 @@ describe('execute handlers (integration)', () => {
       expect(res.status).toBe(200);
       expect(res.body.success).toBe(false);
       expect(res.body.error).toMatch(/not allowed/);
+    });
+  });
+
+
+  // ─── Cross-origin routing ────────────────────────────────────────
+
+  describe('cross-origin routing', () => {
+    // An in-page fetch() carries the page's origin, so a target that sends no CORS
+    // headers fails as "TypeError: Failed to fetch" even with a perfectly valid
+    // session. Multi-origin apps are the norm for bank portals (ICICI serves its
+    // dashboard from retailnetbanking.icici.bank.in and its statement APIs from
+    // infinity.icici.bank.in), so those calls must go off-page through the
+    // BrowserContext, which shares cookies but attaches no origin.
+    let contextFetch: jest.Mock;
+
+    beforeEach(() => {
+      contextFetch = page.context().request.fetch as jest.Mock;
+      contextFetch.mockReset();
+      contextFetch.mockResolvedValue(mockApiResponse());
+      (page.evaluate as jest.Mock).mockReset();
+      (page.evaluate as jest.Mock).mockResolvedValue({
+        status: 200, headers: {}, body: 'in-page', encoding: 'utf-8', truncated: false,
+      });
+      (page.url as jest.Mock).mockReturnValue('https://example.com/dashboard');
+    });
+
+    it('routes a cross-origin target off-page so CORS cannot block it', async () => {
+      const res = await request(
+        server, 'POST', '/execute/fetch',
+        { url: 'https://other-host.example/v1/statement' },
+        { Authorization: `Bearer ${signToken()}` },
+      );
+      expect(res.status).toBe(200);
+      expect(contextFetch).toHaveBeenCalledTimes(1);
+      expect(page.evaluate).not.toHaveBeenCalled();
+      expect(res.body.body).toBe('{"via":"context"}');
+    });
+
+    it('keeps same-origin calls in the page so JS interceptors still run', async () => {
+      const res = await request(
+        server, 'POST', '/execute/fetch',
+        { url: 'https://example.com/dashboardAPI/summary' },
+        { Authorization: `Bearer ${signToken()}` },
+      );
+      expect(res.status).toBe(200);
+      expect(page.evaluate).toHaveBeenCalledTimes(1);
+      expect(contextFetch).not.toHaveBeenCalled();
+      expect(res.body.body).toBe('in-page');
+    });
+
+    it('falls back off-page when a same-origin fetch is refused (CSP, service worker)', async () => {
+      (page.evaluate as jest.Mock).mockRejectedValue(new Error('TypeError: Failed to fetch'));
+      const res = await request(
+        server, 'POST', '/execute/fetch',
+        { url: 'https://example.com/dashboardAPI/summary' },
+        { Authorization: `Bearer ${signToken()}` },
+      );
+      expect(res.status).toBe(200);
+      expect(contextFetch).toHaveBeenCalledTimes(1);
+      expect(res.body.body).toBe('{"via":"context"}');
+    });
+
+    it('reports the target status instead of throwing on 4xx', async () => {
+      // Callers need to see a 401/403 to react to it; failOnStatusCode must stay off.
+      contextFetch.mockResolvedValue(mockApiResponse({ status: jest.fn().mockReturnValue(403) }));
+      const res = await request(
+        server, 'POST', '/execute/fetch',
+        { url: 'https://other-host.example/v1/statement' },
+        { Authorization: `Bearer ${signToken()}` },
+      );
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe(403);
     });
   });
 });

--- a/apps/worker/src/health-predicate-runner.spec.ts
+++ b/apps/worker/src/health-predicate-runner.spec.ts
@@ -32,6 +32,46 @@ function runner(page: any, check: Record<string, unknown>) {
   return new HealthPredicateRunner(page, CONTEXT, { health_checks: [check], policy: 'all' });
 }
 
+/** Page + context stubs for url_check: page.url() is the LIVE browser URL; the
+ *  APIRequestContext GET returns a fixed 200 (the SPA shell, served on every
+ *  route regardless of auth). */
+function makeUrlCheckPage(liveUrl: string) {
+  const page = { url: jest.fn().mockReturnValue(liveUrl) } as any;
+  const context = {
+    request: {
+      get: jest.fn(async () => ({ url: () => liveUrl, status: () => 200 })),
+    },
+  } as any;
+  return { page, context };
+}
+
+describe('HealthPredicateRunner — url_check live-page detection', () => {
+  const CHECK = {
+    type: 'url_check',
+    url: 'https://bank.test/credit-card',
+    expect_status: 200,
+    auth_redirect_pattern: '/login|/session-expire|/logout',
+  };
+
+  it('AUTH_FAIL when the live browser is on an auth/expiry URL, even though the HTTP probe 200s', async () => {
+    // The ICICI case: SPA route-changed the browser to /session-expire client-
+    // side, but the server still serves the shell with 200 on every route, so
+    // the APIRequestContext GET alone would wrongly PASS.
+    const { page, context } = makeUrlCheckPage('https://bank.test/session-expire');
+    const r = new HealthPredicateRunner(page, context, { health_checks: [CHECK], policy: 'all' });
+    const res = await r.evaluate();
+    expect(res.checks[0].result).toBe(HealthResultType.AUTH_FAIL);
+    expect(res.checks[0].detail).toMatch(/Live page is on an auth/);
+  });
+
+  it('PASS when the live page is on a normal authenticated route', async () => {
+    const { page, context } = makeUrlCheckPage('https://bank.test/credit-card');
+    const r = new HealthPredicateRunner(page, context, { health_checks: [CHECK], policy: 'all' });
+    const res = await r.evaluate();
+    expect(res.checks[0].result).toBe(HealthResultType.PASS);
+  });
+});
+
 describe('HealthPredicateRunner — dom_check', () => {
   it('passes when an expected selector is present', async () => {
     const res = await runner(makePage(true), {

--- a/apps/worker/src/health-predicate-runner.spec.ts
+++ b/apps/worker/src/health-predicate-runner.spec.ts
@@ -128,4 +128,40 @@ describe('HealthPredicateRunner — dom_check', () => {
       expect.objectContaining({ state: 'detached' }),
     );
   });
+
+  // DOM presence is right for SPA portals, but it silently redefined `exists`
+  // for every stored config: a portal that HIDES rather than unmounts its
+  // logged-in chrome on sign-out keeps the marker attached on the login page, so
+  // 'attached' reports PASS on a dead session and it never reaches LOGIN_NEEDED.
+  // `match: 'visible'` is the opt-out for those.
+  it('honors match:visible as an opt-out to strict CSS visibility', async () => {
+    const page = makePage(true);
+    await runner(page, {
+      type: 'dom_check', selector: '#x', exists: true, match: 'visible',
+    }).evaluate();
+    expect(page.locator().first().waitFor).toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'visible' }),
+    );
+  });
+
+  // Under strict visibility, "the logged-out marker is gone" means Playwright's
+  // 'hidden' (detached OR present-but-invisible) — which is what the comment at
+  // the top of runDomCheck always claimed, while the code used 'detached'.
+  it('uses hidden (not detached) for a negative check under match:visible', async () => {
+    const page = makePage(false);
+    await runner(page, {
+      type: 'dom_check', selector: '#x', exists: false, match: 'visible',
+    }).evaluate();
+    expect(page.locator().first().waitFor).toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'hidden' }),
+    );
+  });
+
+  it('reports which mode failed so a false AUTH_FAIL is diagnosable', async () => {
+    const res = await runner(makePage(false), {
+      type: 'dom_check', selector: '#dashboard', exists: true, match: 'visible',
+    }).evaluate();
+    expect(res.checks[0].result).toBe(HealthResultType.AUTH_FAIL);
+    expect(res.checks[0].detail).toMatch(/not visible/);
+  });
 });

--- a/apps/worker/src/health-predicate-runner.spec.ts
+++ b/apps/worker/src/health-predicate-runner.spec.ts
@@ -1,0 +1,80 @@
+import { HealthPredicateRunner } from './health-predicate-runner';
+import { HealthResultType } from '@browser-hitl/shared';
+
+/**
+ * Page stub whose locator resolves waitFor() per requested state.
+ *
+ * `present` models whether the selector is on the page: Playwright resolves
+ * `state: 'visible'` only when it is, and `state: 'hidden'` only when it is not
+ * (detached counts as hidden).
+ */
+function makePage(present: boolean) {
+  return {
+    locator: jest.fn().mockReturnValue({
+      waitFor: jest.fn(async ({ state }: { state?: string }) => {
+        const wanted = state === 'hidden' ? !present : present;
+        if (!wanted) throw new Error('Timeout waiting for selector');
+      }),
+    }),
+    url: jest.fn().mockReturnValue('https://app.test/dashboard'),
+  } as any;
+}
+
+const CONTEXT = { request: {} } as any;
+
+function runner(page: any, check: Record<string, unknown>) {
+  return new HealthPredicateRunner(page, CONTEXT, { health_checks: [check], policy: 'all' });
+}
+
+describe('HealthPredicateRunner — dom_check', () => {
+  it('passes when an expected selector is present', async () => {
+    const res = await runner(makePage(true), {
+      type: 'dom_check', selector: '#dashboard', exists: true,
+    }).evaluate();
+    expect(res.checks[0].result).toBe(HealthResultType.PASS);
+  });
+
+  it('fails when an expected selector is missing', async () => {
+    const res = await runner(makePage(false), {
+      type: 'dom_check', selector: '#dashboard', exists: true,
+    }).evaluate();
+    expect(res.checks[0].result).toBe(HealthResultType.AUTH_FAIL);
+  });
+
+  // The regression this file exists for.
+  //
+  // `exists: false` asserts the selector is ABSENT — the way to say "the
+  // logged-out marker is gone". The old implementation always waited for the
+  // element to appear and mapped the resulting timeout to AUTH_FAIL, so the
+  // passing condition reported failure and a negative check could never pass.
+  // That left no way to detect "signed out" on an SPA portal, where every route
+  // returns 200 whether or not anyone is authenticated.
+  it('passes when a selector asserted absent really is absent', async () => {
+    const res = await runner(makePage(false), {
+      type: 'dom_check', selector: 'text=Please click the login button', exists: false,
+    }).evaluate();
+    expect(res.checks[0].result).toBe(HealthResultType.PASS);
+  });
+
+  it('fails when a selector asserted absent is present', async () => {
+    const res = await runner(makePage(true), {
+      type: 'dom_check', selector: 'text=Please click the login button', exists: false,
+    }).evaluate();
+    expect(res.checks[0].result).toBe(HealthResultType.AUTH_FAIL);
+    expect(res.checks[0].detail).toMatch(/found/);
+  });
+
+  it('waits for the right Playwright state in each mode', async () => {
+    const page = makePage(true);
+    await runner(page, { type: 'dom_check', selector: '#x', exists: true }).evaluate();
+    expect(page.locator().waitFor).toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'visible' }),
+    );
+
+    const page2 = makePage(false);
+    await runner(page2, { type: 'dom_check', selector: '#x', exists: false }).evaluate();
+    expect(page2.locator().waitFor).toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'hidden' }),
+    );
+  });
+});

--- a/apps/worker/src/health-predicate-runner.spec.ts
+++ b/apps/worker/src/health-predicate-runner.spec.ts
@@ -11,9 +11,13 @@ import { HealthResultType } from '@browser-hitl/shared';
 function makePage(present: boolean) {
   return {
     locator: jest.fn().mockReturnValue({
-      waitFor: jest.fn(async ({ state }: { state?: string }) => {
-        const wanted = state === 'hidden' ? !present : present;
-        if (!wanted) throw new Error('Timeout waiting for selector');
+      // .first() is what the runner actually waits on — a bare locator throws a
+      // strict-mode violation when the selector matches several nodes.
+      first: jest.fn().mockReturnValue({
+        waitFor: jest.fn(async ({ state }: { state?: string }) => {
+          const wanted = state === 'hidden' ? !present : present;
+          if (!wanted) throw new Error('Timeout waiting for selector');
+        }),
       }),
     }),
     url: jest.fn().mockReturnValue('https://app.test/dashboard'),
@@ -61,19 +65,19 @@ describe('HealthPredicateRunner — dom_check', () => {
       type: 'dom_check', selector: 'text=Please click the login button', exists: false,
     }).evaluate();
     expect(res.checks[0].result).toBe(HealthResultType.AUTH_FAIL);
-    expect(res.checks[0].detail).toMatch(/found/);
+    expect(res.checks[0].detail).toMatch(/still visible/);
   });
 
   it('waits for the right Playwright state in each mode', async () => {
     const page = makePage(true);
     await runner(page, { type: 'dom_check', selector: '#x', exists: true }).evaluate();
-    expect(page.locator().waitFor).toHaveBeenCalledWith(
+    expect(page.locator().first().waitFor).toHaveBeenCalledWith(
       expect.objectContaining({ state: 'visible' }),
     );
 
     const page2 = makePage(false);
     await runner(page2, { type: 'dom_check', selector: '#x', exists: false }).evaluate();
-    expect(page2.locator().waitFor).toHaveBeenCalledWith(
+    expect(page2.locator().first().waitFor).toHaveBeenCalledWith(
       expect.objectContaining({ state: 'hidden' }),
     );
   });

--- a/apps/worker/src/health-predicate-runner.spec.ts
+++ b/apps/worker/src/health-predicate-runner.spec.ts
@@ -4,9 +4,11 @@ import { HealthResultType } from '@browser-hitl/shared';
 /**
  * Page stub whose locator resolves waitFor() per requested state.
  *
- * `present` models whether the selector is on the page: Playwright resolves
- * `state: 'visible'` only when it is, and `state: 'hidden'` only when it is not
- * (detached counts as hidden).
+ * `present` models whether the selector is in the DOM: Playwright resolves
+ * `state: 'attached'` only when it is, and `state: 'detached'` only when it is
+ * not. The runner deliberately asks about DOM presence rather than CSS
+ * visibility — SPA portals render logged-in chrome that Playwright reports as
+ * hidden, which made signed-in sessions fail.
  */
 function makePage(present: boolean) {
   return {
@@ -15,7 +17,7 @@ function makePage(present: boolean) {
       // strict-mode violation when the selector matches several nodes.
       first: jest.fn().mockReturnValue({
         waitFor: jest.fn(async ({ state }: { state?: string }) => {
-          const wanted = state === 'hidden' ? !present : present;
+          const wanted = state === 'detached' ? !present : present;
           if (!wanted) throw new Error('Timeout waiting for selector');
         }),
       }),
@@ -65,20 +67,25 @@ describe('HealthPredicateRunner — dom_check', () => {
       type: 'dom_check', selector: 'text=Please click the login button', exists: false,
     }).evaluate();
     expect(res.checks[0].result).toBe(HealthResultType.AUTH_FAIL);
-    expect(res.checks[0].detail).toMatch(/still visible/);
+    expect(res.checks[0].detail).toMatch(/still in DOM/);
   });
 
-  it('waits for the right Playwright state in each mode', async () => {
+  // Regression: asking for 'visible' made a fully signed-in ICICI dashboard
+  // report AUTH_FAIL — Playwright resolved its sidebar link to
+  // "hidden <a class=\"mb-0\">Payment & Transfer</a>" 20 times in a row while the
+  // user was looking at it on screen. The check is named `exists`; DOM presence
+  // is what it must test.
+  it('tests DOM presence, not CSS visibility', async () => {
     const page = makePage(true);
     await runner(page, { type: 'dom_check', selector: '#x', exists: true }).evaluate();
     expect(page.locator().first().waitFor).toHaveBeenCalledWith(
-      expect.objectContaining({ state: 'visible' }),
+      expect.objectContaining({ state: 'attached' }),
     );
 
     const page2 = makePage(false);
     await runner(page2, { type: 'dom_check', selector: '#x', exists: false }).evaluate();
     expect(page2.locator().first().waitFor).toHaveBeenCalledWith(
-      expect.objectContaining({ state: 'hidden' }),
+      expect.objectContaining({ state: 'detached' }),
     );
   });
 });

--- a/apps/worker/src/health-predicate-runner.ts
+++ b/apps/worker/src/health-predicate-runner.ts
@@ -64,6 +64,14 @@ export class HealthPredicateRunner {
         detail,
         duration_ms: Date.now() - start,
       });
+
+      // A failing health check drives the whole session lifecycle (AUTH_FAIL ->
+      // LOGIN_NEEDED, and every consumer that reads session health), so the reason
+      // must be visible in the pod log. Debugging a wrong verdict without it means
+      // guessing at the selector.
+      if (result !== HealthResultType.PASS) {
+        console.log(`[Health] ${check.type} -> ${result}${detail ? `: ${detail}` : ''}`);
+      }
     }
 
     const overall = evaluateHealthPolicy(results, policy, quorumN);
@@ -152,20 +160,35 @@ export class HealthPredicateRunner {
     // Wait for the state each mode actually wants. Playwright's 'hidden' resolves
     // when the element is detached OR present-but-invisible, which is what "not
     // showing the logged-out marker" means in practice.
+    // .first() throughout: a selector matching several nodes (very easy with a
+    // text= selector on a rich page) makes a bare locator.waitFor throw a strict-mode
+    // violation, and the catch below cannot tell that apart from the element genuinely
+    // being there — so a logged-IN page reported AUTH_FAIL. Matching the first node is
+    // the right semantics for a presence check anyway.
+    const first = locator.first();
+
     if (check.exists) {
       try {
-        await locator.waitFor({ state: 'visible', timeout });
+        await first.waitFor({ state: 'visible', timeout });
         return { result: HealthResultType.PASS };
-      } catch {
-        return { result: HealthResultType.AUTH_FAIL, detail: `Selector ${check.selector} not found` };
+      } catch (error) {
+        return {
+          result: HealthResultType.AUTH_FAIL,
+          detail: `Selector ${check.selector} not visible: ${error}`,
+        };
       }
     }
 
     try {
-      await locator.waitFor({ state: 'hidden', timeout });
+      await first.waitFor({ state: 'hidden', timeout });
       return { result: HealthResultType.PASS };
-    } catch {
-      return { result: HealthResultType.AUTH_FAIL, detail: `Selector ${check.selector} found` };
+    } catch (error) {
+      // Report WHY. A bare "found" hid the difference between the marker really
+      // being on the page and the check itself misfiring.
+      return {
+        result: HealthResultType.AUTH_FAIL,
+        detail: `Selector ${check.selector} still visible: ${error}`,
+      };
     }
   }
 

--- a/apps/worker/src/health-predicate-runner.ts
+++ b/apps/worker/src/health-predicate-runner.ts
@@ -189,38 +189,53 @@ export class HealthPredicateRunner {
     // the right semantics for a presence check anyway.
     const first = locator.first();
 
-    // attached/detached, NOT visible/hidden. The check is named `exists`, and DOM
-    // presence is what it should mean — CSS visibility is a different question that
-    // SPA portals answer badly. Playwright reports the sidebar link of a fully
-    // logged-in ICICI dashboard as hidden:
+    // What `exists` means is selectable via `match`, defaulting to DOM presence:
     //
-    //   20 x locator resolved to hidden <a class="mb-0">Payment & Transfer</a>
+    //   'attached' (default) — the marker is in the DOM at all. CSS visibility is
+    //     a different question that SPA portals answer badly: Playwright reports
+    //     the sidebar link of a fully logged-in ICICI dashboard as hidden
+    //     (`20 x locator resolved to hidden <a class="mb-0">Payment & Transfer</a>`),
+    //     so a signed-in session reported AUTH_FAIL. Salesforce Lightning and
+    //     Workday do the same (see the gotchas in CLAUDE.md); it is the single
+    //     most common cause of a false AUTH_FAIL on this platform.
     //
-    // ...so a signed-in session reported AUTH_FAIL. Salesforce Lightning and
-    // Workday do the same thing (see the gotchas in CLAUDE.md); it is the single
-    // most common cause of a false AUTH_FAIL on this platform. A marker rendered
-    // into the DOM at all is the signal worth having.
+    //   'visible' — opt back in to strict CSS visibility. Needed by portals that
+    //     HIDE rather than unmount their logged-in chrome on sign-out: there the
+    //     marker stays attached on the login page, so 'attached' would report
+    //     PASS on a dead session and it would never transition to LOGIN_NEEDED.
+    //     Opt-in rather than default, because defaulting to it reintroduces the
+    //     dominant false-AUTH_FAIL above for every SPA app.
+    const strictVisibility = check.match === 'visible';
+
     if (check.exists) {
       try {
-        await first.waitFor({ state: 'attached', timeout });
+        await first.waitFor({ state: strictVisibility ? 'visible' : 'attached', timeout });
         return { result: HealthResultType.PASS };
       } catch (error) {
         return {
           result: HealthResultType.AUTH_FAIL,
-          detail: `Selector ${check.selector} not in DOM: ${error}`,
+          detail: strictVisibility
+            ? `Selector ${check.selector} not visible: ${error}`
+            : `Selector ${check.selector} not in DOM: ${error}`,
         };
       }
     }
 
+    // Negative check: assert the logged-OUT marker is gone. Mirror the mode —
+    // under strict visibility "gone" means Playwright's 'hidden' (detached OR
+    // present-but-invisible), which is what "not showing the marker" means to a
+    // user; under DOM presence it means fully detached.
     try {
-      await first.waitFor({ state: 'detached', timeout });
+      await first.waitFor({ state: strictVisibility ? 'hidden' : 'detached', timeout });
       return { result: HealthResultType.PASS };
     } catch (error) {
       // Report WHY. A bare "found" hid the difference between the marker really
       // being on the page and the check itself misfiring.
       return {
         result: HealthResultType.AUTH_FAIL,
-        detail: `Selector ${check.selector} still in DOM: ${error}`,
+        detail: strictVisibility
+          ? `Selector ${check.selector} still showing: ${error}`
+          : `Selector ${check.selector} still in DOM: ${error}`,
       };
     }
   }

--- a/apps/worker/src/health-predicate-runner.ts
+++ b/apps/worker/src/health-predicate-runner.ts
@@ -138,22 +138,34 @@ export class HealthPredicateRunner {
    * DOM check: verify selector exists on current page (spec section 9.9).
    */
   private async runDomCheck(check: any): Promise<{ result: HealthResultType; detail?: string }> {
+    const locator = this.page.locator(check.selector);
+    const timeout = check.timeout_ms ?? 5000;
+
+    // `exists: false` asserts the selector is ABSENT — which is the whole point of
+    // a negative check: assert the logged-out marker (a login form, an auth error
+    // page) is gone. The previous implementation always waited for the element to
+    // appear and treated the resulting timeout as AUTH_FAIL, so an absent selector
+    // — the passing condition — reported failure. A negative check could therefore
+    // never pass, and the only way to detect "signed out" on an SPA portal was
+    // unavailable.
+    //
+    // Wait for the state each mode actually wants. Playwright's 'hidden' resolves
+    // when the element is detached OR present-but-invisible, which is what "not
+    // showing the logged-out marker" means in practice.
+    if (check.exists) {
+      try {
+        await locator.waitFor({ state: 'visible', timeout });
+        return { result: HealthResultType.PASS };
+      } catch {
+        return { result: HealthResultType.AUTH_FAIL, detail: `Selector ${check.selector} not found` };
+      }
+    }
+
     try {
-      const locator = this.page.locator(check.selector);
-      await locator.waitFor({ timeout: 5000 });
-
-      const visible = await locator.isVisible();
-      if (check.exists && visible) {
-        return { result: HealthResultType.PASS };
-      }
-      if (!check.exists && !visible) {
-        return { result: HealthResultType.PASS };
-      }
-
-      return { result: HealthResultType.AUTH_FAIL, detail: `Selector ${check.exists ? 'not found' : 'found'}` };
+      await locator.waitFor({ state: 'hidden', timeout });
+      return { result: HealthResultType.PASS };
     } catch {
-      // Timeout or page loading
-      return { result: HealthResultType.AUTH_FAIL, detail: `Selector ${check.selector} not found` };
+      return { result: HealthResultType.AUTH_FAIL, detail: `Selector ${check.selector} found` };
     }
   }
 

--- a/apps/worker/src/health-predicate-runner.ts
+++ b/apps/worker/src/health-predicate-runner.ts
@@ -91,6 +91,28 @@ export class HealthPredicateRunner {
   private async runUrlCheck(check: any): Promise<{ result: HealthResultType; detail?: string }> {
     const timeoutMs = check.timeout_ms ?? 15000;
 
+    // Where the LIVE browser actually is, checked FIRST. An SPA enforces session
+    // expiry client-side: the JS detects a dead session and route-changes to a
+    // /session-expire page, but the server still serves the app shell with HTTP
+    // 200 on every route. So the APIRequestContext GET below can't see it — it
+    // gets 200 and PASSes while the user is staring at "Your session has
+    // expired" (observed on ICICI: HEALTHY/PASS on /session-expire). If the
+    // browser page itself is already sitting on an auth/expiry URL, that is
+    // ground truth the HTTP probe cannot override.
+    if (check.auth_redirect_pattern) {
+      try {
+        const liveUrl = this.page.url();
+        if (new RegExp(check.auth_redirect_pattern, 'i').test(liveUrl)) {
+          return {
+            result: HealthResultType.AUTH_FAIL,
+            detail: `Live page is on an auth/expiry URL: ${liveUrl}`,
+          };
+        }
+      } catch {
+        // page.url() should never throw, but never let it break the check.
+      }
+    }
+
     try {
       // Use Playwright's APIRequestContext — it inherits the browser's proxy
       // and cookies, so it can reach external URLs through the egress proxy.

--- a/apps/worker/src/health-predicate-runner.ts
+++ b/apps/worker/src/health-predicate-runner.ts
@@ -167,27 +167,38 @@ export class HealthPredicateRunner {
     // the right semantics for a presence check anyway.
     const first = locator.first();
 
+    // attached/detached, NOT visible/hidden. The check is named `exists`, and DOM
+    // presence is what it should mean — CSS visibility is a different question that
+    // SPA portals answer badly. Playwright reports the sidebar link of a fully
+    // logged-in ICICI dashboard as hidden:
+    //
+    //   20 x locator resolved to hidden <a class="mb-0">Payment & Transfer</a>
+    //
+    // ...so a signed-in session reported AUTH_FAIL. Salesforce Lightning and
+    // Workday do the same thing (see the gotchas in CLAUDE.md); it is the single
+    // most common cause of a false AUTH_FAIL on this platform. A marker rendered
+    // into the DOM at all is the signal worth having.
     if (check.exists) {
       try {
-        await first.waitFor({ state: 'visible', timeout });
+        await first.waitFor({ state: 'attached', timeout });
         return { result: HealthResultType.PASS };
       } catch (error) {
         return {
           result: HealthResultType.AUTH_FAIL,
-          detail: `Selector ${check.selector} not visible: ${error}`,
+          detail: `Selector ${check.selector} not in DOM: ${error}`,
         };
       }
     }
 
     try {
-      await first.waitFor({ state: 'hidden', timeout });
+      await first.waitFor({ state: 'detached', timeout });
       return { result: HealthResultType.PASS };
     } catch (error) {
       // Report WHY. A bare "found" hid the difference between the marker really
       // being on the page and the check itself misfiring.
       return {
         result: HealthResultType.AUTH_FAIL,
-        detail: `Selector ${check.selector} still visible: ${error}`,
+        detail: `Selector ${check.selector} still in DOM: ${error}`,
       };
     }
   }

--- a/apps/worker/src/keepalive-runner.spec.ts
+++ b/apps/worker/src/keepalive-runner.spec.ts
@@ -1,0 +1,72 @@
+import { KeepaliveRunner } from './keepalive-runner';
+
+// Drive runCycle() directly with mocked deps to assert the HEALTHY-gate on the
+// 'activity' nudge: robotic mouse/scroll must not run once the session is on a
+// login/expired page (health != PASS), or reCAPTCHA v3 scores it as a bot.
+function build(healthSeq: string[]) {
+  let i = 0;
+  const execCalls: any[][] = [];
+  const dslRunner = {
+    execute: jest.fn(async (actions: any[]) => {
+      execCalls.push(actions);
+    }),
+  };
+  const healthRunner = {
+    evaluate: jest.fn(async () => ({
+      overall: healthSeq[Math.min(i++, healthSeq.length - 1)],
+      checks: [],
+    })),
+    setKeepaliveConfig: jest.fn(),
+  };
+  const page = { waitForTimeout: jest.fn(async () => undefined) };
+  const db = {
+    loadAppConfig: jest.fn(async () => null), // keep the constructor's appConfig
+    updateHealthResult: jest.fn(async () => undefined),
+    getLastExportedAt: jest.fn(async () => new Date().toISOString()), // fresh → no extract
+    updateLastExportedAt: jest.fn(async () => undefined),
+  };
+  const artifactExtractor = { extractAndUpload: jest.fn(async () => undefined) };
+  const appConfig = {
+    keepalive_config: { interval_seconds: 60, actions: [{ action: 'activity' }] },
+    export_policy: { refresh_interval_seconds: 3600 },
+  };
+  const runner = new KeepaliveRunner(
+    page as any,
+    {} as any,
+    dslRunner as any,
+    healthRunner as any,
+    artifactExtractor as any,
+    db as any,
+    appConfig,
+    'app-1',
+    'sess-1',
+    { username: '', password: '' },
+    false,
+  );
+  return { runner, execCalls, dslRunner };
+}
+
+describe('KeepaliveRunner activity HEALTHY-gate', () => {
+  it('runs the activity nudge on the first cycle and while the session stays healthy', async () => {
+    const { runner, execCalls } = build(['PASS', 'PASS']);
+    await (runner as any).runCycle(); // lastHealth null → runs
+    await (runner as any).runCycle(); // lastHealth PASS → runs
+    expect(execCalls).toEqual([[{ action: 'activity' }], [{ action: 'activity' }]]);
+  });
+
+  it('stops the activity nudge once the session is no longer PASS (bounced to login)', async () => {
+    const { runner, execCalls, dslRunner } = build(['AUTH_FAIL', 'AUTH_FAIL']);
+    await (runner as any).runCycle(); // lastHealth null → runs once, then records AUTH_FAIL
+    await (runner as any).runCycle(); // lastHealth AUTH_FAIL → 'activity' filtered → no execute
+    expect(dslRunner.execute).toHaveBeenCalledTimes(1);
+    expect(execCalls).toEqual([[{ action: 'activity' }]]);
+  });
+
+  it('resumes the nudge if the session returns to PASS', async () => {
+    const { runner, dslRunner } = build(['AUTH_FAIL', 'PASS', 'PASS']);
+    await (runner as any).runCycle(); // null → runs
+    await (runner as any).runCycle(); // AUTH_FAIL → skips
+    await (runner as any).runCycle(); // PASS → runs again
+    expect(dslRunner.execute).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/worker/src/keepalive-runner.spec.ts
+++ b/apps/worker/src/keepalive-runner.spec.ts
@@ -70,3 +70,16 @@ describe('KeepaliveRunner activity HEALTHY-gate', () => {
     expect(dslRunner.execute).toHaveBeenCalledTimes(2);
   });
 });
+
+describe('KeepaliveRunner activity gate is AUTH_FAIL-only', () => {
+  it('keeps nudging through a TRANSIENT_FAIL', async () => {
+    // A 5xx / probe timeout / egress blip does not mean the session is signed
+    // out. Suppressing the nudge there lets the portal's own idle timer run out
+    // and turns a recoverable blip into a real expiry — the outcome 'activity'
+    // exists to prevent. Only a login page (AUTH_FAIL) should stop it.
+    const { runner, dslRunner } = build(['TRANSIENT_FAIL', 'TRANSIENT_FAIL']);
+    await (runner as any).runCycle();
+    await (runner as any).runCycle();
+    expect(dslRunner.execute).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/worker/src/keepalive-runner.ts
+++ b/apps/worker/src/keepalive-runner.ts
@@ -107,11 +107,16 @@ export class KeepaliveRunner {
       // reCAPTCHA v3 / a fingerprint SDK is scoring reads as a bot and tanks the
       // score before the human can re-login. Non-interactive actions (e.g. goto
       // for header capture) are unaffected, and health checks below still run.
-      if (this.lastHealthOverall !== null && this.lastHealthOverall !== 'PASS') {
+      // AUTH_FAIL only, NOT any non-PASS. TRANSIENT_FAIL is a 5xx / probe
+      // timeout / egress blip — the session is still signed in, so suppressing
+      // the nudge there lets the portal's own idle timer run out and converts a
+      // recoverable blip into a real expiry, the exact outcome 'activity' exists
+      // to prevent. The bot-scoring rationale only applies to a login page.
+      if (this.lastHealthOverall === 'AUTH_FAIL') {
         const before = actions.length;
         actions = actions.filter((a: { action?: string }) => a.action !== 'activity');
         if (actions.length < before) {
-          console.log(`Keepalive: skipping 'activity' nudge (last health ${this.lastHealthOverall}, likely on login page)`);
+          console.log(`Keepalive: skipping 'activity' nudge (last health AUTH_FAIL, likely on login page)`);
         }
       }
       if (actions.length > 0) {

--- a/apps/worker/src/keepalive-runner.ts
+++ b/apps/worker/src/keepalive-runner.ts
@@ -22,6 +22,12 @@ export class KeepaliveRunner {
   private running = false;
   private extracting = false;
   private redis: Redis | null = null;
+  // Last health verdict, used to gate the human-simulation 'activity' nudge:
+  // once a session bounces to a login/expired page (health != PASS), we must
+  // stop feeding it robotic mouse/scroll input, or reCAPTCHA v3 / fingerprint
+  // SDKs score the page as a bot before the human can re-login. null until the
+  // first cycle's health check (session enters keepalive already logged in).
+  private lastHealthOverall: string | null = null;
 
   constructor(
     private readonly page: Page,
@@ -93,8 +99,21 @@ export class KeepaliveRunner {
     try {
       await this.refreshConfig();
 
-      // Step 1: Execute keepalive actions (suppressed in recording mode)
-      const actions = this.recordingMode ? [] : (this.appConfig.keepalive_config?.actions || []);
+      // Step 1: Execute keepalive actions (suppressed in recording mode).
+      let actions = this.recordingMode ? [] : (this.appConfig.keepalive_config?.actions || []);
+      // HEALTHY-gate the 'activity' nudge: if the previous cycle found the
+      // session NOT healthy (it has likely bounced to the app's login/expired
+      // page), skip the trusted mouse-move + scroll — robotic input on a page
+      // reCAPTCHA v3 / a fingerprint SDK is scoring reads as a bot and tanks the
+      // score before the human can re-login. Non-interactive actions (e.g. goto
+      // for header capture) are unaffected, and health checks below still run.
+      if (this.lastHealthOverall !== null && this.lastHealthOverall !== 'PASS') {
+        const before = actions.length;
+        actions = actions.filter((a: { action?: string }) => a.action !== 'activity');
+        if (actions.length < before) {
+          console.log(`Keepalive: skipping 'activity' nudge (last health ${this.lastHealthOverall}, likely on login page)`);
+        }
+      }
       if (actions.length > 0) {
         try {
           await this.dslRunner.execute(actions, this.credentials);
@@ -108,6 +127,9 @@ export class KeepaliveRunner {
 
       // Step 3-4: Execute health predicates and write results
       const healthResult = await this.healthRunner.evaluate();
+      // Remember the verdict so the NEXT cycle can gate the 'activity' nudge
+      // (see Step 1) — a not-PASS session is likely sitting on a login page.
+      this.lastHealthOverall = healthResult.overall;
       await this.db.updateHealthResult(this.sessionId, healthResult.overall);
 
       console.log(`Health check: ${healthResult.overall} (${healthResult.checks.length} checks)`);

--- a/apps/worker/src/login-dsl-runner.spec.ts
+++ b/apps/worker/src/login-dsl-runner.spec.ts
@@ -46,6 +46,11 @@ function createMockPage() {
     evaluate: jest.fn().mockResolvedValue(undefined),
     screenshot: jest.fn().mockResolvedValue(undefined),
     reload: jest.fn().mockResolvedValue(undefined),
+    viewportSize: jest.fn().mockReturnValue({ width: 1200, height: 800 }),
+    mouse: {
+      move: jest.fn().mockResolvedValue(undefined),
+      wheel: jest.fn().mockResolvedValue(undefined),
+    },
     _locator: locator,
     _frameLocatorObj: frameLocatorObj,
   };
@@ -561,5 +566,27 @@ describe('LoginDslRunner', () => {
 
       expect(page.goto).toHaveBeenCalledWith('https://example.com/quote/abc123', expect.any(Object));
     });
+  });
+});
+
+describe('activity keepalive action', () => {
+  it('nudges the mouse and scrolls (trusted events) without clicking or navigating', async () => {
+    const { runner, page } = buildRunner();
+    await runner.execute([{ action: 'activity' } as any], { username: '', password: '' });
+    // real Playwright input → trusted events a bank's idle listener resets on
+    expect(page.mouse.move).toHaveBeenCalled();
+    expect(page.mouse.wheel).toHaveBeenCalled();
+    // and it must NOT reload / navigate (that is what expires the session)
+    expect(page.goto).not.toHaveBeenCalled();
+    expect(page.reload).not.toHaveBeenCalled();
+  });
+
+  it('never throws even if input fails (must not break the keepalive loop)', async () => {
+    const page = createMockPage();
+    (page.mouse.move as jest.Mock).mockRejectedValue(new Error('detached'));
+    const { runner } = buildRunner({ page });
+    await expect(
+      runner.execute([{ action: 'activity' } as any], { username: '', password: '' }),
+    ).resolves.not.toThrow();
   });
 });

--- a/apps/worker/src/login-dsl-runner.ts
+++ b/apps/worker/src/login-dsl-runner.ts
@@ -204,6 +204,30 @@ export class LoginDslRunner {
         await this.page.reload({ timeout });
         break;
 
+      case 'activity': {
+        // Human-like idle-reset keepalive. Banks typically detect idle via DOM
+        // interaction events (mousemove / scroll / keypress reset a client-side
+        // countdown that redirects to /session-expire), NOT via HTTP activity —
+        // which is why an open page still expires and a fetch heartbeat may not
+        // help. Playwright's mouse input generates TRUSTED events (isTrusted =
+        // true), indistinguishable from a real user, so a small move + a scroll
+        // nudge resets that timer the way a human would. No clicks, no keys, no
+        // navigation — safe on any page (including the login/expiry page).
+        try {
+          const vp = this.page.viewportSize() || { width: 1200, height: 800 };
+          const cx = Math.floor(vp.width / 2);
+          const cy = Math.floor(vp.height / 2);
+          await this.page.mouse.move(cx, cy, { steps: 3 });
+          await this.page.mouse.move(cx + 25, cy + 18, { steps: 3 });
+          await this.page.mouse.wheel(0, 40);
+          await this.page.mouse.wheel(0, -40);
+        } catch (error) {
+          // Never let a keepalive nudge fail the loop.
+          console.warn(`[DSL] activity keepalive nudge failed: ${error}`);
+        }
+        break;
+      }
+
       case 'request_human_input':
         await this.handleHumanInputRequest(step, stepIndex);
         break;

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -22,6 +22,7 @@ import { SessionDb } from './session-db';
 import { RecyclingMonitor } from './recycling-monitor';
 import { ScreenshotFallback } from './screenshot-fallback';
 import { resolveCredentials } from './credential-resolver';
+import { enableDownloadCapture } from './download-capture';
 import { RecordingRunner } from './recording-runner';
 import type { RecordingMode } from '@browser-hitl/shared';
 
@@ -172,19 +173,28 @@ async function main() {
       browser = await chromium.launch(launchOptions);
     }
 
+    // Read policy before creating the context: acceptDownloads must be set at
+    // context-creation time for Playwright to save downloads at all.
+    const browserPolicy = appConfig.browser_policy || { downloads: false, clipboard: false, file_chooser: false };
+    const recordingMode = (browserPolicy as { recording_mode?: RecordingMode }).recording_mode;
+    const downloadsEnabled = browserPolicy.downloads === true;
+
     context = await browser.newContext({
       // VNC: null viewport => the page fills the actual browser window (which we
       // sized to the Xvfb display), so the human sees a full, properly-sized
       // page. CDP/headless keeps a fixed 1920x1080 viewport.
       viewport: streamingMode === 'cdp' ? { width: 1920, height: 1080 } : null,
+      // Without this Playwright silently cancels every download.
+      acceptDownloads: downloadsEnabled,
     });
 
-    // Disable downloads, clipboard, file chooser per browser_policy
-    const browserPolicy = appConfig.browser_policy || { downloads: false, clipboard: false, file_chooser: false };
-    const recordingMode = (browserPolicy as { recording_mode?: RecordingMode }).recording_mode;
-    if (!browserPolicy.downloads) {
-      // Playwright doesn't have a direct "disable downloads" API,
-      // but we intercept and cancel download events
+    // Downloads, clipboard, file chooser per browser_policy.
+    if (downloadsEnabled) {
+      // Opt-in: capture downloads to temp files + an index the /execute/browser
+      // `list_downloads`/`get_download` commands read (see download-capture.ts).
+      enableDownloadCapture(context);
+    } else {
+      // Default: Playwright has no "disable downloads" API, so intercept + cancel.
       context.on('page', (page) => {
         page.on('download', (download) => download.cancel());
       });

--- a/charts/browser-hitl/templates/egress-proxy-deployment.yaml
+++ b/charts/browser-hitl/templates/egress-proxy-deployment.yaml
@@ -46,6 +46,17 @@ spec:
             - node
             - /app/server.js
           env:
+            # Node's Happy Eyeballs (autoSelectFamily, on by default since 20) races the
+            # A and AAAA connects but caps EACH attempt at 250ms. When a target publishes
+            # an AAAA we cannot route, the v6 attempt fails instantly and the v4 fallback
+            # is aborted at 250ms — so any host further away than that never connects and
+            # the browser sees ERR_TUNNEL_CONNECTION_FAILED. Real-world example: ICICI
+            # (retailnetbanking.icici.bank.in) has an AAAA and a ~500ms v4 RTT from
+            # outside India, which fails 100% at the default budget.
+            # Raise the per-attempt budget rather than disabling autoselection, so
+            # dual-stack targets still work where v6 IS routable.
+            - name: NODE_OPTIONS
+              value: "--network-family-autoselection-attempt-timeout={{ .Values.egressProxy.familyAutoselectionTimeoutMs }}"
             - name: EGRESS_PROXY_PORT
               value: {{ .Values.egressProxy.port | quote }}
             - name: EGRESS_PROXY_ADMIN_PORT

--- a/charts/browser-hitl/values-local.secret.yaml.example
+++ b/charts/browser-hitl/values-local.secret.yaml.example
@@ -1,0 +1,14 @@
+# Local-only secret overrides for `make kind-reload-all` / Tilt `tabby-deploy`.
+#
+# Copy to `values-local.secret.yaml` (gitignored) and fill in real values. The
+# Kind helm command auto-includes it with a second `-f` when present, so it
+# survives every reload — unlike a manual `kubectl patch` on the Secret.
+#
+#   cp charts/browser-hitl/values-local.secret.yaml.example \
+#      charts/browser-hitl/values-local.secret.yaml
+#
+# Residential upstream proxy (Oxylabs), used when a session is flagged
+# residential_proxy_enabled. India-targeted + sticky session for bank logins.
+# The {sessionId} placeholder is substituted per session by the egress-proxy.
+secrets:
+  egressUpstreamProxyUrl: "http://customer-<USER>-cc-in-sessid-{sessionId}:<PASS>@pr.oxylabs.io:7777"

--- a/charts/browser-hitl/values-local.yaml
+++ b/charts/browser-hitl/values-local.yaml
@@ -319,6 +319,8 @@ egressProxy:
     - ".icici.bank.in"
     - ".icicibank.com"
     - ".hsbcnet.com"
+    # --- HDFC Life (myaccount portal) ---
+    - ".hdfclife.com"
     # --- Dev/test ---
     - ".dontpad.com"
     - ".api.dontpad.com"

--- a/charts/browser-hitl/values-local.yaml
+++ b/charts/browser-hitl/values-local.yaml
@@ -313,6 +313,12 @@ egressProxy:
     # --- Workday ---
     - ".workday.com"
     - ".workdaycdn.com"
+    # --- ICICI Net Banking ---
+    # Scoped to .icici.bank.in rather than .bank.in: leading-dot entries are suffix
+    # matches, so the broader form would open every *.bank.in registrar domain.
+    - ".icici.bank.in"
+    - ".icicibank.com"
+    - ".hsbcnet.com"
     # --- Dev/test ---
     - ".dontpad.com"
     - ".api.dontpad.com"

--- a/charts/browser-hitl/values.yaml
+++ b/charts/browser-hitl/values.yaml
@@ -365,6 +365,12 @@ egressProxy:
     tag: "20.18.1-alpine"
     pullPolicy: IfNotPresent
   port: 3128
+  # Per-address-family connect budget for Node's Happy Eyeballs (default 250ms).
+  # Must exceed the slowest legitimate target RTT: when a host publishes an AAAA
+  # this cluster cannot route, the v6 attempt fails instantly and the v4 fallback
+  # is cancelled at this deadline, surfacing as ERR_TUNNEL_CONNECTION_FAILED.
+  # 2000ms comfortably covers intercontinental targets.
+  familyAutoselectionTimeoutMs: 2000
   adminPort: 8095
   allowInsecureAdmin: false
   allowInsecureSessionAllowlist: false

--- a/infra/docker/Dockerfile.api
+++ b/infra/docker/Dockerfile.api
@@ -19,6 +19,21 @@ COPY apps/api/src ./apps/api/src
 RUN pnpm install --frozen-lockfile
 RUN pnpm --filter @browser-hitl/shared build && pnpm --filter @browser-hitl/api build
 
+# Vendor the noVNC browser client so the VNC viewer does not fetch it at page load.
+# It must come from the GitHub tree, not the @novnc/novnc npm package: npm publishes
+# only `lib/`, which is a CommonJS (Babel) build, and the viewer loads the client with
+# `import RFB from '/vnc/assets/rfb.js'` — a browser ES-module import of CommonJS fails.
+# Only GitHub's `core/` is ESM. Keep NOVNC_VERSION in step with noVncRootBaseUrl in
+# streaming.controller.ts, which stays as the runtime fallback.
+# Downloaded with node's global fetch since this base image has no curl/wget.
+ARG NOVNC_VERSION=1.5.0
+RUN node -e "const fs=require('fs');fetch('https://github.com/novnc/noVNC/archive/refs/tags/v${NOVNC_VERSION}.tar.gz').then(r=>{if(!r.ok)throw new Error('HTTP '+r.status);return r.arrayBuffer()}).then(b=>fs.writeFileSync('/tmp/novnc.tgz',Buffer.from(b)))" \
+    && tar -xzf /tmp/novnc.tgz -C /tmp \
+    && mkdir -p /app/vendor/novnc \
+    && cp -r /tmp/noVNC-${NOVNC_VERSION}/core /tmp/noVNC-${NOVNC_VERSION}/vendor /app/vendor/novnc/ \
+    && rm -rf /tmp/novnc.tgz /tmp/noVNC-${NOVNC_VERSION} \
+    && test -f /app/vendor/novnc/core/rfb.js
+
 EXPOSE 8000
 
 USER node

--- a/infra/docker/Dockerfile.worker
+++ b/infra/docker/Dockerfile.worker
@@ -14,6 +14,26 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     xvfb x11vnc xclip autocutsel && \
     rm -rf /var/lib/apt/lists/*
 
+# Windows core fonts for CloakBrowser's Windows spoof. A Windows-claiming browser
+# that enumerates only Linux fonts is an anti-bot fingerprint tell — bank login
+# risk engines decline it ("Unable to process your request"). ttf-mscorefonts-
+# installer provides the real MS font *names* (Arial, Times New Roman, Verdana,
+# Georgia, Courier New, Trebuchet, ...) that font probing checks for;
+# fonts-liberation adds metric-compatible fallbacks. Enable multiverse (Noble
+# deb822 format) and auto-accept the EULA. See CloakBrowser font-setup-on-linux.
+RUN set -eux; \
+    if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then \
+      sed -i -E 's/^(Components:.*)$/\1 multiverse/; s/multiverse( multiverse)+/multiverse/' /etc/apt/sources.list.d/ubuntu.sources; \
+    else \
+      echo "deb http://archive.ubuntu.com/ubuntu noble multiverse" > /etc/apt/sources.list.d/multiverse.list; \
+    fi; \
+    apt-get update; \
+    echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | debconf-set-selections; \
+    apt-get install -y --no-install-recommends \
+      ttf-mscorefonts-installer fonts-liberation fontconfig cabextract; \
+    fc-cache -f; \
+    rm -rf /var/lib/apt/lists/*
+
 # Install pnpm
 RUN npm install -g pnpm@10
 

--- a/packages/shared/src/config.types.ts
+++ b/packages/shared/src/config.types.ts
@@ -31,6 +31,17 @@ export interface UrlCheck {
   type: 'url_check';
   url: string;
   expect_status: number;
+  /**
+   * Regex (case-insensitive) tested against the final URL after redirects. A match
+   * means the target bounced us to its login flow → AUTH_FAIL (triggers the HITL
+   * re-login) rather than a generic failure. Set this whenever the target redirects
+   * to something the built-in heuristic misses — it only matches /login|signin|sso|
+   * oauth|saml|authgw|identity/ in the host+path, so a bounce to a bare `/` root
+   * (common for SPAs) goes undetected without an explicit pattern.
+   */
+  auth_redirect_pattern?: string;
+  /** Per-check request timeout. Default 15000. */
+  timeout_ms?: number;
 }
 
 export interface DomCheck {
@@ -44,6 +55,8 @@ export interface NetworkCheck {
   url: string;
   expect_status: number;
   body_contains?: string;
+  /** Per-check request timeout. Default 15000. */
+  timeout_ms?: number;
 }
 
 export type HealthCheck = UrlCheck | DomCheck | NetworkCheck;

--- a/packages/shared/src/config.types.ts
+++ b/packages/shared/src/config.types.ts
@@ -48,6 +48,18 @@ export interface DomCheck {
   type: 'dom_check';
   selector: string;
   exists: boolean;
+  /**
+   * What `exists` tests. Default 'attached' (DOM presence) — SPA portals render
+   * logged-in chrome that Playwright reports as hidden, so requiring CSS
+   * visibility is the most common cause of a false AUTH_FAIL here.
+   *
+   * Use 'visible' for portals that HIDE rather than unmount their logged-in
+   * markers on sign-out: there the marker stays attached on the login page, so
+   * 'attached' would report PASS on a dead session.
+   */
+  match?: 'attached' | 'visible';
+  /** Per-check timeout in ms. Default 5000. */
+  timeout_ms?: number;
 }
 
 export interface NetworkCheck {

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -14,7 +14,17 @@ export const CHROMIUM_FLAGS = [
   '--remote-debugging-address=127.0.0.1',
   '--remote-debugging-port=9222',
   '--disable-dev-shm-usage',
-  '--disable-gpu',
+  // Software WebGL via ANGLE+SwiftShader instead of '--disable-gpu'. Plain
+  // --disable-gpu leaves the page with NO WebGL context at all ("Canvas has no
+  // webgl context" on bot.sannysoft.com) — a real Chrome ALWAYS has a WebGL
+  // context, so "no context" is a hard bot signature that reCAPTCHA v3 /
+  // fingerprint SDKs flag, and it also leaves CloakBrowser nothing to spoof.
+  // These give a working software WebGL context (Chrome gates SwiftShader behind
+  // --enable-unsafe-swiftshader in recent builds) that CloakBrowser can then
+  // present with a plausible vendor/renderer.
+  '--use-gl=angle',
+  '--use-angle=swiftshader',
+  '--enable-unsafe-swiftshader',
   // Force all egress over TCP so it goes through the HTTP CONNECT egress-proxy.
   // Chrome uses QUIC/HTTP-3 (UDP) for sites that support it (e.g. Akamai-fronted
   // banks like ICICI), and QUIC CANNOT traverse an HTTP CONNECT proxy — Chrome

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -15,6 +15,13 @@ export const CHROMIUM_FLAGS = [
   '--remote-debugging-port=9222',
   '--disable-dev-shm-usage',
   '--disable-gpu',
+  // Force all egress over TCP so it goes through the HTTP CONNECT egress-proxy.
+  // Chrome uses QUIC/HTTP-3 (UDP) for sites that support it (e.g. Akamai-fronted
+  // banks like ICICI), and QUIC CANNOT traverse an HTTP CONNECT proxy — Chrome
+  // sends it DIRECTLY from the pod, bypassing the egress allowlist AND the
+  // residential upstream (the "Chrome ignores residential proxy" symptom). This
+  // makes the browser fall back to HTTP/1.1+2 over TCP, which the proxy tunnels.
+  '--disable-quic',
   // NOTE: '--enable-automation' is deliberately OMITTED. It sets
   // navigator.webdriver = true and the "controlled by automated software"
   // signals, which re-expose automation even under CloakBrowser stealth and get

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -15,7 +15,13 @@ export const CHROMIUM_FLAGS = [
   '--remote-debugging-port=9222',
   '--disable-dev-shm-usage',
   '--disable-gpu',
-  '--enable-automation',
+  // NOTE: '--enable-automation' is deliberately OMITTED. It sets
+  // navigator.webdriver = true and the "controlled by automated software"
+  // signals, which re-expose automation even under CloakBrowser stealth and get
+  // bank/anti-bot login risk engines to decline the session ("Unable to process
+  // your request"). Disabling the AutomationControlled blink feature instead
+  // keeps navigator.webdriver falsey. See gotcha #8.
+  '--disable-blink-features=AutomationControlled',
   '--password-store=basic',
   '--disable-component-extensions-with-background-pages',
   '--disable-client-side-phishing-detection',

--- a/packages/shared/src/dsl.types.ts
+++ b/packages/shared/src/dsl.types.ts
@@ -20,6 +20,7 @@ export type DslActionType =
   | 'sleep'
   | 'screenshot'
   | 'reload'
+  | 'activity'
   | 'request_human_input';
 
 export type FailureHandler =
@@ -119,6 +120,16 @@ export interface ReloadStep extends BaseDslStep {
   action: 'reload';
 }
 
+/**
+ * Human-like idle-reset keepalive: a small trusted mouse move + scroll nudge, no
+ * clicks/keys/navigation. Resets client-side idle timers (banks detect idle via
+ * DOM interaction events, not HTTP) the way a real user would, without side
+ * effects. Safe on any page.
+ */
+export interface ActivityStep extends BaseDslStep {
+  action: 'activity';
+}
+
 export interface RequestHumanInputStep extends BaseDslStep {
   action: 'request_human_input';
   input_type: HumanInputType;
@@ -145,6 +156,7 @@ export type DslStep =
   | SleepStep
   | ScreenshotStep
   | ReloadStep
+  | ActivityStep
   | RequestHumanInputStep;
 
 /** Metadata for a pending human input request, stored on session + passed via NATS. */

--- a/packages/shared/src/dsl.validator.ts
+++ b/packages/shared/src/dsl.validator.ts
@@ -18,7 +18,7 @@ export interface ValidationResult {
 const VALID_ACTIONS: DslActionType[] = [
   'goto', 'fill', 'type', 'click', 'select',
   'wait_for', 'wait_for_url', 'frame', 'main_frame',
-  'popup', 'keyboard', 'evaluate', 'sleep', 'screenshot', 'reload',
+  'popup', 'keyboard', 'evaluate', 'sleep', 'screenshot', 'reload', 'activity',
   'request_human_input',
 ];
 
@@ -154,6 +154,7 @@ function validateStep(step: DslStep, index: number, prefix: string): ValidationE
 
     case 'screenshot':
     case 'reload':
+    case 'activity':
       // No params needed
       break;
 

--- a/packages/shared/src/execute-types.ts
+++ b/packages/shared/src/execute-types.ts
@@ -30,6 +30,7 @@ export const BROWSER_COMMANDS = [
   'get_page_summary', 'get_page_info', 'screenshot',
   'wait_for_selector', 'scroll_page',
   'har_start', 'har_stop', 'har_status',
+  'list_downloads', 'get_download',
 ] as const;
 
 export type BrowserCommandName = typeof BROWSER_COMMANDS[number];


### PR DESCRIPTION
## Summary

Everything needed to make **browser-driven skills** (`call_web_browser` → Tabby `/execute/browser`) work reliably against refresh-sensitive, bot-protected bank portals (HSBCnet, ICICI, HDFC Life), plus the supporting worker/controller/api/egress reliability fixes surfaced along the way.

> Squash-merged, so per-commit history collapses — grouped summary below.

### Browser-driven skill support
- **`activity` keepalive** — trusted mouse/scroll idle-reset that holds SPA/bank sessions **without a full-page reload** (a `goto` keepalive re-handshakes single-session portals → "already logged on"). Health-gated so it never nudges a login page. (`2a1e5df`, `1181de5`)
- **`click_by_text` robustness** — visible-first + substring matching for duplicate/near-miss labels; **DOM-dispatched click-through** when an overlay intercepts the click; **`get_page_summary` returns only visible elements** so hidden/stale modals stop misleading the model. (`767f6b1`, `3369e44`)
- **Download capture** — `download-capture` + `list_downloads`/`get_download` on `/execute/browser` (base64), gated on `browser_policy.downloads`. (`71f8b13`)

### Anti-bot / egress hardening (global CHROMIUM_FLAGS)
- `--disable-quic` so bank traffic can't bypass the HTTP-CONNECT egress proxy over HTTP/3. (`c4d21ae`)
- Drop `--enable-automation`, add Windows fonts, SwiftShader software WebGL (present a real GPU renderer). (`20022dd`, `aee9818`)
- Egress-proxy Happy-Eyeballs attempt budget raised for distant hosts. (`9098c7e`)

### Health-check correctness
- `url_check` catches client-side SPA session expiry; `dom_check` tests DOM **presence** (not CSS visibility), handles multi-match, and `exists:false` can pass; health-check config fields declared. (`1563c1a`, `fa9a030`, `d22c267`, `91ec3b2`, `bbdc189`)

### Controller / API reliability
- FAILED session no longer blocks its own replacement (dead-zone). (`b9ace4b`)
- `session-status` never returns a TERMINATED session as current. (`428a764`)
- App-template updates propagate from a fresh read. (`0466ee0`)
- MinIO orphan sweep no longer deletes recording bundles. (`6560864`)

### Viewer
- Human health label instead of the raw `AUTH_FAIL` enum; noVNC vendored into the image; stop claiming "Signed in" while recording. (`ec8174d`, `1a23508`)

### Cross-origin execute
- Route cross-origin fetches off-page so CORS can't block them (`/execute/fetch`). (`b67341e`)

### Local dev tooling (no stage/prod effect)
- Makefile: pin kube-context on kind targets, fix the MTU patch race, pin `--context` on port-forward; optional gitignored local-secrets override. (`a6ad3d4`, `14af184`, `045dcef`)
- Local egress allowlist entries for the test bank portals in `values-local.yaml`. (`ae38444`, `6e15a1c`)

## Non-browser flow impact
Browser-driven-specific changes (click_by_text, visible summary, download capture, activity keepalive) are **additive / opt-in / browser-scoped** — HAR-replay `call_web_api`, login-DSL and other non-browser flows are unaffected. Three globally-scoped changes touch shared paths and warrant a non-browser regression check before stage: **CHROMIUM_FLAGS** (every browser session), **dom_check semantics** (presence vs visibility — used by all health checks), and **cross-origin fetch off-page** (`/execute/fetch`).
