### PR TITLE
fix(worker): order recorded DOM events by an interaction-time sequence

### DIFF
--- a/apps/api/src/modules/recording/recording.store.spec.ts
+++ b/apps/api/src/modules/recording/recording.store.spec.ts
@@ -44,10 +44,14 @@ const sampleBundle: RecordingBundle = {
       value: '[REDACTED]',
       field_role: 'password',
       is_redacted: true,
-      timestamp: '2026-06-15T00:01:00.000Z',
+      seq: 1,
+      event_time: '2026-06-15T00:01:00.000Z',
+      timestamp: '2026-06-15T00:01:00.500Z',
     },
   ],
-  url_events: [{ from_url: 'https://example.com/login', to_url: 'https://example.com/home', timestamp: 'x' }],
+  url_events: [
+    { from_url: 'https://example.com/login', to_url: 'https://example.com/home', seq: 2, timestamp: 'x' },
+  ],
 };
 
 describe('RecordingStore', () => {

--- a/apps/worker/src/dom-recorder.injected.spec.ts
+++ b/apps/worker/src/dom-recorder.injected.spec.ts
@@ -1,0 +1,199 @@
+import { domRecorderScript, REC_EVENT_PATH } from './dom-recorder.injected';
+
+/**
+ * The recorder runs inside the page, so there is no DOM here — we install a
+ * minimal fake `window`/`document` on globalThis, run the script, then drive the
+ * capture-phase listeners it registered with synthetic events.
+ *
+ * The behaviour under test is ORDER: `input` is debounced 500ms, so its payload
+ * is built long after the human typed. `seq` and `event_time` are added to carry
+ * the interaction itself — `timestamp` keeps its existing flush-time meaning so
+ * that consumers reading it (the NoUI login compiler) are untouched.
+ */
+
+type Listener = (e: unknown) => void;
+
+interface Harness {
+  listeners: Record<string, Listener>;
+  emitted: Array<Record<string, any>>;
+  teardown: () => void;
+}
+
+function installFakeDom(href = 'https://example.com/login'): Harness {
+  const listeners: Record<string, Listener> = {};
+  const emitted: Array<Record<string, any>> = [];
+
+  const fakeWindow: Record<string, any> = {
+    location: { href },
+    fetch: (url: string, init: { body: string }) => {
+      if (url === REC_EVENT_PATH) emitted.push(JSON.parse(init.body));
+      return Promise.resolve();
+    },
+  };
+  const fakeDocument = {
+    addEventListener: (type: string, fn: Listener) => {
+      listeners[type] = fn;
+    },
+    removeEventListener: () => undefined,
+  };
+
+  const g = globalThis as any;
+  const prev = { window: g.window, document: g.document };
+  g.window = fakeWindow;
+  g.document = fakeDocument;
+
+  return {
+    listeners,
+    emitted,
+    teardown: () => {
+      g.window = prev.window;
+      g.document = prev.document;
+    },
+  };
+}
+
+/** A stand-in for a DOM element: only the properties the recorder reads. */
+function el(props: Record<string, any> = {}): Record<string, any> {
+  const attrs: Record<string, string> = props.attrs || {};
+  const node: Record<string, any> = {
+    tagName: 'INPUT',
+    id: '',
+    name: '',
+    type: 'text',
+    value: '',
+    className: '',
+    placeholder: '',
+    textContent: '',
+    attributes: [],
+    getAttribute: (n: string) => attrs[n] ?? null,
+    ...props,
+  };
+  node.closest = () => node;
+  return node;
+}
+
+describe('domRecorderScript', () => {
+  let h: Harness;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-06-15T00:00:00.000Z'));
+    h = installFakeDom();
+    domRecorderScript();
+  });
+
+  afterEach(() => {
+    h.teardown();
+    jest.useRealTimers();
+  });
+
+  it('reports the keystroke in event_time and the flush in timestamp', () => {
+    const field = el({ id: 'user', name: 'username', value: 'a' });
+
+    h.listeners.input({ target: field });
+    jest.advanceTimersByTime(500);
+
+    expect(h.emitted).toHaveLength(1);
+    expect(h.emitted[0].event_type).toBe('input');
+    expect(h.emitted[0].event_time).toBe('2026-06-15T00:00:00.000Z');
+    // `timestamp` is untouched: still the flush, 500ms later. Existing consumers
+    // of this field must see exactly what they saw before.
+    expect(h.emitted[0].timestamp).toBe('2026-06-15T00:00:00.500Z');
+  });
+
+  it('keeps the first keystroke of a burst as the interaction time', () => {
+    const field = el({ id: 'user', name: 'username' });
+
+    field.value = 'a';
+    h.listeners.input({ target: field });
+    jest.advanceTimersByTime(200);
+    field.value = 'ab';
+    h.listeners.input({ target: field }); // resets the debounce
+    jest.advanceTimersByTime(500);
+
+    expect(h.emitted).toHaveLength(1);
+    expect(h.emitted[0].value).toBe('ab'); // final value...
+    expect(h.emitted[0].event_time).toBe('2026-06-15T00:00:00.000Z'); // ...first keystroke
+    expect(h.emitted[0].timestamp).toBe('2026-06-15T00:00:00.700Z'); // ...flushed at 700ms
+  });
+
+  it('orders a fill-then-submit inside the debounce window correctly', () => {
+    // The regression: typing and clicking submit within 500ms flushed the input
+    // AFTER the click, so a timestamp sort reconstructed "click" before "fill".
+    const field = el({ id: 'password', name: 'password', type: 'password', value: 'hunter2' });
+    const button = el({ tagName: 'BUTTON', id: 'signin', textContent: 'Sign in' });
+
+    h.listeners.input({ target: field });
+    jest.advanceTimersByTime(100);
+    h.listeners.click({ target: button, clientX: 10, clientY: 20 });
+    jest.advanceTimersByTime(400); // input flushes here — after the click
+
+    const byArrival = h.emitted.map((e) => e.event_type);
+    expect(byArrival).toEqual(['click', 'input']); // delivery order is still click-first
+
+    const bySeq = [...h.emitted].sort((a, b) => a.seq - b.seq).map((e) => e.event_type);
+    expect(bySeq).toEqual(['input', 'click']); // ...but seq recovers the true order
+
+    const input = h.emitted.find((e) => e.event_type === 'input') as Record<string, any>;
+    const click = h.emitted.find((e) => e.event_type === 'click') as Record<string, any>;
+    expect(input.seq).toBeLessThan(click.seq);
+    expect(input.event_time < click.event_time).toBe(true);
+    // The premise this whole change exists for: `timestamp` still inverts them,
+    // and is deliberately left that way.
+    expect(input.timestamp > click.timestamp).toBe(true);
+    expect(input.value).toBe('[REDACTED]'); // password redaction still applies
+  });
+
+  it('numbers every event type from one strictly increasing counter', () => {
+    const field = el({ id: 'user', name: 'username', value: 'x' });
+    const box = el({ id: 'remember', type: 'checkbox', checked: true });
+    const button = el({ tagName: 'BUTTON', id: 'go', textContent: 'Go' });
+    const form = el({ tagName: 'FORM', id: 'login-form' });
+
+    h.listeners.input({ target: field });
+    jest.advanceTimersByTime(500);
+    h.listeners.change({ target: box });
+    h.listeners.click({ target: button, clientX: 1, clientY: 2 });
+    h.listeners.submit({ target: form });
+
+    expect(h.emitted.map((e) => e.event_type)).toEqual(['input', 'change', 'click', 'submit']);
+    const seqs = h.emitted.map((e) => e.seq);
+    expect(seqs).toEqual([1, 2, 3, 4]);
+  });
+
+  it('starts a fresh stamp for the next burst on the same field', () => {
+    const field = el({ id: 'otp', name: 'otp', value: '1' });
+
+    h.listeners.input({ target: field });
+    jest.advanceTimersByTime(500);
+    jest.setSystemTime(new Date('2026-06-15T00:00:10.000Z'));
+    field.value = '123456';
+    h.listeners.input({ target: field });
+    jest.advanceTimersByTime(500);
+
+    expect(h.emitted.map((e) => e.event_time)).toEqual([
+      '2026-06-15T00:00:00.000Z',
+      '2026-06-15T00:00:10.000Z',
+    ]);
+    expect(h.emitted.map((e) => e.seq)).toEqual([1, 2]);
+  });
+
+  it('emits event_time no later than timestamp on non-debounced events', () => {
+    // These handlers emit inline, so the two clock reads are a statement apart.
+    // `timestamp` is deliberately still its own original read — not a copy of
+    // event_time — so equality is not guaranteed, only ordering.
+    const box = el({ id: 'remember', type: 'checkbox', checked: true });
+    const button = el({ tagName: 'BUTTON', id: 'go', textContent: 'Go' });
+    const form = el({ tagName: 'FORM', id: 'login-form' });
+
+    h.listeners.change({ target: box });
+    h.listeners.click({ target: button, clientX: 1, clientY: 2 });
+    h.listeners.submit({ target: form });
+
+    expect(h.emitted).toHaveLength(3);
+    for (const ev of h.emitted) {
+      expect(ev.event_time).toBeTruthy();
+      expect(ev.event_time <= ev.timestamp).toBe(true);
+    }
+  });
+});

--- a/apps/worker/src/dom-recorder.injected.ts
+++ b/apps/worker/src/dom-recorder.injected.ts
@@ -56,6 +56,37 @@ export function domRecorderScript(): void {
     }
   };
 
+  /**
+   * Ordinal + wall clock of an interaction, captured AT EVENT TIME. Every handler
+   * stamps once, up front, and carries the stamp to the payload it emits.
+   *
+   * These feed two ADDITIVE fields, `seq` and `event_time`. `timestamp` is not
+   * sourced from here at all: every handler keeps its own original
+   * `new Date().toISOString()` call, in its original position, so the value is
+   * byte-identical to what the recorder emitted before this change. It therefore
+   * keeps its existing meaning — the moment the payload was built, which for the
+   * debounced `input` handler is the FLUSH, not the keystroke. That is exactly
+   * why it cannot order the stream: a human who types a field and clicks submit
+   * inside the 500ms window flushes the input after the click, so a timestamp
+   * sort reconstructs "click submit" before "fill password". Consumers that need
+   * order read `seq`; consumers that need the interaction's wall clock read
+   * `event_time`. Nothing reading `timestamp` changes behaviour.
+   *
+   * For every handler but `handleInput` the two clock reads are the same
+   * statement apart, so `event_time` and `timestamp` are equal in practice —
+   * but only `event_time` is guaranteed to be the interaction.
+   *
+   * `seq` restarts at 1 in every document (and in every subframe — the recorder
+   * installs per document). RecordingRunner rebases each run onto a session-global
+   * counter as the beacons arrive, so consumers get a total order that survives
+   * navigation and does not depend on beacon delivery order.
+   */
+  let seq = 0;
+  const stamp = (): { seq: number; eventTime: string } => ({
+    seq: ++seq,
+    eventTime: new Date().toISOString(),
+  });
+
   const getDataAttrs = (el: any): string | null => {
     const attrs: Record<string, string> = {};
     for (const attr of el.attributes || []) {
@@ -121,6 +152,7 @@ export function domRecorderScript(): void {
     const target =
       e.target.closest('[id], [class], a, button, input, select, textarea, [role]') || e.target;
     if (!target || !target.tagName) return;
+    const at = stamp();
     emit({
       event_type: 'click',
       tag_name: target.tagName || '',
@@ -138,17 +170,33 @@ export function domRecorderScript(): void {
       aria_label: target.getAttribute ? target.getAttribute('aria-label') : null,
       role_attr: target.getAttribute ? target.getAttribute('role') : null,
       data_attrs_json: getDataAttrs(target),
+      seq: at.seq,
+      event_time: at.eventTime,
+      // Left as the ORIGINAL clock read, in its original position, so the value
+      // is byte-identical to what this handler produced before seq/event_time.
       timestamp: new Date().toISOString(),
     });
   };
 
   const inputTimers = new WeakMap<any, any>();
+  // Stamp of the FIRST keystroke in the field's current debounce burst, carried
+  // across the debounce so the flushed payload can report when the human
+  // actually started typing (`seq`/`event_time`) alongside its existing
+  // flush-time `timestamp` — see stamp().
+  const inputMarks = new WeakMap<any, { seq: number; eventTime: string }>();
 
   const handleInput = (e: any): void => {
     const target = e.target;
     if (!target || !target.tagName) return;
     const tag = target.tagName.toLowerCase();
     if (tag !== 'input' && tag !== 'textarea') return;
+
+    let mark = inputMarks.get(target);
+    if (!mark) {
+      mark = stamp();
+      inputMarks.set(target, mark);
+    }
+    const at = mark;
 
     const existing = inputTimers.get(target);
     if (existing) clearTimeout(existing);
@@ -157,6 +205,7 @@ export function domRecorderScript(): void {
       target,
       setTimeout(() => {
         inputTimers.delete(target);
+        inputMarks.delete(target); // next burst on this field starts a new stamp
         const fieldRole = detectFieldRole(target);
         const redact = shouldRedact(fieldRole);
         const rawValue = (target.value || '').slice(0, 500);
@@ -177,6 +226,10 @@ export function domRecorderScript(): void {
           aria_label: target.getAttribute('aria-label') || null,
           role_attr: target.getAttribute('role') || null,
           data_attrs_json: getDataAttrs(target),
+          seq: at.seq,
+          event_time: at.eventTime,
+          // Flush time, NOT the keystroke — preserved verbatim so every existing
+          // consumer of this field is untouched. Order by `seq` instead.
           timestamp: new Date().toISOString(),
         });
       }, 500),
@@ -190,6 +243,7 @@ export function domRecorderScript(): void {
     if (tag === 'input' && !['checkbox', 'radio'].includes(target.type)) return;
     if (tag !== 'select' && tag !== 'input') return;
 
+    const at = stamp();
     const fieldRole = detectFieldRole(target);
     const redact = shouldRedact(fieldRole);
     let val: string;
@@ -215,13 +269,16 @@ export function domRecorderScript(): void {
       aria_label: target.getAttribute('aria-label') || null,
       role_attr: target.getAttribute('role') || null,
       data_attrs_json: getDataAttrs(target),
-      timestamp: new Date().toISOString(),
+      seq: at.seq,
+      event_time: at.eventTime,
+      timestamp: new Date().toISOString(), // original clock read, original position
     });
   };
 
   const handleSubmit = (e: any): void => {
     const form = e.target;
     if (!form || (form.tagName && form.tagName.toLowerCase() !== 'form')) return;
+    const at = stamp();
     emit({
       event_type: 'submit',
       tag_name: 'FORM',
@@ -235,7 +292,9 @@ export function domRecorderScript(): void {
       field_role: null,
       is_redacted: false,
       data_attrs_json: null,
-      timestamp: new Date().toISOString(),
+      seq: at.seq,
+      event_time: at.eventTime,
+      timestamp: new Date().toISOString(), // original clock read, original position
     });
   };
 

--- a/apps/worker/src/recording-runner.spec.ts
+++ b/apps/worker/src/recording-runner.spec.ts
@@ -68,6 +68,14 @@ const pageEvent = (seq: number, selector: string): RecordedInteractionEvent => (
   seq,
 });
 
+/**
+ * The ordinal of a drained event. `seq` is optional on the wire — bundles from
+ * before schema_version 2 have none — but RecordingRunner assigns one to every
+ * event it drains, so -1 here means the guarantee broke and the assertion fails
+ * rather than silently comparing undefined.
+ */
+const seqOf = (e: { seq?: number }): number => e.seq ?? -1;
+
 describe('RecordingRunner', () => {
   it('injects the recorder on start', async () => {
     const f = makeFakes('https://example.com/login');
@@ -156,7 +164,12 @@ describe('RecordingRunner', () => {
 
     const bundle = await runner.drain();
 
-    const timeline = [...bundle.click_events, ...bundle.url_events].sort((a, b) => a.seq - b.seq);
+    // `seq` is optional on the wire (pre-schema_version-2 bundles have none), so
+    // assert the producer guarantee before relying on it to sort.
+    const all = [...bundle.click_events, ...bundle.url_events];
+    expect(all.every((e) => typeof e.seq === 'number')).toBe(true);
+
+    const timeline = [...all].sort((a, b) => seqOf(a) - seqOf(b));
     expect(timeline.map((e) => ('selector' in e ? e.selector : e.to_url))).toEqual([
       '#user',
       '#next',
@@ -164,7 +177,7 @@ describe('RecordingRunner', () => {
       '#password',
       '#signin',
     ]);
-    const seqs = timeline.map((e) => e.seq);
+    const seqs = timeline.map(seqOf);
     expect(seqs).toEqual([...seqs].sort((a, b) => a - b));
     expect(new Set(seqs).size).toBe(seqs.length);
   });
@@ -174,7 +187,7 @@ describe('RecordingRunner', () => {
     const runner = new RecordingRunner(f.page, f.context, 'sess-1', 'login');
     await runner.start();
 
-    f.emit({ ...clickEvent, seq: undefined as unknown as number, selector: '#a' });
+    f.emit({ ...clickEvent, seq: undefined, selector: '#a' });
     f.emit(pageEvent(1, '#b'));
 
     const bundle = await runner.drain();
@@ -182,7 +195,8 @@ describe('RecordingRunner', () => {
       '#a',
       '#b',
     ]);
-    expect(bundle.click_events[0].seq).toBeLessThan(bundle.click_events[1].seq);
+    // The runner still numbers it, from arrival order.
+    expect(seqOf(bundle.click_events[0])).toBeLessThan(seqOf(bundle.click_events[1]));
   });
 
   it('does not record a url event when the url is unchanged', async () => {

--- a/apps/worker/src/recording-runner.spec.ts
+++ b/apps/worker/src/recording-runner.spec.ts
@@ -56,8 +56,17 @@ const clickEvent: RecordedInteractionEvent = {
   class_name: null,
   selector: '#submit',
   url: 'https://example.com/login',
+  seq: 1,
+  event_time: '2026-06-15T00:00:00.000Z',
   timestamp: '2026-06-15T00:00:00.000Z',
 };
+
+/** A page-side event carrying the per-document ordinal the recorder assigned. */
+const pageEvent = (seq: number, selector: string): RecordedInteractionEvent => ({
+  ...clickEvent,
+  selector,
+  seq,
+});
 
 describe('RecordingRunner', () => {
   it('injects the recorder on start', async () => {
@@ -103,6 +112,8 @@ describe('RecordingRunner', () => {
     expect(bundle.har.log.version).toBe('1.2');
     expect(bundle.started_at).toBeTruthy();
     expect(bundle.stopped_at).toBeTruthy();
+    // Marks the event contract as the one that carries seq/event_time.
+    expect(bundle.schema_version).toBe(2);
   });
 
   it('reset() drops pre-bind capture so the bundle starts at the real target', async () => {
@@ -128,6 +139,50 @@ describe('RecordingRunner', () => {
     expect(bundle.url_events).toEqual([
       expect.objectContaining({ from_url: '', to_url: 'https://www.airbnb.com/' }),
     ]);
+  });
+
+  it('rebases per-document ordinals onto one increasing session-global order', async () => {
+    // A two-page login: the recorder's counter restarts at 1 on the second
+    // document, so the raw ordinals alone would interleave the pages.
+    const f = makeFakes('https://example.com/login');
+    const runner = new RecordingRunner(f.page, f.context, 'sess-1', 'login');
+    await runner.start();
+
+    f.emit(pageEvent(1, '#user'));
+    f.emit(pageEvent(2, '#next'));
+    f.navigate('https://example.com/login/password');
+    f.emit(pageEvent(1, '#password')); // new document — counter restarted
+    f.emit(pageEvent(2, '#signin'));
+
+    const bundle = await runner.drain();
+
+    const timeline = [...bundle.click_events, ...bundle.url_events].sort((a, b) => a.seq - b.seq);
+    expect(timeline.map((e) => ('selector' in e ? e.selector : e.to_url))).toEqual([
+      '#user',
+      '#next',
+      'https://example.com/login/password',
+      '#password',
+      '#signin',
+    ]);
+    const seqs = timeline.map((e) => e.seq);
+    expect(seqs).toEqual([...seqs].sort((a, b) => a - b));
+    expect(new Set(seqs).size).toBe(seqs.length);
+  });
+
+  it('falls back to arrival order for events with no page-side ordinal', async () => {
+    const f = makeFakes('https://example.com/login');
+    const runner = new RecordingRunner(f.page, f.context, 'sess-1', 'login');
+    await runner.start();
+
+    f.emit({ ...clickEvent, seq: undefined as unknown as number, selector: '#a' });
+    f.emit(pageEvent(1, '#b'));
+
+    const bundle = await runner.drain();
+    expect(bundle.click_events.map((e: RecordedInteractionEvent) => e.selector)).toEqual([
+      '#a',
+      '#b',
+    ]);
+    expect(bundle.click_events[0].seq).toBeLessThan(bundle.click_events[1].seq);
   });
 
   it('does not record a url event when the url is unchanged', async () => {

--- a/apps/worker/src/recording-runner.ts
+++ b/apps/worker/src/recording-runner.ts
@@ -5,6 +5,7 @@ import type {
   RecordedInteractionEvent,
   RecordedUrlEvent,
 } from '@browser-hitl/shared';
+import { RECORDING_SCHEMA_VERSION } from '@browser-hitl/shared';
 import { startHarCapture, stopHarCapture, cleanupHarListeners } from './har-capture';
 import { REC_BEACON, REC_INSTALL_PATH, domRecorderScript } from './dom-recorder.injected';
 import { sanitizeHar } from './har-sanitizer';
@@ -31,6 +32,18 @@ export class RecordingRunner {
   private started = false;
   private installSeen = false;
 
+  // Session-global event ordering. The injected recorder numbers events per
+  // DOCUMENT — its counter dies with the page — so a two-page login (username
+  // page, then password page) would restart at 1 and a global sort on the raw
+  // ordinal would interleave the pages. Each document's run is rebased onto a
+  // running counter here: a raw ordinal that fails to advance means a new
+  // document (or a subframe's recorder), so the base moves past everything
+  // numbered so far. URL events draw from the same counter, giving consumers one
+  // total order over interactions and navigations.
+  private seqMax = 0;
+  private seqBase = 0;
+  private lastRawSeq = 0;
+
   constructor(
     private readonly page: Page,
     private readonly context: BrowserContext,
@@ -38,6 +51,29 @@ export class RecordingRunner {
     private readonly recordingMode: RecordingMode,
   ) {
     this.startedAt = new Date().toISOString();
+  }
+
+  /** Next session-global ordinal, for events we number ourselves (URL transitions). */
+  private nextSeq(): number {
+    this.seqMax += 1;
+    // Force the next page-side ordinal to rebase past this one, whatever it is.
+    this.seqBase = this.seqMax;
+    this.lastRawSeq = Number.MAX_SAFE_INTEGER;
+    return this.seqMax;
+  }
+
+  /** Map a page-local ordinal onto the session-global one. See seqMax/seqBase. */
+  private rebaseSeq(raw: unknown): number {
+    if (typeof raw !== 'number' || !Number.isFinite(raw) || raw < 1) {
+      // A recorder too old to number its events, or a mangled beacon: fall back
+      // to arrival order so the event still sorts where it landed.
+      return this.nextSeq();
+    }
+    if (raw <= this.lastRawSeq) this.seqBase = this.seqMax; // counter restarted
+    this.lastRawSeq = raw;
+    const seq = this.seqBase + raw;
+    if (seq > this.seqMax) this.seqMax = seq;
+    return seq;
   }
 
   async start(): Promise<void> {
@@ -72,7 +108,10 @@ export class RecordingRunner {
         const body = typeof req.postData === 'function' ? req.postData() : '';
         if (!body) return;
         const ev = JSON.parse(body) as RecordedInteractionEvent;
-        if (ev && typeof ev === 'object') this.events.push(ev);
+        if (ev && typeof ev === 'object') {
+          ev.seq = this.rebaseSeq(ev.seq);
+          this.events.push(ev);
+        }
       } catch {
         /* malformed beacon — ignore */
       }
@@ -104,6 +143,7 @@ export class RecordingRunner {
         this.urlEvents.push({
           from_url: this.lastUrl,
           to_url: to,
+          seq: this.nextSeq(),
           timestamp: new Date().toISOString(),
         });
         this.lastUrl = to;
@@ -133,6 +173,9 @@ export class RecordingRunner {
     this.events.length = 0;
     this.urlEvents.length = 0;
     this.lastUrl = '';
+    this.seqMax = 0;
+    this.seqBase = 0;
+    this.lastRawSeq = 0;
     // Re-arm HAR capture: startHarCapture detaches the existing listeners and
     // installs fresh ones over a new (empty) entries buffer, dropping any
     // placeholder-page requests captured while the spare was warm.
@@ -184,6 +227,7 @@ export class RecordingRunner {
     );
 
     return {
+      schema_version: RECORDING_SCHEMA_VERSION,
       session_id: this.sessionId,
       recording_mode: this.recordingMode,
       started_at: this.startedAt,

--- a/packages/shared/src/recording.types.ts
+++ b/packages/shared/src/recording.types.ts
@@ -36,6 +36,42 @@ export interface RecordedInteractionEvent {
   aria_label?: string | null;
   role_attr?: string | null;
   data_attrs_json?: string | null;
+  /**
+   * Total-order key across ALL events in the bundle (interactions and URL
+   * transitions share one counter). Strictly increasing in interaction order;
+   * gaps are normal and carry no meaning.
+   *
+   * Order by this, not by `timestamp`. The injected recorder debounces `input`
+   * by 500ms, so a field filled and submitted inside that window flushes its
+   * input event AFTER the click — and `timestamp` records that flush (see
+   * below), which puts the click first. `seq` is assigned at interaction time
+   * and is also immune to the beacon channel's delivery order and to clock
+   * granularity.
+   *
+   * Added additively — bundles recorded before it have no `seq`, so consumers
+   * must detect its presence rather than assume it.
+   */
+  seq: number;
+  /**
+   * Wall clock of the interaction itself. For `input` this is the first
+   * keystroke of the debounce burst; for every other event type it is the same
+   * clock read as `timestamp` to within a statement. Read this when you need the
+   * time an interaction happened, and `seq` when you need order. Added
+   * additively alongside `seq`.
+   */
+  event_time: string;
+  /**
+   * Wall clock at which the event payload was BUILT — for the debounced `input`
+   * handler that is the flush, up to 500ms after the keystroke; for every other
+   * event type it is the interaction itself.
+   *
+   * Semantics AND value are frozen: this field predates `seq`/`event_time` and
+   * existing consumers (notably the NoUI login compiler) read it, so each handler
+   * keeps its own original clock read in its original position rather than
+   * copying `event_time`. Never assume `event_time === timestamp`; only
+   * `event_time <= timestamp` holds. New code wanting interaction time should
+   * read `event_time`, and wanting order, `seq`.
+   */
   timestamp: string;
 }
 
@@ -43,6 +79,12 @@ export interface RecordedInteractionEvent {
 export interface RecordedUrlEvent {
   from_url: string;
   to_url: string;
+  /**
+   * Same counter as RecordedInteractionEvent.seq — clicks and navigations
+   * interleave in one total order. Added additively.
+   */
+  seq: number;
+  /** Emitted inline at navigation, so this is also the interaction time. */
   timestamp: string;
 }
 
@@ -72,8 +114,25 @@ export interface RecordedCookie {
   sameSite?: 'Strict' | 'Lax' | 'None';
 }
 
+/**
+ * Bundle schema revision. Bumped only when the event contract changes.
+ *   1 — implicit (absent). Events carry no `seq`/`event_time`.
+ *   2 — every event carries `seq`; interaction events also carry `event_time`.
+ */
+export const RECORDING_SCHEMA_VERSION = 2;
+
 /** The bundle drained on "Finish & export" and pulled by NoUI. */
 export interface RecordingBundle {
+  /**
+   * See RECORDING_SCHEMA_VERSION. Absent on bundles drained before it existed,
+   * which is what "version 1" means.
+   *
+   * Informational: it describes what the WORKER produced. Consumers should still
+   * detect `seq` per event rather than dispatch on this, because a bundle can
+   * lose the field in transit — NoUI's `/clicks` ingestion projects events onto
+   * a fixed column list, and anything not in it is dropped.
+   */
+  schema_version?: number;
   session_id: string;
   recording_mode: RecordingMode;
   started_at: string;

--- a/packages/shared/src/recording.types.ts
+++ b/packages/shared/src/recording.types.ts
@@ -48,18 +48,25 @@ export interface RecordedInteractionEvent {
    * and is also immune to the beacon channel's delivery order and to clock
    * granularity.
    *
-   * Added additively — bundles recorded before it have no `seq`, so consumers
-   * must detect its presence rather than assume it.
+   * OPTIONAL because it was added additively: this interface also describes
+   * bundles read back from storage (RecordingStore.retrieve), and anything
+   * persisted before schema_version 2 has no `seq`. It can also be lost in
+   * transit — NoUI's `/clicks` ingestion projects events onto a fixed column
+   * list. Detect it; never assume it. RecordingRunner does guarantee it on every
+   * bundle IT drains, but that is a producer guarantee, not a wire one.
    */
-  seq: number;
+  seq?: number;
   /**
    * Wall clock of the interaction itself. For `input` this is the first
    * keystroke of the debounce burst; for every other event type it is the same
    * clock read as `timestamp` to within a statement. Read this when you need the
-   * time an interaction happened, and `seq` when you need order. Added
-   * additively alongside `seq`.
+   * time an interaction happened, and `seq` when you need order.
+   *
+   * Optional for the same reason as `seq` — see there. Unlike `seq` it is never
+   * reconstructed server-side: it comes from the page, so a bundle drained by a
+   * worker older than schema_version 2 has none.
    */
-  event_time: string;
+  event_time?: string;
   /**
    * Wall clock at which the event payload was BUILT — for the debounced `input`
    * handler that is the flush, up to 500ms after the keystroke; for every other
@@ -81,9 +88,9 @@ export interface RecordedUrlEvent {
   to_url: string;
   /**
    * Same counter as RecordedInteractionEvent.seq — clicks and navigations
-   * interleave in one total order. Added additively.
+   * interleave in one total order. Optional for the same reason: see there.
    */
-  seq: number;
+  seq?: number;
   /** Emitted inline at navigation, so this is also the interaction time. */
   timestamp: string;
 }


### PR DESCRIPTION
## The bug

`handleInput` in `apps/worker/src/dom-recorder.injected.ts` debounces for 500ms and builds its event payload **inside** the `setTimeout` callback, so `timestamp: new Date().toISOString()` records the **flush time**, not the interaction time. `handleClick` emits immediately with the true interaction time.

A human who fills a field and clicks submit within 500ms — the ordinary login — therefore produces a click event whose `timestamp` is **earlier** than the input event that preceded it. Any consumer ordering events by `timestamp` reconstructs the steps in the wrong order, and re-sorting cannot repair it because the true interaction time was never captured.

The downstream effect is visible in the NoUI login compiler, which emits its DSL in list order. The same recording compiled to:

```
goto, fill, click, fill     ← clicks "Sign in" on a half-empty form, then fills the password
```

## The fix — strictly additive

`timestamp` is **not** changed. This script is injected via `context.addInitScript` for *both* recording modes (`'login' | 'workflow'`), so redefining an existing field's meaning would land on the login / HAR-replay path, where consumers already read it. Two new fields were added beside it instead:

- **`seq`** — a monotonically increasing ordinal stamped at interaction time, on every emitted event (click/input/change/submit). `handleInput` captures it on the first keystroke of a debounce burst (an `inputMarks` WeakMap, cleared on flush so the next burst restarts) and carries it across the debounce.
- **`event_time`** — the interaction's wall clock. First keystroke of the burst for `input`; the inline read for every other handler.

`timestamp` keeps its own original `new Date().toISOString()` call, in its original position as the last property of each emitted literal, so its value is byte-identical to what the recorder produced before. `recording_mode === 'login'` behaves exactly as it did. Never assume `event_time === timestamp` — only `event_time <= timestamp` holds.

### Making `seq` a real total order

The page counter dies with the document, so a two-page login (username page, then password page) would restart at 1 and a global sort would interleave the pages. `RecordingRunner.rebaseSeq()` maps each document's run onto a session-global counter: a raw ordinal that fails to advance means a new document (or a subframe's recorder), so the base jumps past everything numbered so far. `url_events` draw from the same counter via `nextSeq()`, so clicks and navigations share one total order. Events with no usable ordinal fall back to arrival order. `reset()` clears the counters alongside the buffers.

Also stamps `schema_version: 2` on the drained bundle (absent ⇒ version 1). It is informational: consumers should still detect `seq` **per event**, because a bundle can lose the field in transit — NoUI's `/clicks` ingestion projects events onto a fixed column list.

The script remains self-contained with no outer closures (`stamp`, `seq`, and `inputMarks` all live inside `domRecorderScript`), and object spread is avoided so nothing depends on TS helper emit.

## Tests

New `apps/worker/src/dom-recorder.injected.spec.ts` drives the injected script against a minimal fake `window`/`document` with fake timers, and pins the invariant in both directions — for a fill-then-click inside 500ms, `seq` and `event_time` order them correctly while `timestamp` still inverts them, asserted explicitly as intended:

```js
expect(byArrival).toEqual(['click', 'input']);   // delivery order
expect(bySeq).toEqual(['input', 'click']);       // seq recovers the truth
expect(input.timestamp > click.timestamp).toBe(true);  // deliberately left inverted
```

Plus rebasing / fallback coverage in `recording-runner.spec.ts`.

`pnpm run build`, `pnpm run lint`, and `pnpm run test` (790 tests) all pass, verified after rebasing onto current `dev`.

## Consumer side

The NoUI half is https://github.com/adoptai/noui/pull/new/fix/recorded-event-seq-ordering — it prefers `seq` when present and falls back to the previous list/timestamp behaviour, so recordings captured before this change still compile unchanged.

## Base branch

Branched from `origin/dev`. The worktree branch was originally cut from a `main` merge commit that wasn't an ancestor of `dev` (which was 14 commits ahead); rebased onto `dev` so the diff is only these 6 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
