### PR TITLE
chore(egress): allow ICICI and HSBCnet domains on stage and prod

### DIFF
--- a/infra/tfy/deploy.yaml
+++ b/infra/tfy/deploy.yaml
@@ -356,6 +356,14 @@ values:
       # --- Workday ---
       - ".workday.com"
       - ".workdaycdn.com"
+      # --- ICICI Net Banking ---
+      # Scoped to .icici.bank.in rather than .bank.in: leading-dot entries are
+      # suffix matches, so the broader form would open every *.bank.in registrar
+      # domain.
+      - ".icici.bank.in"
+      - ".icicibank.com"
+      # --- HSBCnet ---
+      - ".hsbcnet.com"
       # --- Adopt platform assets + Frontegg-hosted logins (Spendflo etc.) ---
       - ".adopt.ai"
       - ".frontegg.com"


### PR DESCRIPTION
The bank domains were only ever added to values-local.yaml, which is Kind-only — stage and prod render infra/tfy/deploy.yaml, whose defaultAllowlist had no bank entries, so browser sessions against those portals were blocked on egress.

.icici.bank.in is scoped deliberately rather than .bank.in: leading-dot entries are suffix matches, so the broader form would open every *.bank.in registrar domain.

Note this is the CLUSTER-WIDE default list (baseline for every session and the fallback when a session has no per-session list), not per-app. The per-app mechanism is target_urls + extra_egress_allowlist, synced per session by the controller — that remains the narrower home for portal-specific asset domains.

## Summary

<!-- 1-3 bullet points: what changed and why -->

-

## Test plan

- [ ] `pnpm run lint` passes
- [ ] `pnpm run build` passes
- [ ] `pnpm run test` passes (all ~640 tests)
- [ ] `helm lint charts/browser-hitl/` passes
- [ ] Manually tested locally (if applicable)
- [ ] No secrets or credentials committed
