### PR TITLE
[Dev to Main] Anti-bot fingerprint hardening, egress allowlists, browser downloads, health-check fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,6 @@ docs/zero-to-hero-test-workflow.md
 docs/zero-to-hero-tabby-platform-setup.md
 docs/adopt-org-templates-backup.json
 docs/tabby-platform-setup-consolidation.md
+
+# Local-only Kind secrets override (never commit — real credentials)
+charts/browser-hitl/values-local.secret.yaml

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,10 +33,22 @@ Monorepo (NX + pnpm workspaces):
 ## Local Development (Kind)
 
 ```bash
-make kind-create          # one-time: create Kind cluster
+make kind-create          # one-time: create Kind cluster (auto-runs kind-fix-mtu + kind-fix-dns)
 make kind-reload-all      # clean + build + docker-build + load + helm upgrade with values-local.yaml
 make k8s-port-forward     # forward API (18080), Admin UI (13000), Postgres, Redis, MinIO, NATS
 ```
+
+**Existing Kind cluster (created before these targets existed):** run the two
+node-fixups by hand once, or worker egress to external sites will fail:
+
+```bash
+make kind-fix-mtu         # patch kindnet pod MTU 65535 -> 1500 (large-cert TLS handshakes)
+make kind-fix-dns         # repoint CoreDNS at 8.8.8.8/1.1.1.1 (Docker Desktop AAAA SERVFAIL)
+```
+
+Both are **Kind-only** — they pin `--context kind-<cluster>` and refuse to run if
+that context is absent, so they can never touch a remote cluster. See gotchas
+about MTU and CoreDNS AAAA below.
 
 All local config (API URL, stream host, service auth, secrets) is in `values-local.yaml` — no manual `kubectl set env` needed.
 
@@ -282,6 +294,8 @@ Recent migrations (newest first):
 21. **Admin-UI ingress route gated on `adminUi.enabled`** — The `{{- if .Values.adminUi.enabled }}` block in `charts/browser-hitl/templates/ingress.yaml` controls the `/` route. Disabling admin-UI removes it cleanly.
 22. **VNC access requires OAuth authentication** — Opening a VNC viewer URL sets a `tabby_vnc` HttpOnly cookie (1h TTL) via OAuth callback. Without it, the user hits the IdP login wall. Falls back to email gate if no OAuth IdP is configured. Wrong user → 403 (not a redirect loop). Currently owner-only (session owner matched via `owner_user_id` in cookie).
 23. **Squash merge breaks long-lived branch sync** — Repo only allows squash merge. For feature→dev PRs this is fine, but syncing between long-lived branches (e.g. `dev`→`tabby-noui`) via GitHub PR causes the next sync to show ALL previous changes again (different SHAs). Sync locally instead: `git checkout target && git merge origin/source && git push`.
+24. **Kind pod MTU defaults to 65535** — Breaks TLS handshakes to external sites whose certs produce large packets (GitHub, LinkedIn CDN). Kind exposes no MTU setting, so `make kind-fix-mtu` patches kindnet's conflist to 1500 post-create (restart-first so the patch survives kindnet's startup rewrite; verifies the patch landed). Local Kind only.
+25. **CoreDNS AAAA SERVFAIL in Kind** — Docker Desktop's embedded DNS (which Kind's CoreDNS forwards to via `/etc/resolv.conf`) returns SERVFAIL on AAAA lookups for CNAME→CloudFront domains. `getaddrinfo` (Chromium + the egress proxy's `net.connect`) does a dual A+AAAA lookup and fails the whole thing with EAI_AGAIN → `ERR_TUNNEL_CONNECTION_FAILED` in worker sessions. `make kind-fix-dns` repoints CoreDNS `forward` at `8.8.8.8 1.1.1.1`. Diagnose with `dns.resolve4` OK but `dns.lookup` failing = AAAA SERVFAIL. Cloud clusters use well-behaved VPC resolvers and never hit this — local Kind only.
 
 ## Git
 

--- a/Makefile
+++ b/Makefile
@@ -260,19 +260,45 @@ kind-guard:
 
 .PHONY: kind-fix-mtu
 kind-fix-mtu: kind-guard ## Fix Kind pod MTU from 65535 to 1500 (prevents TLS failures to external sites)
-	@echo "Patching kindnet MTU to 1500 on all nodes of '$(KIND_CLUSTER)'..."
-	@# kindnet rewrites its conflist on startup, so restart the daemonset FIRST,
-	@# then patch every node's conflist, so the patch is what survives.
+	@echo "Patching kindnet pod MTU to 1500 on all nodes of '$(KIND_CLUSTER)'..."
+	@# Patch ONLY the CNI conflist (pod veth MTU). Do NOT touch the node's own eth0:
+	@# it must keep matching the Docker bridge (`docker network inspect kind` ->
+	@# com.docker.network.driver.mtu, 65535 on Docker Desktop). Lowering the node
+	@# interface while the bridge stays 65535 makes the bridge emit frames the node
+	@# drops, which wedges kubectl port-forward with
+	@#   'error creating error stream ...: Timeout occurred'
+	@# and takes the API/VNC tunnels down with it.
+	@#
+	@# kindnet rewrites the conflist on startup, and does so a moment AFTER the
+	@# daemonset reports Ready — so a patch applied immediately gets clobbered.
+	@# Restart first, then patch, then RE-verify once kindnet has settled, retrying
+	@# before giving up. The previous version verified instantly and printed success
+	@# against a file that was about to be overwritten.
 	kubectl --context $(KIND_CONTEXT) rollout restart daemonset/kindnet -n kube-system
-	kubectl --context $(KIND_CONTEXT) rollout status daemonset/kindnet -n kube-system --timeout=30s
-	@for node in $$(kind get nodes --name $(KIND_CLUSTER)); do \
-		docker exec $$node sh -c '\
-			CNI=/etc/cni/net.d/10-kindnet.conflist; \
-			[ -s "$$CNI" ] && sed -i "s/\"mtu\": *[0-9]*/\"mtu\": 1500/g" "$$CNI"; \
-			grep -q "\"mtu\": 1500" "$$CNI"' \
-			|| { echo "MTU patch did not land on $$node (no \"mtu\" key? kindnet variant changed)"; exit 1; }; \
-	done
-	@echo "MTU set to 1500 on all nodes (verified). Restart pods to pick it up."
+	kubectl --context $(KIND_CONTEXT) rollout status daemonset/kindnet -n kube-system --timeout=60s
+	@ok=0; \
+	for attempt in 1 2 3 4 5; do \
+		for node in $$(kind get nodes --name $(KIND_CLUSTER)); do \
+			docker exec $$node sh -c '\
+				CNI=/etc/cni/net.d/10-kindnet.conflist; \
+				[ -s "$$CNI" ] && sed -i "s/\"mtu\": *[0-9]*/\"mtu\": 1500/g" "$$CNI"; \
+				grep -q "\"mtu\": 1500" "$$CNI"' \
+				|| { echo "MTU patch did not land on $$node (no \"mtu\" key? kindnet variant changed)"; exit 1; }; \
+		done; \
+		sleep 20; \
+		stable=1; \
+		for node in $$(kind get nodes --name $(KIND_CLUSTER)); do \
+			docker exec $$node sh -c 'grep -q "\"mtu\": 1500" /etc/cni/net.d/10-kindnet.conflist' || stable=0; \
+		done; \
+		if [ "$$stable" = "1" ]; then \
+			echo "Pod MTU 1500 verified stable on all nodes (attempt $$attempt)."; ok=1; break; \
+		fi; \
+		echo "kindnet reverted the patch (attempt $$attempt) — retrying..."; \
+	done; \
+	if [ "$$ok" != "1" ]; then echo "MTU patch keeps being reverted by kindnet; aborting."; exit 1; fi
+	@echo "NOTE: kindnet rewrites this on every restart — re-run after one."
+	@echo "Existing pods keep their old MTU — recreate them to pick this up:"
+	@echo "  kubectl --context $(KIND_CONTEXT) rollout restart deploy -n $(HELM_NAMESPACE)"
 
 .PHONY: kind-fix-dns
 kind-fix-dns: kind-guard ## Point CoreDNS at public resolvers (fixes AAAA SERVFAIL from Docker Desktop embedded DNS)
@@ -306,10 +332,10 @@ kind-load-images: ## Load all Docker images into the Kind cluster
 	@echo "Images loaded into Kind cluster '$(KIND_CLUSTER)'"
 
 .PHONY: kind-deploy
-kind-deploy: ## Full local deploy: load images + helm install with local values
+kind-deploy: kind-guard ## Full local deploy: load images + helm install with local values
 	$(MAKE) kind-load-images
-	kubectl create namespace $(HELM_NAMESPACE) --dry-run=client -o yaml | kubectl apply -f -
-	helm upgrade --install $(HELM_RELEASE) charts/browser-hitl/ \
+	kubectl --context $(KIND_CONTEXT) create namespace $(HELM_NAMESPACE) --dry-run=client -o yaml | kubectl --context $(KIND_CONTEXT) apply -f -
+	helm upgrade --install $(HELM_RELEASE) charts/browser-hitl/ --kube-context $(KIND_CONTEXT) \
 		-f charts/browser-hitl/values-local.yaml \
 		--namespace $(HELM_NAMESPACE) \
 		--wait --timeout 5m
@@ -318,36 +344,36 @@ kind-deploy: ## Full local deploy: load images + helm install with local values
 # --- Kind reload shortcuts: build + load + restart a single service ----------
 
 .PHONY: kind-reload-api
-kind-reload-api: docker-build-api ## Rebuild API and reload into Kind
+kind-reload-api: kind-guard docker-build-api ## Rebuild API and reload into Kind
 	kind load docker-image $(IMG_API) --name $(KIND_CLUSTER)
-	helm upgrade $(HELM_RELEASE) charts/browser-hitl/ \
+	helm upgrade $(HELM_RELEASE) charts/browser-hitl/ --kube-context $(KIND_CONTEXT) \
 		-f charts/browser-hitl/values-local.yaml \
 		--namespace $(HELM_NAMESPACE) --reuse-values \
 		--wait --timeout 5m
 	@echo "API reloaded."
 
 .PHONY: kind-reload-controller
-kind-reload-controller: docker-build-controller ## Rebuild controller and reload into Kind
+kind-reload-controller: kind-guard docker-build-controller ## Rebuild controller and reload into Kind
 	kind load docker-image $(IMG_CONTROLLER) --name $(KIND_CLUSTER)
-	helm upgrade $(HELM_RELEASE) charts/browser-hitl/ \
+	helm upgrade $(HELM_RELEASE) charts/browser-hitl/ --kube-context $(KIND_CONTEXT) \
 		-f charts/browser-hitl/values-local.yaml \
 		--namespace $(HELM_NAMESPACE) --reuse-values \
 		--wait --timeout 5m
 	@echo "Controller reloaded."
 
 .PHONY: kind-reload-worker
-kind-reload-worker: docker-build-worker ## Rebuild worker and reload into Kind
+kind-reload-worker: kind-guard docker-build-worker ## Rebuild worker and reload into Kind
 	kind load docker-image $(IMG_WORKER) --name $(KIND_CLUSTER)
-	helm upgrade $(HELM_RELEASE) charts/browser-hitl/ \
+	helm upgrade $(HELM_RELEASE) charts/browser-hitl/ --kube-context $(KIND_CONTEXT) \
 		-f charts/browser-hitl/values-local.yaml \
 		--namespace $(HELM_NAMESPACE) --reuse-values \
 		--wait --timeout 5m
 	@echo "Worker reloaded."
 
 .PHONY: kind-reload-admin-ui
-kind-reload-admin-ui: docker-build-admin-ui ## Rebuild admin-ui and reload into Kind
+kind-reload-admin-ui: kind-guard docker-build-admin-ui ## Rebuild admin-ui and reload into Kind
 	kind load docker-image $(IMG_ADMIN_UI) --name $(KIND_CLUSTER)
-	helm upgrade $(HELM_RELEASE) charts/browser-hitl/ \
+	helm upgrade $(HELM_RELEASE) charts/browser-hitl/ --kube-context $(KIND_CONTEXT) \
 		-f charts/browser-hitl/values-local.yaml \
 		--namespace $(HELM_NAMESPACE) --reuse-values \
 		--wait --timeout 5m
@@ -359,33 +385,33 @@ kind-reload-novnc: docker-build-novnc ## Rebuild noVNC and reload into Kind
 	@echo "noVNC reloaded (sidecar — new worker pods will pick it up)."
 
 .PHONY: kind-reload-all
-kind-reload-all: clean build docker-build ## Clean + build source + images, load into Kind, and upgrade Helm release
+kind-reload-all: kind-guard clean build docker-build ## Clean + build source + images, load into Kind, and upgrade Helm release
 	$(MAKE) kind-load-images
-	helm upgrade --install $(HELM_RELEASE) charts/browser-hitl/ \
+	helm upgrade --install $(HELM_RELEASE) charts/browser-hitl/ --kube-context $(KIND_CONTEXT) \
 		-f charts/browser-hitl/values-local.yaml \
 		--namespace $(HELM_NAMESPACE) --create-namespace \
 		$(HELM_DOTENV_SETS) \
 		--wait --timeout 5m
 	@echo "Force-restarting deployments (image tag :dev never changes, so pods must be bounced)..."
-	kubectl rollout restart deployment \
+	kubectl --context $(KIND_CONTEXT) rollout restart deployment \
 		-l app.kubernetes.io/instance=$(HELM_RELEASE) \
 		-n $(HELM_NAMESPACE)
-	kubectl rollout status deployment \
+	kubectl --context $(KIND_CONTEXT) rollout status deployment \
 		-l app.kubernetes.io/instance=$(HELM_RELEASE) \
 		-n $(HELM_NAMESPACE) \
 		--timeout 3m
 	@echo "All services rebuilt and deployed with local images."
 
 .PHONY: kind-stop
-kind-stop: ## Scale all deployments and statefulsets to 0 replicas (stop pods without deleting)
-	kubectl scale deployment --all --replicas=0 -n $(HELM_NAMESPACE)
-	kubectl scale statefulset --all --replicas=0 -n $(HELM_NAMESPACE)
+kind-stop: kind-guard ## Scale all deployments and statefulsets to 0 replicas (stop pods without deleting)
+	kubectl --context $(KIND_CONTEXT) scale deployment --all --replicas=0 -n $(HELM_NAMESPACE)
+	kubectl --context $(KIND_CONTEXT) scale statefulset --all --replicas=0 -n $(HELM_NAMESPACE)
 	@echo "All pods scaled to 0 in namespace '$(HELM_NAMESPACE)'."
 
 .PHONY: kind-start
-kind-start: ## Scale all deployments and statefulsets back to 1 replica
-	kubectl scale deployment --all --replicas=1 -n $(HELM_NAMESPACE)
-	kubectl scale statefulset --all --replicas=1 -n $(HELM_NAMESPACE)
+kind-start: kind-guard ## Scale all deployments and statefulsets back to 1 replica
+	kubectl --context $(KIND_CONTEXT) scale deployment --all --replicas=1 -n $(HELM_NAMESPACE)
+	kubectl --context $(KIND_CONTEXT) scale statefulset --all --replicas=1 -n $(HELM_NAMESPACE)
 	@echo "All pods scaled to 1 in namespace '$(HELM_NAMESPACE)'."
 
 .PHONY: kind-delete

--- a/Makefile
+++ b/Makefile
@@ -232,6 +232,13 @@ ifneq (,$(wildcard $(DOTENV_FILE)))
   HELM_DOTENV_SETS := $(shell ./scripts/dotenv-to-helm-sets.sh $(DOTENV_FILE))
 endif
 
+# Optional gitignored local secrets override, auto-included in every local helm
+# upgrade when present. A values FILE (not --set) so credentials with dots/braces
+# — e.g. the residential EGRESS_UPSTREAM_PROXY_URL Oxylabs URL with its
+# {sessionId} template — don't trip helm's --set parser. Copy the committed
+# values-local.secret.yaml.example to values-local.secret.yaml and fill it in.
+LOCAL_SECRET_VALUES := $(if $(wildcard charts/browser-hitl/values-local.secret.yaml),-f charts/browser-hitl/values-local.secret.yaml)
+
 KIND_CLUSTER ?= tabby-dev
 
 .PHONY: tilt
@@ -337,6 +344,7 @@ kind-deploy: kind-guard ## Full local deploy: load images + helm install with lo
 	kubectl --context $(KIND_CONTEXT) create namespace $(HELM_NAMESPACE) --dry-run=client -o yaml | kubectl --context $(KIND_CONTEXT) apply -f -
 	helm upgrade --install $(HELM_RELEASE) charts/browser-hitl/ --kube-context $(KIND_CONTEXT) \
 		-f charts/browser-hitl/values-local.yaml \
+		$(LOCAL_SECRET_VALUES) \
 		--namespace $(HELM_NAMESPACE) \
 		--wait --timeout 5m
 	@echo "Stack deployed. Run: kubectl port-forward -n $(HELM_NAMESPACE) svc/$(HELM_RELEASE)-api 18080:8080"
@@ -348,6 +356,7 @@ kind-reload-api: kind-guard docker-build-api ## Rebuild API and reload into Kind
 	kind load docker-image $(IMG_API) --name $(KIND_CLUSTER)
 	helm upgrade $(HELM_RELEASE) charts/browser-hitl/ --kube-context $(KIND_CONTEXT) \
 		-f charts/browser-hitl/values-local.yaml \
+		$(LOCAL_SECRET_VALUES) \
 		--namespace $(HELM_NAMESPACE) --reuse-values \
 		--wait --timeout 5m
 	@echo "API reloaded."
@@ -357,6 +366,7 @@ kind-reload-controller: kind-guard docker-build-controller ## Rebuild controller
 	kind load docker-image $(IMG_CONTROLLER) --name $(KIND_CLUSTER)
 	helm upgrade $(HELM_RELEASE) charts/browser-hitl/ --kube-context $(KIND_CONTEXT) \
 		-f charts/browser-hitl/values-local.yaml \
+		$(LOCAL_SECRET_VALUES) \
 		--namespace $(HELM_NAMESPACE) --reuse-values \
 		--wait --timeout 5m
 	@echo "Controller reloaded."
@@ -366,6 +376,7 @@ kind-reload-worker: kind-guard docker-build-worker ## Rebuild worker and reload 
 	kind load docker-image $(IMG_WORKER) --name $(KIND_CLUSTER)
 	helm upgrade $(HELM_RELEASE) charts/browser-hitl/ --kube-context $(KIND_CONTEXT) \
 		-f charts/browser-hitl/values-local.yaml \
+		$(LOCAL_SECRET_VALUES) \
 		--namespace $(HELM_NAMESPACE) --reuse-values \
 		--wait --timeout 5m
 	@echo "Worker reloaded."
@@ -375,6 +386,7 @@ kind-reload-admin-ui: kind-guard docker-build-admin-ui ## Rebuild admin-ui and r
 	kind load docker-image $(IMG_ADMIN_UI) --name $(KIND_CLUSTER)
 	helm upgrade $(HELM_RELEASE) charts/browser-hitl/ --kube-context $(KIND_CONTEXT) \
 		-f charts/browser-hitl/values-local.yaml \
+		$(LOCAL_SECRET_VALUES) \
 		--namespace $(HELM_NAMESPACE) --reuse-values \
 		--wait --timeout 5m
 	@echo "Admin UI reloaded."
@@ -389,6 +401,7 @@ kind-reload-all: kind-guard clean build docker-build ## Clean + build source + i
 	$(MAKE) kind-load-images
 	helm upgrade --install $(HELM_RELEASE) charts/browser-hitl/ --kube-context $(KIND_CONTEXT) \
 		-f charts/browser-hitl/values-local.yaml \
+		$(LOCAL_SECRET_VALUES) \
 		--namespace $(HELM_NAMESPACE) --create-namespace \
 		$(HELM_DOTENV_SETS) \
 		--wait --timeout 5m

--- a/Makefile
+++ b/Makefile
@@ -240,8 +240,21 @@ tilt: ## Start Tilt for live rebuild and deploy (replaces kind-reload-all)
 
 .PHONY: kind-create
 kind-create: ## Create a Kind cluster for local development
-	kind create cluster --name $(KIND_CLUSTER)
+	kind create cluster --name $(KIND_CLUSTER) --config infra/kind/cluster-config.yaml
+	$(MAKE) kind-fix-mtu
 	@echo "Kind cluster '$(KIND_CLUSTER)' created. Context: kind-$(KIND_CLUSTER)"
+
+.PHONY: kind-fix-mtu
+kind-fix-mtu: ## Fix Kind pod MTU from 65535 to 1500 (prevents TLS failures to external sites)
+	@echo "Patching kindnet MTU to 1500..."
+	@docker exec $(KIND_CLUSTER)-control-plane sh -c '\
+		CNI=/etc/cni/net.d/10-kindnet.conflist; \
+		if [ -s "$$CNI" ]; then \
+			sed -i "s/\"mtu\": *[0-9]*/\"mtu\": 1500/g" "$$CNI"; \
+		fi'
+	kubectl rollout restart daemonset/kindnet -n kube-system
+	kubectl rollout status daemonset/kindnet -n kube-system --timeout=30s
+	@echo "MTU fixed to 1500. Restart pods to pick up the new MTU."
 
 .PHONY: kind-load-images
 kind-load-images: ## Load all Docker images into the Kind cluster

--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ k8s-logs-controller: ## Tail controller logs
 	kubectl logs -n $(HELM_NAMESPACE) -l app.kubernetes.io/component=controller -f --tail=100
 
 .PHONY: k8s-port-forward
-k8s-port-forward: ## Port-forward all services for local development
+k8s-port-forward: kind-guard ## Port-forward all services for local development
 	@echo "API:        http://localhost:18080        (Swagger: http://localhost:18080/api/docs)"
 	@echo "Admin UI:   http://localhost:13000"
 	@echo "PostgreSQL: localhost:25432"
@@ -214,12 +214,12 @@ k8s-port-forward: ## Port-forward all services for local development
 	@echo ""
 	@echo "Stop all: pkill -f 'kubectl port-forward'"
 	@echo ""
-	kubectl port-forward -n $(HELM_NAMESPACE) svc/$(HELM_RELEASE)-api 18080:8000 &
-	kubectl port-forward -n $(HELM_NAMESPACE) svc/$(HELM_RELEASE)-admin-ui 13000:8000 &
-	kubectl port-forward -n $(HELM_NAMESPACE) svc/$(HELM_RELEASE)-postgres 25432:5432 &
-	kubectl port-forward -n $(HELM_NAMESPACE) svc/$(HELM_RELEASE)-redis 16379:6379 &
-	kubectl port-forward -n $(HELM_NAMESPACE) svc/$(HELM_RELEASE)-minio 19000:9000 &
-	kubectl port-forward -n $(HELM_NAMESPACE) svc/$(HELM_RELEASE)-nats 4222:4222 &
+	kubectl --context $(KIND_CONTEXT) port-forward -n $(HELM_NAMESPACE) svc/$(HELM_RELEASE)-api 18080:8000 &
+	kubectl --context $(KIND_CONTEXT) port-forward -n $(HELM_NAMESPACE) svc/$(HELM_RELEASE)-admin-ui 13000:8000 &
+	kubectl --context $(KIND_CONTEXT) port-forward -n $(HELM_NAMESPACE) svc/$(HELM_RELEASE)-postgres 25432:5432 &
+	kubectl --context $(KIND_CONTEXT) port-forward -n $(HELM_NAMESPACE) svc/$(HELM_RELEASE)-redis 16379:6379 &
+	kubectl --context $(KIND_CONTEXT) port-forward -n $(HELM_NAMESPACE) svc/$(HELM_RELEASE)-minio 19000:9000 &
+	kubectl --context $(KIND_CONTEXT) port-forward -n $(HELM_NAMESPACE) svc/$(HELM_RELEASE)-nats 4222:4222 &
 	@wait
 
 # ============================================================

--- a/Makefile
+++ b/Makefile
@@ -245,33 +245,54 @@ kind-create: ## Create a Kind cluster for local development
 	$(MAKE) kind-fix-dns
 	@echo "Kind cluster '$(KIND_CLUSTER)' created. Context: kind-$(KIND_CLUSTER)"
 
+# The Kind cluster's kubectl context (Kind names it kind-<cluster>). All mutating
+# targets below pin --context to this so they can NEVER touch a remote cluster,
+# even if the current kube-context is pointed at staging/prod.
+KIND_CONTEXT := kind-$(KIND_CLUSTER)
+
+# Guard: refuse to run if the Kind cluster's context doesn't exist (i.e. the
+# cluster isn't up). Prevents these local-only targets from silently no-oping
+# against whatever context happens to be current.
+.PHONY: kind-guard
+kind-guard:
+	@kubectl config get-contexts -o name 2>/dev/null | grep -qx '$(KIND_CONTEXT)' || \
+		{ echo "refusing: kube-context '$(KIND_CONTEXT)' not found — is the Kind cluster up? (make kind-create)"; exit 1; }
+
 .PHONY: kind-fix-mtu
-kind-fix-mtu: ## Fix Kind pod MTU from 65535 to 1500 (prevents TLS failures to external sites)
-	@echo "Patching kindnet MTU to 1500..."
-	@docker exec $(KIND_CLUSTER)-control-plane sh -c '\
-		CNI=/etc/cni/net.d/10-kindnet.conflist; \
-		if [ -s "$$CNI" ]; then \
-			sed -i "s/\"mtu\": *[0-9]*/\"mtu\": 1500/g" "$$CNI"; \
-		fi'
-	kubectl rollout restart daemonset/kindnet -n kube-system
-	kubectl rollout status daemonset/kindnet -n kube-system --timeout=30s
-	@echo "MTU fixed to 1500. Restart pods to pick up the new MTU."
+kind-fix-mtu: kind-guard ## Fix Kind pod MTU from 65535 to 1500 (prevents TLS failures to external sites)
+	@echo "Patching kindnet MTU to 1500 on all nodes of '$(KIND_CLUSTER)'..."
+	@# kindnet rewrites its conflist on startup, so restart the daemonset FIRST,
+	@# then patch every node's conflist, so the patch is what survives.
+	kubectl --context $(KIND_CONTEXT) rollout restart daemonset/kindnet -n kube-system
+	kubectl --context $(KIND_CONTEXT) rollout status daemonset/kindnet -n kube-system --timeout=30s
+	@for node in $$(kind get nodes --name $(KIND_CLUSTER)); do \
+		docker exec $$node sh -c '\
+			CNI=/etc/cni/net.d/10-kindnet.conflist; \
+			[ -s "$$CNI" ] && sed -i "s/\"mtu\": *[0-9]*/\"mtu\": 1500/g" "$$CNI"; \
+			grep -q "\"mtu\": 1500" "$$CNI"' \
+			|| { echo "MTU patch did not land on $$node (no \"mtu\" key? kindnet variant changed)"; exit 1; }; \
+	done
+	@echo "MTU set to 1500 on all nodes (verified). Restart pods to pick it up."
 
 .PHONY: kind-fix-dns
-kind-fix-dns: ## Point CoreDNS at public resolvers (fixes AAAA SERVFAIL from Docker Desktop embedded DNS)
-	@echo "Pointing CoreDNS forward at 8.8.8.8 1.1.1.1 (local-dev only)..."
+kind-fix-dns: kind-guard ## Point CoreDNS at public resolvers (fixes AAAA SERVFAIL from Docker Desktop embedded DNS)
+	@echo "Pointing CoreDNS forward at 8.8.8.8 1.1.1.1 on '$(KIND_CONTEXT)' (local-dev only)..."
 	@# Docker Desktop's embedded DNS (127.0.0.11, reached via /etc/resolv.conf) returns
 	@# SERVFAIL on AAAA lookups for CNAME->CloudFront domains. getaddrinfo (Chromium + the
 	@# egress proxy's net.connect) does a dual A+AAAA lookup and fails the whole resolution
 	@# with EAI_AGAIN, surfacing as ERR_TUNNEL_CONNECTION_FAILED in worker sessions.
 	@# Forwarding to a public resolver that answers AAAA cleanly avoids this. Cloud clusters
 	@# (staging/prod) use a well-behaved VPC resolver and never hit this, so it stays local.
-	@kubectl get configmap coredns -n kube-system -o yaml | \
+	@kubectl --context $(KIND_CONTEXT) get configmap coredns -n kube-system -o yaml | \
 		sed 's#forward . /etc/resolv.conf#forward . 8.8.8.8 1.1.1.1#' | \
-		kubectl apply -f -
-	kubectl rollout restart deployment/coredns -n kube-system
-	kubectl rollout status deployment/coredns -n kube-system --timeout=60s
-	@echo "CoreDNS now forwards to public resolvers."
+		kubectl --context $(KIND_CONTEXT) apply -f -
+	@# Verify the substitution actually landed (CoreDNS Corefile variants differ; a
+	@# no-op sed would otherwise re-apply an identical ConfigMap and still report success).
+	@kubectl --context $(KIND_CONTEXT) get configmap coredns -n kube-system -o yaml | grep -q '8.8.8.8' \
+		|| { echo "CoreDNS Corefile did not match 'forward . /etc/resolv.conf' — nothing changed. Inspect the Corefile manually."; exit 1; }
+	kubectl --context $(KIND_CONTEXT) rollout restart deployment/coredns -n kube-system
+	kubectl --context $(KIND_CONTEXT) rollout status deployment/coredns -n kube-system --timeout=60s
+	@echo "CoreDNS now forwards to public resolvers (verified 8.8.8.8 in Corefile)."
 
 .PHONY: kind-load-images
 kind-load-images: ## Load all Docker images into the Kind cluster

--- a/Makefile
+++ b/Makefile
@@ -242,6 +242,7 @@ tilt: ## Start Tilt for live rebuild and deploy (replaces kind-reload-all)
 kind-create: ## Create a Kind cluster for local development
 	kind create cluster --name $(KIND_CLUSTER) --config infra/kind/cluster-config.yaml
 	$(MAKE) kind-fix-mtu
+	$(MAKE) kind-fix-dns
 	@echo "Kind cluster '$(KIND_CLUSTER)' created. Context: kind-$(KIND_CLUSTER)"
 
 .PHONY: kind-fix-mtu
@@ -255,6 +256,22 @@ kind-fix-mtu: ## Fix Kind pod MTU from 65535 to 1500 (prevents TLS failures to e
 	kubectl rollout restart daemonset/kindnet -n kube-system
 	kubectl rollout status daemonset/kindnet -n kube-system --timeout=30s
 	@echo "MTU fixed to 1500. Restart pods to pick up the new MTU."
+
+.PHONY: kind-fix-dns
+kind-fix-dns: ## Point CoreDNS at public resolvers (fixes AAAA SERVFAIL from Docker Desktop embedded DNS)
+	@echo "Pointing CoreDNS forward at 8.8.8.8 1.1.1.1 (local-dev only)..."
+	@# Docker Desktop's embedded DNS (127.0.0.11, reached via /etc/resolv.conf) returns
+	@# SERVFAIL on AAAA lookups for CNAME->CloudFront domains. getaddrinfo (Chromium + the
+	@# egress proxy's net.connect) does a dual A+AAAA lookup and fails the whole resolution
+	@# with EAI_AGAIN, surfacing as ERR_TUNNEL_CONNECTION_FAILED in worker sessions.
+	@# Forwarding to a public resolver that answers AAAA cleanly avoids this. Cloud clusters
+	@# (staging/prod) use a well-behaved VPC resolver and never hit this, so it stays local.
+	@kubectl get configmap coredns -n kube-system -o yaml | \
+		sed 's#forward . /etc/resolv.conf#forward . 8.8.8.8 1.1.1.1#' | \
+		kubectl apply -f -
+	kubectl rollout restart deployment/coredns -n kube-system
+	kubectl rollout status deployment/coredns -n kube-system --timeout=60s
+	@echo "CoreDNS now forwards to public resolvers."
 
 .PHONY: kind-load-images
 kind-load-images: ## Load all Docker images into the Kind cluster

--- a/apps/api/src/modules/agent/agent.service.spec.ts
+++ b/apps/api/src/modules/agent/agent.service.spec.ts
@@ -225,6 +225,28 @@ describe('AgentService', () => {
       });
     });
 
+    it('excludes TERMINATED/FAILED sessions and 404s so the caller provisions fresh', async () => {
+      // Regression: returning the newest session regardless of state handed a
+      // just-expired TERMINATED session back as "current", so the harness minted
+      // a sign-in card pointing at a dead session (the recurring ICICI failure).
+      const credentialsService = createMockCredentialsService();
+      credentialsService.resolveActiveProfile.mockResolvedValue({ app_id: 'app-1' });
+
+      const sessionRepo = createMockSessionRepo();
+      // With the state filter applied, no LIVE session matches → findOne returns null.
+      sessionRepo.findOne.mockResolvedValue(null);
+
+      const { service } = buildService({ sessionRepo, credentialsService });
+
+      await expect(
+        service.getSessionStatus('profile-1', 'tenant-1', [], 'Operator'),
+      ).rejects.toThrow(/No live session/);
+
+      // and the query must carry a state exclusion, not just an order-by.
+      const call = sessionRepo.findOne.mock.calls[0][0];
+      expect(call.where.state).toBeDefined();
+    });
+
     it('falls back to session.pending_input_request when no intervention exists', async () => {
       const credentialsService = createMockCredentialsService();
       credentialsService.resolveActiveProfile.mockResolvedValue({ app_id: 'app-1' });
@@ -362,7 +384,7 @@ describe('AgentService', () => {
 
       await expect(
         service.getSessionStatus(PROFILE_ID, TENANT, [PROFILE_ID], 'Agent', 'user-a'),
-      ).rejects.toThrow('No session found for profile');
+      ).rejects.toThrow(/No .*session found for profile/);
     });
   });
 });

--- a/apps/api/src/modules/agent/agent.service.ts
+++ b/apps/api/src/modules/agent/agent.service.ts
@@ -10,7 +10,7 @@ import {
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { SessionState, requireEnv, REDIS_KEYS } from '@browser-hitl/shared';
-import { Repository } from 'typeorm';
+import { Repository, Not, In } from 'typeorm';
 import Redis from 'ioredis';
 import { createHash } from 'crypto';
 import { SessionEntity, InterventionEntity } from '../../entities';
@@ -91,14 +91,22 @@ export class AgentService implements OnModuleDestroy {
     if (ownerUserId) {
       where.owner_user_id = ownerUserId;
     }
+    // Prefer a LIVE session. Ordering by started_at alone returns the newest row
+    // regardless of state, so a just-expired TERMINATED/FAILED session is handed
+    // back as "current" — and the harness then mints a sign-in card pointing at a
+    // dead session, so the user clicks the link and lands on "session terminated"
+    // (a recurring ICICI failure). A terminal session is not a usable session:
+    // exclude it so the caller sees "none" and provisions a fresh one instead.
     const session = await this.sessionRepo.findOne({
-      where,
+      where: { ...where, state: Not(In([SessionState.TERMINATED, SessionState.FAILED])) },
       order: { started_at: 'DESC' },
       relations: ['application'],
     });
 
     if (!session) {
-      throw new NotFoundException('No session found for profile');
+      // No live session — the only rows are terminal. Report "none" so the agent
+      // path provisions fresh, rather than surfacing a dead session id.
+      throw new NotFoundException('No live session found for profile');
     }
 
     const hitlActive = session.state === 'LOGIN_IN_PROGRESS' || session.state === 'LOGIN_NEEDED';

--- a/apps/api/src/modules/app-templates/app-templates.service.spec.ts
+++ b/apps/api/src/modules/app-templates/app-templates.service.spec.ts
@@ -77,6 +77,7 @@ function buildService(overrides: {
 } = {}) {
   const templateRepo = overrides.templateRepo ?? {
     findOne: jest.fn().mockResolvedValue(null),
+    findOneOrFail: jest.fn().mockResolvedValue(null),
     find: jest.fn().mockResolvedValue([]),
     create: jest.fn().mockImplementation((d: any) => d),
     save: jest.fn().mockImplementation((d: any) => Promise.resolve({ id: 'tpl-uuid-1', ...d })),
@@ -127,6 +128,7 @@ describe('AppTemplatesService — propagation', () => {
       const { service, templateRepo, appRepo } = buildService({
         templateRepo: {
           findOne: jest.fn().mockResolvedValue(template),
+          findOneOrFail: jest.fn().mockResolvedValue(template),
           save: jest.fn().mockResolvedValue(template),
         },
         appRepo: {
@@ -159,6 +161,7 @@ describe('AppTemplatesService — propagation', () => {
       const { service, appRepo } = buildService({
         templateRepo: {
           findOne: jest.fn().mockResolvedValue(template),
+          findOneOrFail: jest.fn().mockResolvedValue(template),
           save: jest.fn().mockResolvedValue(template),
         },
         appRepo: {
@@ -183,6 +186,7 @@ describe('AppTemplatesService — propagation', () => {
       const { service, appRepo } = buildService({
         templateRepo: {
           findOne: jest.fn().mockResolvedValue(template),
+          findOneOrFail: jest.fn().mockResolvedValue(template),
           save: jest.fn().mockResolvedValue(template),
         },
         appRepo: {
@@ -202,6 +206,7 @@ describe('AppTemplatesService — propagation', () => {
       const { service } = buildService({
         templateRepo: {
           findOne: jest.fn().mockResolvedValue(template),
+          findOneOrFail: jest.fn().mockResolvedValue(template),
           save: jest.fn().mockResolvedValue(template),
         },
         appRepo: {
@@ -230,6 +235,7 @@ describe('AppTemplatesService — propagation', () => {
       const { service } = buildService({
         templateRepo: {
           findOne: jest.fn().mockResolvedValue(template),
+          findOneOrFail: jest.fn().mockResolvedValue(template),
           save: jest.fn().mockResolvedValue(template),
         },
         appRepo: {
@@ -253,6 +259,7 @@ describe('AppTemplatesService — propagation', () => {
       const { service } = buildService({
         templateRepo: {
           findOne: jest.fn().mockResolvedValue(template),
+          findOneOrFail: jest.fn().mockResolvedValue(template),
           save: jest.fn().mockResolvedValue(template),
         },
         appRepo: {
@@ -274,6 +281,7 @@ describe('AppTemplatesService — propagation', () => {
       const { service } = buildService({
         templateRepo: {
           findOne: jest.fn().mockResolvedValue(template),
+          findOneOrFail: jest.fn().mockResolvedValue(template),
           save: jest.fn().mockResolvedValue(template),
         },
         appRepo: {
@@ -313,6 +321,7 @@ describe('AppTemplatesService — propagation', () => {
       const { service } = buildService({
         templateRepo: {
           findOne: jest.fn().mockResolvedValue(template),
+          findOneOrFail: jest.fn().mockResolvedValue(template),
           save: jest.fn().mockResolvedValue(template),
         },
         appRepo: {
@@ -348,6 +357,64 @@ describe('AppTemplatesService — propagation', () => {
       );
     });
 
+    it('propagates full config on a PATCH even though save() returns only the patched fields', async () => {
+      // Regression: repo.save() resolves to an object carrying only the properties it was
+      // handed. On a PATCH that is just the patched field, so propagating from save()'s
+      // return value read login_config as undefined and inserted a profile row with a NULL
+      // login_config — a NOT NULL violation that 500'd the request after appRepo.update()
+      // had already written. The service must propagate from a fresh read instead.
+      const newExportPolicy = {
+        target_domains: ['salesforce.com'],
+        credential_types: { token: 'VOLATILE', headers: ['x-xsrf-token'] },
+      };
+      const template = makeTemplate({ export_policy: newExportPolicy });
+      const existingProfile = makeProfile();
+
+      let managerSave: jest.Mock;
+      const dataSource = {
+        transaction: jest.fn().mockImplementation(async (cb: any) => {
+          managerSave = jest.fn().mockResolvedValue({});
+          return cb({ update: jest.fn().mockResolvedValue(undefined), save: managerSave });
+        }),
+      };
+
+      const appRepo = {
+        find: jest.fn().mockResolvedValue([{ id: 'app-1' }]),
+        update: jest.fn().mockResolvedValue(undefined),
+      };
+
+      const { service } = buildService({
+        templateRepo: {
+          findOne: jest.fn().mockResolvedValue(template),
+          // Fresh read after save — carries every column.
+          findOneOrFail: jest.fn().mockResolvedValue(template),
+          // Mimics real TypeORM: resolves to just what the PATCH handed it.
+          save: jest.fn().mockResolvedValue({ export_policy: newExportPolicy }),
+        },
+        appRepo,
+        profileRepo: { find: jest.fn().mockResolvedValue([existingProfile]) },
+        dataSource,
+      });
+
+      await service.update('tenant-1', 'tpl-uuid-1', { export_policy: newExportPolicy }, 'actor-1');
+
+      // The new profile row must carry the template's real login_config, never undefined.
+      expect(managerSave!).toHaveBeenCalledWith(
+        expect.any(Function),
+        expect.objectContaining({
+          login_config: template.login_config,
+          credential_types: newExportPolicy.credential_types,
+          target_domains: newExportPolicy.target_domains,
+        }),
+      );
+
+      // And the linked app must not be handed an undefined login_config either.
+      expect(appRepo.update).toHaveBeenCalledWith(
+        'app-1',
+        expect.objectContaining({ login_config: template.login_config }),
+      );
+    });
+
     it('does not create a new profile version when only browser_policy changes', async () => {
       const template = makeTemplate({ browser_policy: { downloads: true, clipboard: false, file_chooser: false } });
       // Profile fields match the template exactly
@@ -362,6 +429,7 @@ describe('AppTemplatesService — propagation', () => {
       const { service } = buildService({
         templateRepo: {
           findOne: jest.fn().mockResolvedValue(template),
+          findOneOrFail: jest.fn().mockResolvedValue(template),
           save: jest.fn().mockResolvedValue(template),
         },
         appRepo: {
@@ -388,6 +456,7 @@ describe('AppTemplatesService — propagation', () => {
       const { service } = buildService({
         templateRepo: {
           findOne: jest.fn().mockResolvedValue(template),
+          findOneOrFail: jest.fn().mockResolvedValue(template),
           save: jest.fn().mockResolvedValue(template),
         },
         appRepo: {
@@ -430,6 +499,7 @@ describe('AppTemplatesService — propagation', () => {
       const { service } = buildService({
         templateRepo: {
           findOne: jest.fn().mockResolvedValue(template),
+          findOneOrFail: jest.fn().mockResolvedValue(template),
           save: jest.fn().mockResolvedValue(template),
         },
         appRepo: {
@@ -467,6 +537,7 @@ describe('AppTemplatesService — propagation', () => {
       const { service } = buildService({
         templateRepo: {
           findOne: jest.fn().mockResolvedValue(template),
+          findOneOrFail: jest.fn().mockResolvedValue(template),
           save: jest.fn().mockResolvedValue(template),
         },
         appRepo: {
@@ -497,6 +568,7 @@ describe('AppTemplatesService — propagation', () => {
       const { service } = buildService({
         templateRepo: {
           findOne: jest.fn().mockResolvedValue(template),
+          findOneOrFail: jest.fn().mockResolvedValue(template),
           save: jest.fn().mockResolvedValue(template),
         },
         appRepo: {
@@ -529,6 +601,7 @@ describe('AppTemplatesService — propagation', () => {
       const { service } = buildService({
         templateRepo: {
           findOne: jest.fn().mockResolvedValue(template),
+          findOneOrFail: jest.fn().mockResolvedValue(template),
           save: jest.fn().mockResolvedValue(template),
         },
         appRepo: {

--- a/apps/api/src/modules/app-templates/app-templates.service.ts
+++ b/apps/api/src/modules/app-templates/app-templates.service.ts
@@ -69,7 +69,16 @@ export class AppTemplatesService {
   async update(tenantId: string | undefined, id: string, data: Partial<AppTemplateEntity>, actorId: string) {
     const template = await this.findOne(tenantId, id);
     Object.assign(template, data);
-    const saved = await this.templateRepo.save(template);
+    await this.templateRepo.save(template);
+
+    // Re-read the persisted row instead of propagating from save()'s return value.
+    // save() resolves to an object carrying only the properties it was handed, so on a
+    // PATCH it comes back holding just the patched fields. Propagation then reads
+    // template.login_config as undefined and inserts a profile row with a NULL
+    // login_config, which trips the NOT NULL constraint and 500s the whole request —
+    // after appRepo.update() has already written, leaving a partial update behind.
+    // A fresh read guarantees every PROPAGATED_FIELD is present regardless of payload shape.
+    const saved = await this.templateRepo.findOneOrFail({ where: { id: template.id } });
 
     await this.auditService.log({
       tenant_id: template.tenant_id,

--- a/apps/api/src/modules/apps/apps.dto.ts
+++ b/apps/api/src/modules/apps/apps.dto.ts
@@ -56,19 +56,46 @@ export class CreateAppDto {
   @IsString({ each: true })
   extra_egress_allowlist?: string[];
 
-  @ApiProperty({ description: 'Login DSL configuration with URL, credential ref, and steps', example: { login_url: 'https://app.hubspot.com/login', credential_ref: 'k8s:secret/hubspot-creds', steps: [{ action: 'goto', url: 'https://app.hubspot.com/login' }, { action: 'fill', selector: '#username', value: '${USERNAME}' }, { action: 'click', selector: '#loginBtn' }] } })
+  @ApiProperty({
+    description: 'Login DSL configuration. Required fields: login_url, credential_ref (k8s:secret/{name} or manual:), steps (array with at least one goto action). Step actions: goto, fill, type, click, select, wait_for, wait_for_url, frame, main_frame, popup, keyboard, evaluate, sleep, screenshot, reload, request_human_input.',
+    example: {
+      login_url: 'https://app.hubspot.com/login',
+      credential_ref: 'k8s:secret/hubspot-creds',
+      steps: [
+        { action: 'goto', url: 'https://app.hubspot.com/login' },
+        { action: 'fill', selector: '#username', value: '${USERNAME}' },
+        { action: 'fill', selector: '#password', value: '${PASSWORD}' },
+        { action: 'click', selector: '#loginBtn' },
+      ],
+    },
+  })
   @IsObject()
   login_config: Record<string, unknown>;
 
-  @ApiProperty({ description: 'Health check configuration', example: { interval_seconds: 300, actions: [{ action: 'goto', url: 'https://app.hubspot.com/home' }], health_checks: [{ type: 'url_check', url: 'https://app.hubspot.com/home', expect_status: 200 }], policy: 'all' } })
+  @ApiProperty({
+    description: 'Health check configuration. Required fields: interval_seconds (>= 60), actions (array, can be empty), health_checks (non-empty array). Health check types: url_check (needs url + expect_status), dom_check (needs selector), network_check (needs url + expect_status). policy: all | any | quorum.',
+    example: {
+      interval_seconds: 300,
+      actions: [],
+      health_checks: [{ type: 'url_check', url: 'https://app.hubspot.com/home', expect_status: 200 }],
+      policy: 'all',
+    },
+  })
   @IsObject()
   keepalive_config: Record<string, unknown>;
 
-  @ApiProperty({ description: 'Credential export configuration', example: { artifact_types: ['cookies', 'headers', 'csrf_token'], encryption: { algo: 'AES-256-GCM', key_ref: 'k8s:secret/tenant-key' }, ttl_seconds: 3600 } })
+  @ApiProperty({
+    description: 'Credential export configuration. Required fields: artifact_types (non-empty array from: cookies, headers, csrf_token, local_storage, session_storage), encryption (algo must be AES-256-GCM), ttl_seconds (>= 300).',
+    example: {
+      artifact_types: ['cookies'],
+      encryption: { algo: 'AES-256-GCM' },
+      ttl_seconds: 3600,
+    },
+  })
   @IsObject()
   export_policy: Record<string, unknown>;
 
-  @ApiProperty({ description: 'Notification channels for HITL events. Omit for silent/agent-poll mode.', example: { channels: ['slack:#tabby-experiments'] }, required: false })
+  @ApiProperty({ description: 'Notification channels for HITL events. Omit entirely for silent/agent-poll mode. Channels format: {provider}:{reference} where provider is slack, teams, or agent.', example: { channels: [] }, required: false })
   @IsOptional()
   @IsObject()
   notification_config?: Record<string, unknown>;

--- a/apps/api/src/modules/apps/apps.dto.ts
+++ b/apps/api/src/modules/apps/apps.dto.ts
@@ -73,7 +73,7 @@ export class CreateAppDto {
   login_config: Record<string, unknown>;
 
   @ApiProperty({
-    description: 'Health check configuration. Required fields: interval_seconds (>= 60), actions (array, can be empty), health_checks (non-empty array). Health check types: url_check (needs url + expect_status), dom_check (needs selector), network_check (needs url + expect_status). policy: all | any | quorum.',
+    description: 'Health check configuration. Required fields: interval_seconds (>= 60), actions (array, can be empty), health_checks (non-empty array). Health check types: url_check (needs url + expect_status), dom_check (needs selector), network_check (needs url + expect_status). policy: all | any | quorum (quorum requires quorum_n >= 1).',
     example: {
       interval_seconds: 300,
       actions: [],
@@ -85,10 +85,10 @@ export class CreateAppDto {
   keepalive_config: Record<string, unknown>;
 
   @ApiProperty({
-    description: 'Credential export configuration. Required fields: artifact_types (non-empty array from: cookies, headers, csrf_token, local_storage, session_storage), encryption (algo must be AES-256-GCM), ttl_seconds (>= 300).',
+    description: 'Credential export configuration. Required fields: artifact_types (non-empty array from: cookies, headers, csrf_token, local_storage, session_storage), encryption (algo must be AES-256-GCM, key_ref format: k8s:secret/{name}), ttl_seconds (>= 300).',
     example: {
       artifact_types: ['cookies'],
-      encryption: { algo: 'AES-256-GCM' },
+      encryption: { algo: 'AES-256-GCM', key_ref: 'k8s:secret/tenant-key' },
       ttl_seconds: 3600,
     },
   })

--- a/apps/api/src/modules/artifacts/minio-orphan-sweep.service.spec.ts
+++ b/apps/api/src/modules/artifacts/minio-orphan-sweep.service.spec.ts
@@ -176,4 +176,39 @@ describe('MinioOrphanSweepService', () => {
     expect(minioClient.bucketExists).not.toHaveBeenCalled();
     expect(minioClient.removeObjects).not.toHaveBeenCalled();
   });
+
+  it('never deletes recording bundles, even with no DB row and well past the cutoff', async () => {
+    // Recordings share the bucket but are not artifact bundles: RecordingStore
+    // writes them with no artifact_bundles row, so without the prefix skip the
+    // DB-row check classifies every recording as an orphan and deletes it after
+    // ~2h — which silently GC'd captured logins before capture_import ran.
+    const oldDate = new Date(Date.now() - 48 * 60 * 60 * 1000); // 2 days ago
+    const objects = [
+      { name: 'recordings/sess-abc.json.enc', lastModified: oldDate },
+      { name: 'some-real-orphan', lastModified: oldDate },
+    ];
+    const minioClient = makeMockMinioClient({ objects });
+    const tenantRepo = makeMockTenantRepo([{ id: 'tenant-1' }]);
+    const artifactRepo = makeMockArtifactRepo(null); // no rows for anything
+    const provisioner = makeMockProvisioner(minioClient);
+
+    const service = new MinioOrphanSweepService(
+      provisioner as any,
+      artifactRepo as any,
+      tenantRepo as any,
+    );
+
+    await service.sweepOrphans();
+
+    // The real orphan is removed; the recording is spared.
+    expect(minioClient.removeObjects).toHaveBeenCalledWith('artifact-bundles-tenant-1', [
+      'some-real-orphan',
+    ]);
+    // And the recording key was never even DB-checked (skipped before the query).
+    expect(artifactRepo.findOne).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ encrypted_payload_ref: 'recordings/sess-abc.json.enc' }),
+      }),
+    );
+  });
 });

--- a/apps/api/src/modules/artifacts/minio-orphan-sweep.service.ts
+++ b/apps/api/src/modules/artifacts/minio-orphan-sweep.service.ts
@@ -40,6 +40,14 @@ export class MinioOrphanSweepService {
 
         for await (const obj of stream) {
           if (!obj.lastModified || obj.lastModified >= cutoff) continue;
+          // Recording bundles share this bucket but are NOT artifact bundles:
+          // RecordingStore writes them via a bare putObject and creates no
+          // artifact_bundles row, so the DB-row check below would classify every
+          // recording as an orphan and delete it after MINIO_ORPHAN_MAX_AGE_HOURS
+          // (default 2h). That silently GC'd captured login recordings before
+          // capture_import could compile them. The sweep only owns credential
+          // artifact bundles; skip the recordings/ prefix entirely.
+          if ((obj.name as string).startsWith('recordings/')) continue;
           // Check if DB row exists
           const dbRow = await this.artifactRepo.findOne({
             where: { encrypted_payload_ref: obj.name, tenant_id: tenant.id },

--- a/apps/api/src/modules/auth/bootstrap.service.ts
+++ b/apps/api/src/modules/auth/bootstrap.service.ts
@@ -1,7 +1,8 @@
 import { Injectable, OnModuleInit, Logger } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { randomUUID } from 'crypto';
-import { Repository } from 'typeorm';
+import { Not, Repository } from 'typeorm';
+import { RECORDING_POOL } from '@browser-hitl/shared';
 import { TenantEntity, UserEntity } from '../../entities';
 import { AuthService } from './auth.service';
 
@@ -26,7 +27,9 @@ export class BootstrapService implements OnModuleInit {
   ) {}
 
   async onModuleInit() {
-    const tenantCount = await this.tenantRepo.count();
+    const tenantCount = await this.tenantRepo.count({
+      where: { id: Not(RECORDING_POOL.SYSTEM_TENANT_ID) },
+    });
     if (tenantCount > 0) {
       this.logger.log('Tenants exist, skipping bootstrap');
       return;

--- a/apps/api/src/modules/auth/bootstrap.service.ts
+++ b/apps/api/src/modules/auth/bootstrap.service.ts
@@ -12,7 +12,9 @@ import { AuthService } from './auth.service';
  * 1. A tenant with name BOOTSTRAP_TENANT_NAME
  * 2. An admin user with ADMIN_BOOTSTRAP_EMAIL/PASSWORD
  * 3. (MinIO bucket + encryption key provisioned separately)
- * Idempotent: skips if any tenant exists.
+ * Idempotent: skips if any *non-system* tenant exists. The system recording-pool
+ * tenant (RECORDING_POOL.SYSTEM_TENANT_ID, seeded by migration 033) is excluded
+ * from the count, so a fresh install with only the system tenant still bootstraps.
  */
 @Injectable()
 export class BootstrapService implements OnModuleInit {

--- a/apps/api/src/modules/recording/recording.store.spec.ts
+++ b/apps/api/src/modules/recording/recording.store.spec.ts
@@ -44,10 +44,14 @@ const sampleBundle: RecordingBundle = {
       value: '[REDACTED]',
       field_role: 'password',
       is_redacted: true,
-      timestamp: '2026-06-15T00:01:00.000Z',
+      seq: 1,
+      event_time: '2026-06-15T00:01:00.000Z',
+      timestamp: '2026-06-15T00:01:00.500Z',
     },
   ],
-  url_events: [{ from_url: 'https://example.com/login', to_url: 'https://example.com/home', timestamp: 'x' }],
+  url_events: [
+    { from_url: 'https://example.com/login', to_url: 'https://example.com/home', seq: 2, timestamp: 'x' },
+  ],
 };
 
 describe('RecordingStore', () => {

--- a/apps/api/src/modules/sessions/sessions.controller.ts
+++ b/apps/api/src/modules/sessions/sessions.controller.ts
@@ -65,7 +65,13 @@ export class SessionsController {
   }
 
   @Get('sessions/:id')
-  @Roles('Admin', 'Operator', 'Viewer', 'Agent')
+  // Editor belongs here too — it's allowed on every sibling session read
+  // (findAll, findInterventions) and on execute/fetch + agent/session-status,
+  // so an Editor member can run call_web_api but previously 403'd reading their
+  // own session. This endpoint backs the tabby-auth card's state poll and the
+  // viewer's liveness check; the 403 surfaced to the FE as a false
+  // "session terminated / poll-for-successor".
+  @Roles('Admin', 'Editor', 'Operator', 'Viewer', 'Agent')
   @ApiOperation({ summary: 'Get session details', description: 'Returns full session entity including state, health result, intervention counts, and timestamps.' })
   @ApiParam({ name: 'id', description: 'Session UUID' })
   @ApiResponse({ status: 200, description: 'Session details' })

--- a/apps/api/src/modules/streaming/streaming.controller.spec.ts
+++ b/apps/api/src/modules/streaming/streaming.controller.spec.ts
@@ -112,6 +112,20 @@ describe('StreamingController — panel-state', () => {
     expect(result.app_id).toBe('app-1');
   });
 
+  it('viewer panels render a human health label, never the raw enum', () => {
+    // AUTH_FAIL on a fresh session is EXPECTED (it drives STARTING ->
+    // LOGIN_NEEDED), so showing the raw enum made a normal sign-in look like a
+    // failure. Both viewers (VNC + CDP) must go through healthLabel().
+    const source = require('fs').readFileSync(
+      require('path').join(__dirname, 'streaming.controller.ts'),
+      'utf-8',
+    );
+    expect(source).not.toContain("stHealth.textContent = data.health_result_type");
+    const calls = source.split('stHealth.textContent = healthLabel(data.state, data.health_result_type)').length - 1;
+    expect(calls).toBe(2); // VNC + CDP viewers
+    expect(source).toContain("'Awaiting sign-in'");
+  });
+
   it('throws UnauthorizedException when token is missing', async () => {
     await expect(controller.getPanelState('sess-1', undefined)).rejects.toThrow(UnauthorizedException);
   });

--- a/apps/api/src/modules/streaming/streaming.controller.spec.ts
+++ b/apps/api/src/modules/streaming/streaming.controller.spec.ts
@@ -121,9 +121,57 @@ describe('StreamingController — panel-state', () => {
       'utf-8',
     );
     expect(source).not.toContain("stHealth.textContent = data.health_result_type");
-    const calls = source.split('stHealth.textContent = healthLabel(data.state, data.health_result_type)').length - 1;
+    const calls = source.split(
+      'stHealth.textContent = healthLabel(data.state, data.health_result_type, recordingMode)',
+    ).length - 1;
     expect(calls).toBe(2); // VNC + CDP viewers
     expect(source).toContain("'Awaiting sign-in'");
+  });
+
+  it('does not claim "Signed in" for a recording session', () => {
+    // Recording sessions suppress health predicates and the worker stamps PASS once
+    // the browser is up, so PASS carries no auth meaning there. Reporting it as
+    // "Signed in" told users they were authenticated before they had typed anything —
+    // on a page that had not even loaded. Both viewers must pass their recordingMode
+    // flag through so the label can say so.
+    const source = require('fs').readFileSync(
+      require('path').join(__dirname, 'streaming.controller.ts'),
+      'utf-8',
+    );
+
+    // The guard must precede the unconditional PASS branch, or it never runs.
+    const recordingBranch = source.indexOf("if (recording && health === 'PASS')");
+    const passBranch = source.indexOf("if (health === 'PASS') return 'Signed in';");
+    expect(recordingBranch).toBeGreaterThan(-1);
+    expect(passBranch).toBeGreaterThan(-1);
+    expect(recordingBranch).toBeLessThan(passBranch);
+
+    // Both viewers must actually declare the flag they pass in.
+    const decls = source.split(
+      "var recordingMode = new URLSearchParams(window.location.search).get('mode') === 'recording';",
+    ).length - 1;
+    expect(decls).toBe(2);
+  });
+
+  it('healthLabel reports recording sessions as unchecked, not signed in', () => {
+    // Execute the real injected helper rather than asserting on source text, so a
+    // future edit to the branch logic is caught behaviourally.
+    const source = require('fs').readFileSync(
+      require('path').join(__dirname, 'streaming.controller.ts'),
+      'utf-8',
+    );
+    const body = source.match(/function healthLabel\(state, health, recording\) \{[\s\S]*?\n {8}\}/);
+    expect(body).not.toBeNull();
+    // eslint-disable-next-line no-new-func
+    const healthLabel = new Function(`${body![0]}; return healthLabel;`)() as
+      (state: string, health: string | null, recording?: boolean) => string;
+
+    expect(healthLabel('HEALTHY', 'PASS', true)).toBe('Not checked');
+    expect(healthLabel('HEALTHY', 'PASS', false)).toBe('Signed in');
+    expect(healthLabel('HEALTHY', 'PASS')).toBe('Signed in'); // non-recording viewers unchanged
+    // Real failures still surface while recording.
+    expect(healthLabel('LOGIN_NEEDED', 'AUTH_FAIL', true)).toBe('Awaiting sign-in');
+    expect(healthLabel('HEALTHY', 'AUTH_FAIL', true)).toBe('Sign-in required');
   });
 
   it('throws UnauthorizedException when token is missing', async () => {

--- a/apps/api/src/modules/streaming/streaming.controller.ts
+++ b/apps/api/src/modules/streaming/streaming.controller.ts
@@ -28,7 +28,7 @@ import { RecordingStore } from '../recording/recording.store';
 import { AppsService } from '../apps/apps.service';
 import { Request, Response } from 'express';
 import { readFile } from 'node:fs/promises';
-import { resolve as resolvePath } from 'node:path';
+import { resolve as resolvePath, relative as relativePath, isAbsolute } from 'node:path';
 import { randomUUID, randomBytes } from 'crypto';
 import { Not, IsNull, MoreThan } from 'typeorm';
 import { Throttle, SkipThrottle } from '@nestjs/throttler';
@@ -2100,10 +2100,15 @@ ${HEALTH_LABEL_JS}
       // @novnc/novnc dependency is therefore not usable here.
       //
       // assetPath is validated by normalizeNoVncAssetPath (no '..', restricted charset)
-      // before it reaches this join.
-      const vendoredPath = resolvePath(
-        StreamingController.noVncVendorRoot, section, assetPath,
-      );
+      // before it reaches this join. Defense-in-depth: confirm the resolved file
+      // stays under the vendored root/section before reading it, so a future change
+      // to the validator can't reopen a path-traversal read.
+      const base = resolvePath(StreamingController.noVncVendorRoot, section);
+      const vendoredPath = resolvePath(base, assetPath);
+      const rel = relativePath(base, vendoredPath);
+      if (rel.startsWith('..') || isAbsolute(rel)) {
+        throw new NotFoundException('Invalid noVNC asset path');
+      }
       const body = await readFile(vendoredPath, 'utf8');
       return {
         body,

--- a/apps/api/src/modules/streaming/streaming.controller.ts
+++ b/apps/api/src/modules/streaming/streaming.controller.ts
@@ -28,6 +28,7 @@ import { RecordingStore } from '../recording/recording.store';
 import { AppsService } from '../apps/apps.service';
 import { Request, Response } from 'express';
 import { readFile } from 'node:fs/promises';
+import { resolve as resolvePath } from 'node:path';
 import { randomUUID, randomBytes } from 'crypto';
 import { Not, IsNull, MoreThan } from 'typeorm';
 import { Throttle, SkipThrottle } from '@nestjs/throttler';
@@ -49,13 +50,24 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
  * like a failure. Map the enum to plain language, using the session state for
  * context so AUTH_FAIL only reads as a problem when it genuinely is one.
  *
+ * `recording` is required for the same reason in reverse: a recording session
+ * never runs a health check, so its PASS is not evidence of anything and must
+ * not be dressed up as "Signed in".
+ *
  * Written as a JS string interpolated into the templates so the two viewers
  * cannot drift apart. Must not contain `${` — the templates are TS template
  * literals.
  */
 const HEALTH_LABEL_JS = `
-        function healthLabel(state, health) {
+        function healthLabel(state, health, recording) {
           if (!health) return state === 'STARTING' ? 'Starting…' : '—';
+          // Recording sessions suppress keepalive actions and health predicates while a
+          // human drives, and the worker stamps PASS once the browser is up (see
+          // apps/worker/src/main.ts, recording branch). That PASS says "recorder
+          // attached", NOT "authenticated" — reporting it as "Signed in" told the user
+          // they were logged in before they had typed anything, on a page that had not
+          // even loaded. Nothing is evaluated here, so say exactly that.
+          if (recording && health === 'PASS') return 'Not checked';
           if (health === 'PASS') return 'Signed in';
           if (health === 'TRANSIENT_FAIL') return 'Checking…';
           if (health === 'AUTH_FAIL') {
@@ -928,7 +940,7 @@ ${HEALTH_LABEL_JS}
             .then(function(data) {
               if (!data) return;
               stState.textContent = data.state || '—';
-              stHealth.textContent = healthLabel(data.state, data.health_result_type);
+              stHealth.textContent = healthLabel(data.state, data.health_result_type, recordingMode);
               stInterventions.textContent = data.intervention_count != null ? String(data.intervention_count) : '—';
               stRetries.textContent = data.retry_count != null ? String(data.retry_count) : '—';
               if (data.started_at) {
@@ -1080,6 +1092,16 @@ ${HEALTH_LABEL_JS}
 @Controller('vnc')
 export class StreamingController {
   private static readonly noVncAssetCache = new Map<string, { body: string; contentType: string }>();
+  /**
+   * Where the noVNC ES-module tree lives inside the image. Dockerfile.api vendors
+   * GitHub's `core/` + `vendor/` here at build time so the viewer does not need
+   * outbound internet to load its client. Absent (e.g. running from a source
+   * checkout), asset loads fall back to the CDN below.
+   */
+  private static readonly noVncVendorRoot =
+    process.env.NOVNC_VENDOR_ROOT || resolvePath(process.cwd(), 'vendor/novnc');
+
+  /** Fallback only — see noVncVendorRoot. Keep the version in step with Dockerfile.api. */
   private static readonly noVncRootBaseUrl = 'https://cdn.jsdelivr.net/gh/novnc/noVNC@v1.5.0';
 
   constructor(
@@ -1820,7 +1842,7 @@ ${HEALTH_LABEL_JS}
             .then(function(data) {
               if (!data) return;
               stState.textContent = data.state || '—';
-              stHealth.textContent = healthLabel(data.state, data.health_result_type);
+              stHealth.textContent = healthLabel(data.state, data.health_result_type, recordingMode);
               stInterventions.textContent = data.intervention_count != null ? String(data.intervention_count) : '—';
               stRetries.textContent = data.retry_count != null ? String(data.retry_count) : '—';
               if (data.started_at) {
@@ -2067,8 +2089,22 @@ ${HEALTH_LABEL_JS}
     assetPath: string,
   ): Promise<{ body: string; contentType: string }> {
     try {
-      const modulePath = require.resolve(`@novnc/novnc/${section}/${assetPath}`);
-      const body = await readFile(modulePath, 'utf8');
+      // Serve the copy vendored into the image at build time (Dockerfile.api pulls the
+      // GitHub tree, which is what noVncRootBaseUrl points at).
+      //
+      // Do NOT swap this for `require.resolve('@novnc/novnc/...')`. The npm package
+      // publishes only `lib/`, and that build is CommonJS — Babel-transpiled, with
+      // `require()` and no `import`/`export`. The viewer loads the client with
+      // `import RFB from '/vnc/assets/rfb.js'`, so a browser ES-module import of those
+      // files fails outright; only the GitHub `core/` tree is ESM. The declared
+      // @novnc/novnc dependency is therefore not usable here.
+      //
+      // assetPath is validated by normalizeNoVncAssetPath (no '..', restricted charset)
+      // before it reaches this join.
+      const vendoredPath = resolvePath(
+        StreamingController.noVncVendorRoot, section, assetPath,
+      );
+      const body = await readFile(vendoredPath, 'utf8');
       return {
         body,
         contentType: this.resolveNoVncAssetContentType(assetPath),

--- a/apps/api/src/modules/streaming/streaming.controller.ts
+++ b/apps/api/src/modules/streaming/streaming.controller.ts
@@ -2088,6 +2088,16 @@ ${HEALTH_LABEL_JS}
     section: 'core' | 'vendor',
     assetPath: string,
   ): Promise<{ body: string; contentType: string }> {
+    // Resolve + contain BEFORE the try. Inside it, the bare `catch` below would
+    // swallow the rejection and then fetch the same unvalidated path from the
+    // public CDN — the guard would re-route rather than deny.
+    const base = resolvePath(StreamingController.noVncVendorRoot, section);
+    const vendoredPath = resolvePath(base, assetPath);
+    const rel = relativePath(base, vendoredPath);
+    if (rel.startsWith('..') || isAbsolute(rel)) {
+      throw new NotFoundException('Invalid noVNC asset path');
+    }
+
     try {
       // Serve the copy vendored into the image at build time (Dockerfile.api pulls the
       // GitHub tree, which is what noVncRootBaseUrl points at).
@@ -2103,18 +2113,17 @@ ${HEALTH_LABEL_JS}
       // before it reaches this join. Defense-in-depth: confirm the resolved file
       // stays under the vendored root/section before reading it, so a future change
       // to the validator can't reopen a path-traversal read.
-      const base = resolvePath(StreamingController.noVncVendorRoot, section);
-      const vendoredPath = resolvePath(base, assetPath);
-      const rel = relativePath(base, vendoredPath);
-      if (rel.startsWith('..') || isAbsolute(rel)) {
-        throw new NotFoundException('Invalid noVNC asset path');
-      }
       const body = await readFile(vendoredPath, 'utf8');
       return {
         body,
         contentType: this.resolveNoVncAssetContentType(assetPath),
       };
     } catch {
+      // The Dockerfile vendors noVNC so the viewer needs no outbound internet;
+      // falling back to the CDN silently defeats that, so say it happened.
+      console.warn(
+        `noVNC asset ${section}/${assetPath} not in the vendored tree — falling back to the CDN`,
+      );
       const upstream = await fetch(`${StreamingController.noVncRootBaseUrl}/${section}/${assetPath}`);
       if (!upstream.ok) {
         if (upstream.status === 404) {

--- a/apps/api/src/modules/streaming/streaming.controller.ts
+++ b/apps/api/src/modules/streaming/streaming.controller.ts
@@ -40,6 +40,36 @@ const PUBLIC_BASE_URL = (process.env.PUBLIC_BASE_URL || 'http://localhost:18080'
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 /**
+ * Browser-side helper injected into both viewer templates (VNC + CDP).
+ *
+ * The status panel used to print the raw `health_result_type` enum. That reads
+ * as an error to a human — but AUTH_FAIL on a fresh session is the EXPECTED
+ * signal (it is what drives STARTING -> LOGIN_NEEDED, i.e. "not signed in
+ * yet"), so users opening the viewer to sign in were greeted by what looked
+ * like a failure. Map the enum to plain language, using the session state for
+ * context so AUTH_FAIL only reads as a problem when it genuinely is one.
+ *
+ * Written as a JS string interpolated into the templates so the two viewers
+ * cannot drift apart. Must not contain `${` — the templates are TS template
+ * literals.
+ */
+const HEALTH_LABEL_JS = `
+        function healthLabel(state, health) {
+          if (!health) return state === 'STARTING' ? 'Starting…' : '—';
+          if (health === 'PASS') return 'Signed in';
+          if (health === 'TRANSIENT_FAIL') return 'Checking…';
+          if (health === 'AUTH_FAIL') {
+            // Expected while the human is being asked to sign in.
+            if (state === 'LOGIN_NEEDED' || state === 'LOGIN_IN_PROGRESS' || state === 'STARTING') {
+              return 'Awaiting sign-in';
+            }
+            return 'Sign-in required';
+          }
+          return health;
+        }
+`;
+
+/**
  * Resolve the email the gate should match for a session owner.
  *
  * owner_user_id is a users.id uuid for password/OAuth users, but
@@ -887,7 +917,7 @@ export class CdpStreamingController {
         var restartConfirm = document.getElementById('restart-confirm');
         var restartYes = document.getElementById('restart-yes');
         var tokenExpired = false;
-
+${HEALTH_LABEL_JS}
         function poll() {
           if (sessionTerminated || tokenExpired || !TOKEN) return;
           fetch('/vnc/' + SESSION_ID + '/panel-state?token=' + encodeURIComponent(TOKEN))
@@ -898,7 +928,7 @@ export class CdpStreamingController {
             .then(function(data) {
               if (!data) return;
               stState.textContent = data.state || '—';
-              stHealth.textContent = data.health_result_type || '—';
+              stHealth.textContent = healthLabel(data.state, data.health_result_type);
               stInterventions.textContent = data.intervention_count != null ? String(data.intervention_count) : '—';
               stRetries.textContent = data.retry_count != null ? String(data.retry_count) : '—';
               if (data.started_at) {
@@ -1779,6 +1809,7 @@ export class StreamingController {
         var tokenExpired = false;
 
         // ── Poll panel-state ──────────────────────────────────────────────────
+${HEALTH_LABEL_JS}
         function poll() {
           if (sessionTerminated || tokenExpired || !TOKEN) return;
           fetch('/vnc/' + SESSION_ID + '/panel-state?token=' + encodeURIComponent(TOKEN))
@@ -1789,7 +1820,7 @@ export class StreamingController {
             .then(function(data) {
               if (!data) return;
               stState.textContent = data.state || '—';
-              stHealth.textContent = data.health_result_type || '—';
+              stHealth.textContent = healthLabel(data.state, data.health_result_type);
               stInterventions.textContent = data.intervention_count != null ? String(data.intervention_count) : '—';
               stRetries.textContent = data.retry_count != null ? String(data.retry_count) : '—';
               if (data.started_at) {

--- a/apps/controller/src/reconcile.service.spec.ts
+++ b/apps/controller/src/reconcile.service.spec.ts
@@ -285,7 +285,9 @@ describe('ReconcileService DISABLE_NETWORK_POLICY', () => {
       state_version: 1,
       retry_count: 0,
       owner_user_id: null,
-      residential_proxy_override: null,
+      // resolveResidential reads session.residential_proxy_enabled ?? app.residential_proxy_enabled;
+      // null here documents the real field and makes the expected `false` come from the app default.
+      residential_proxy_enabled: null,
     };
   }
 
@@ -357,6 +359,38 @@ describe('ReconcileService DISABLE_NETWORK_POLICY', () => {
 
     expect(podManager.createNetworkPolicy).toHaveBeenCalled();
     expect(podManager.syncEgressAllowlist).not.toHaveBeenCalled();
+  });
+
+  it('forces allowAll=true on the reconcile-path allowlist sync for already-active sessions', async () => {
+    // Covers the second half of the flag: reconcileApp() re-syncs the egress
+    // allowlist for existing sessions every tick (reconcile.service.ts:229),
+    // using effectiveAllowAll = disableNetworkPolicy || allowAll. This is the
+    // continuously-running path, distinct from one-shot provisionSessionRuntime.
+    process.env = { ...originalEnv, DISABLE_NETWORK_POLICY: 'true' };
+
+    const activeSession = { ...makeSession(), state: 'HEALTHY', pod_name: 'pod-np-live' };
+    const sessionRepo = {
+      find: jest.fn().mockResolvedValue([activeSession]),
+      count: jest.fn().mockResolvedValue(0),
+      update: jest.fn().mockResolvedValue(undefined),
+    };
+    const podManager = {
+      syncEgressAllowlist: jest.fn().mockResolvedValue(undefined),
+      resolveStreamingMode: jest.fn().mockReturnValue('vnc'),
+    };
+    // desired == actual (1), so reconcileApp only runs the allowlist-sync loop.
+    const app = { ...makeApp(), desired_session_count: 1 };
+    const service = buildService({ podManager, sessionRepo });
+
+    await (service as any).reconcileApp(app);
+
+    expect(podManager.syncEgressAllowlist).toHaveBeenCalledWith(
+      'sess-np',
+      ['https://example.com'],
+      [],
+      true,      // effectiveAllowAll — forced on by the flag despite app allowAll=false
+      false,
+    );
   });
 });
 

--- a/apps/controller/src/reconcile.service.spec.ts
+++ b/apps/controller/src/reconcile.service.spec.ts
@@ -252,6 +252,115 @@ describe('ReconcileService restart_requested', () => {
 });
 
 // ---------------------------------------------------------------------------
+// DISABLE_NETWORK_POLICY — skips K8s NetworkPolicy, pushes allow_all
+// ---------------------------------------------------------------------------
+
+describe('ReconcileService DISABLE_NETWORK_POLICY', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  function makeApp() {
+    return {
+      id: 'app-np',
+      tenant_id: 'tenant-np',
+      target_urls: ['https://example.com'],
+      extra_egress_allowlist: [],
+      execute_enabled: false,
+      residential_proxy_enabled: false,
+      browser_policy: {},
+      export_policy: {},
+    };
+  }
+
+  function makeSession() {
+    return {
+      id: 'sess-np',
+      tenant_id: 'tenant-np',
+      app_id: 'app-np',
+      pod_name: null,
+      state: 'STARTING',
+      state_version: 1,
+      retry_count: 0,
+      owner_user_id: null,
+      residential_proxy_override: null,
+    };
+  }
+
+  it('skips createNetworkPolicy and calls syncEgressAllowlist with allowAll=true when enabled', async () => {
+    process.env = { ...originalEnv, DISABLE_NETWORK_POLICY: 'true' };
+
+    const podManager = {
+      createWorkerPod: jest.fn().mockResolvedValue('pod-np-1'),
+      createNoVncService: jest.fn().mockResolvedValue(undefined),
+      createCdpService: jest.fn().mockResolvedValue(undefined),
+      createWorkerService: jest.fn().mockResolvedValue(undefined),
+      createNetworkPolicy: jest.fn().mockResolvedValue(undefined),
+      syncEgressAllowlist: jest.fn().mockResolvedValue(undefined),
+      deleteWorkerPod: jest.fn().mockResolvedValue(undefined),
+      deleteNoVncService: jest.fn().mockResolvedValue(undefined),
+      deleteCdpService: jest.fn().mockResolvedValue(undefined),
+      deleteWorkerService: jest.fn().mockResolvedValue(undefined),
+      deleteNetworkPolicy: jest.fn().mockResolvedValue(undefined),
+      listWorkerPods: jest.fn().mockResolvedValue([]),
+      podExists: jest.fn().mockResolvedValue(true),
+      resolveStreamingMode: jest.fn().mockReturnValue('vnc'),
+    };
+    const sessionRepo = {
+      find: jest.fn().mockResolvedValue([]),
+      count: jest.fn().mockResolvedValue(0),
+      update: jest.fn().mockResolvedValue(undefined),
+    };
+    const service = buildService({ podManager, sessionRepo });
+
+    await (service as any).provisionSessionRuntime(makeSession(), makeApp());
+
+    expect(podManager.createNetworkPolicy).not.toHaveBeenCalled();
+    expect(podManager.syncEgressAllowlist).toHaveBeenCalledWith(
+      'sess-np',
+      ['https://example.com'],
+      [],
+      true,
+      false,
+    );
+  });
+
+  it('creates NetworkPolicy normally when DISABLE_NETWORK_POLICY is not set', async () => {
+    delete process.env.DISABLE_NETWORK_POLICY;
+
+    const podManager = {
+      createWorkerPod: jest.fn().mockResolvedValue('pod-np-2'),
+      createNoVncService: jest.fn().mockResolvedValue(undefined),
+      createCdpService: jest.fn().mockResolvedValue(undefined),
+      createWorkerService: jest.fn().mockResolvedValue(undefined),
+      createNetworkPolicy: jest.fn().mockResolvedValue(undefined),
+      syncEgressAllowlist: jest.fn().mockResolvedValue(undefined),
+      deleteWorkerPod: jest.fn().mockResolvedValue(undefined),
+      deleteNoVncService: jest.fn().mockResolvedValue(undefined),
+      deleteCdpService: jest.fn().mockResolvedValue(undefined),
+      deleteWorkerService: jest.fn().mockResolvedValue(undefined),
+      deleteNetworkPolicy: jest.fn().mockResolvedValue(undefined),
+      listWorkerPods: jest.fn().mockResolvedValue([]),
+      podExists: jest.fn().mockResolvedValue(true),
+      resolveStreamingMode: jest.fn().mockReturnValue('vnc'),
+    };
+    const sessionRepo = {
+      find: jest.fn().mockResolvedValue([]),
+      count: jest.fn().mockResolvedValue(0),
+      update: jest.fn().mockResolvedValue(undefined),
+    };
+    const service = buildService({ podManager, sessionRepo });
+
+    await (service as any).provisionSessionRuntime(makeSession(), makeApp());
+
+    expect(podManager.createNetworkPolicy).toHaveBeenCalled();
+    expect(podManager.syncEgressAllowlist).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // checkRecycling — idle shutdown + FAILED session cleanup
 // ---------------------------------------------------------------------------
 

--- a/apps/controller/src/reconcile.service.spec.ts
+++ b/apps/controller/src/reconcile.service.spec.ts
@@ -395,6 +395,77 @@ describe('ReconcileService DISABLE_NETWORK_POLICY', () => {
 });
 
 // ---------------------------------------------------------------------------
+// reconcileApp capacity — FAILED sessions must not occupy the app's slot
+// ---------------------------------------------------------------------------
+
+describe('ReconcileService reconcileApp capacity', () => {
+  const originalEnv = { ...process.env };
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  function makeApp(overrides: Record<string, any> = {}) {
+    return {
+      id: 'app-1',
+      tenant_id: 'tenant-1',
+      name: 'some-app',
+      target_urls: ['https://example.com'],
+      desired_session_count: 1,
+      browser_policy: {},
+      extra_egress_allowlist: [],
+      ...overrides,
+    };
+  }
+
+  it('creates a replacement when the only session is FAILED (FAILED is not live capacity)', async () => {
+    // The core of the incident: desired=1 with a single FAILED session. The old
+    // code counted FAILED as occupying the slot (actual=1==desired) and never
+    // provisioned a replacement, so on-demand provisioning silently no-op'd for
+    // the whole cleanup window. FAILED must not count → a fresh session is made.
+    const failed = {
+      id: 'failed-1', app_id: 'app-1', tenant_id: 'tenant-1',
+      state: 'FAILED', pod_name: null, started_at: new Date(),
+    };
+    const sessionRepo = {
+      find: jest.fn().mockResolvedValue([failed]),
+      count: jest.fn().mockResolvedValue(0),
+      update: jest.fn(),
+    };
+    const service = buildService({ sessionRepo });
+    jest.spyOn(service as any, 'isProvisioningCircuitOpen').mockResolvedValue(false);
+    const createSpy = jest
+      .spyOn(service as any, 'createSession')
+      .mockResolvedValue(undefined);
+
+    await (service as any).reconcileApp(makeApp());
+
+    expect(createSpy).toHaveBeenCalledTimes(1); // one replacement for the dead slot
+  });
+
+  it('does NOT create when the circuit breaker is open, even with only a FAILED session', async () => {
+    // Fix A relies on the breaker to bound retries when replacements keep failing.
+    const failed = {
+      id: 'failed-1', app_id: 'app-1', tenant_id: 'tenant-1',
+      state: 'FAILED', pod_name: null, started_at: new Date(),
+    };
+    const sessionRepo = {
+      find: jest.fn().mockResolvedValue([failed]),
+      count: jest.fn().mockResolvedValue(0),
+      update: jest.fn(),
+    };
+    const service = buildService({ sessionRepo });
+    jest.spyOn(service as any, 'isProvisioningCircuitOpen').mockResolvedValue(true);
+    const createSpy = jest
+      .spyOn(service as any, 'createSession')
+      .mockResolvedValue(undefined);
+
+    await (service as any).reconcileApp(makeApp());
+
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // checkRecycling — idle shutdown + FAILED session cleanup
 // ---------------------------------------------------------------------------
 
@@ -424,7 +495,7 @@ describe('ReconcileService checkRecycling', () => {
   function buildForRecycling() {
     const sessionRepo = {
       find: jest.fn(),
-      count: jest.fn(),
+      count: jest.fn().mockResolvedValue(0), // default: no other live session for the app
       update: jest.fn(),
     };
     const appRepo = { update: jest.fn(), find: jest.fn(), findByIds: jest.fn().mockResolvedValue([]) };
@@ -443,23 +514,73 @@ describe('ReconcileService checkRecycling', () => {
     return { service, sessionRepo, appRepo, stateMachine, podManager };
   }
 
-  it('terminates FAILED sessions older than half the idle TTL and zeroes desired_session_count', async () => {
+  it('terminates FAILED sessions older than half the idle TTL and, when the app is idle, zeroes desired_session_count', async () => {
     process.env = { ...originalEnv, IDLE_SHUTDOWN_SECONDS: '120', MAX_SESSION_AGE_HOURS: '24' };
     const { service, sessionRepo, appRepo, stateMachine } = buildForRecycling();
 
     const failed = makeSession({
       id: 'failed-1',
       state: 'FAILED',
-      started_at: new Date(Date.now() - 120_000),
+      started_at: new Date(Date.now() - 120_000), // last used 120s ago >= idle threshold → idle
     });
     sessionRepo.find
       .mockResolvedValueOnce([])       // HEALTHY
       .mockResolvedValueOnce([failed]); // FAILED
+    sessionRepo.count.mockResolvedValue(0); // no other live session for the app
 
     await (service as any).checkRecycling();
 
     expect(appRepo.update).toHaveBeenCalledWith('app-1', { desired_session_count: 0 });
     expect(stateMachine.transition).toHaveBeenCalledWith(failed, expect.anything());
+  });
+
+  it('reaps a FAILED session WITHOUT zeroing desired when the app has recent demand', async () => {
+    // The incident this fixes: a user is actively driving the app, its session
+    // fails (e.g. bank session expired), and the old code zeroed desired on
+    // cleanup — so the user's next call found no session and no way to make one.
+    // With recent activity, cleanup must reap the corpse but leave desired so
+    // reconcile provisions a fresh session for the waiting user.
+    process.env = { ...originalEnv, IDLE_SHUTDOWN_SECONDS: '600', MAX_SESSION_AGE_HOURS: '24' };
+    const { service, sessionRepo, appRepo, stateMachine } = buildForRecycling();
+
+    const failed = makeSession({
+      id: 'failed-active',
+      state: 'FAILED',
+      started_at: new Date(Date.now() - 400_000), // old enough to reap (> 300s half-TTL)
+      last_activity_at: new Date(Date.now() - 5_000), // but used 5s ago → recent demand
+    });
+    sessionRepo.find
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([failed]);
+    sessionRepo.count.mockResolvedValue(0);
+
+    await (service as any).checkRecycling();
+
+    expect(stateMachine.transition).toHaveBeenCalledWith(failed, expect.anything()); // corpse reaped
+    expect(appRepo.update).not.toHaveBeenCalled(); // but desired preserved
+  });
+
+  it('reaps a FAILED session WITHOUT zeroing desired when the app still has a live session', async () => {
+    // A replacement session already came up (reconcile created it because FAILED
+    // no longer counts as capacity). Reaping the old corpse must not scale the
+    // app to 0 — that would kill the live replacement.
+    process.env = { ...originalEnv, IDLE_SHUTDOWN_SECONDS: '120', MAX_SESSION_AGE_HOURS: '24' };
+    const { service, sessionRepo, appRepo, stateMachine } = buildForRecycling();
+
+    const failed = makeSession({
+      id: 'failed-with-replacement',
+      state: 'FAILED',
+      started_at: new Date(Date.now() - 120_000), // idle by activity, but…
+    });
+    sessionRepo.find
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([failed]);
+    sessionRepo.count.mockResolvedValue(1); // …a live replacement exists
+
+    await (service as any).checkRecycling();
+
+    expect(stateMachine.transition).toHaveBeenCalledWith(failed, expect.anything());
+    expect(appRepo.update).not.toHaveBeenCalled();
   });
 
   it('leaves FAILED sessions younger than half TTL alone', async () => {

--- a/apps/controller/src/reconcile.service.spec.ts
+++ b/apps/controller/src/reconcile.service.spec.ts
@@ -660,3 +660,145 @@ describe('ReconcileService checkRecycling', () => {
     expect(stateMachine.transition).not.toHaveBeenCalled();
   });
 });
+
+// ---------------------------------------------------------------------------
+// FAILED sessions must give their pod back immediately
+// ---------------------------------------------------------------------------
+
+describe('ReconcileService FAILED session runtime reap', () => {
+  const originalEnv = { ...process.env };
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  function makeFailedApp() {
+    return {
+      id: 'app-f',
+      tenant_id: 'tenant-f',
+      desired_session_count: 1,
+      target_urls: ['https://example.com'],
+      extra_egress_allowlist: [],
+      execute_enabled: false,
+      residential_proxy_enabled: false,
+      browser_policy: {},
+      export_policy: {},
+    };
+  }
+
+  function podManagerMock() {
+    return {
+      createWorkerPod: jest.fn().mockResolvedValue('pod-new'),
+      createNoVncService: jest.fn().mockResolvedValue(undefined),
+      createCdpService: jest.fn().mockResolvedValue(undefined),
+      createWorkerService: jest.fn().mockResolvedValue(undefined),
+      createNetworkPolicy: jest.fn().mockResolvedValue(undefined),
+      syncEgressAllowlist: jest.fn().mockResolvedValue(undefined),
+      deleteWorkerPod: jest.fn().mockResolvedValue(undefined),
+      deleteNoVncService: jest.fn().mockResolvedValue(undefined),
+      deleteCdpService: jest.fn().mockResolvedValue(undefined),
+      deleteWorkerService: jest.fn().mockResolvedValue(undefined),
+      deleteNetworkPolicy: jest.fn().mockResolvedValue(undefined),
+      listWorkerPods: jest.fn().mockResolvedValue([]),
+      podExists: jest.fn().mockResolvedValue(true),
+      resolveStreamingMode: jest.fn().mockReturnValue('vnc'),
+    };
+  }
+
+  it('deletes the pod of a FAILED session with IDLE_SHUTDOWN disabled (the default)', async () => {
+    // The FAILED-cleanup pass is gated on IDLE_SHUTDOWN_SECONDS, which defaults
+    // to 0 — so without this reap the pod outlives the session forever while
+    // reconcile creates replacements on top of it (one leaked pod per failure).
+    process.env = { ...originalEnv, IDLE_SHUTDOWN_SECONDS: '0' };
+
+    const failed = {
+      id: 'sess-failed',
+      tenant_id: 'tenant-f',
+      app_id: 'app-f',
+      state: 'FAILED',
+      pod_name: 'worker-sess-failed',
+      started_at: new Date(),
+    };
+    const sessionRepo = {
+      find: jest.fn().mockResolvedValue([failed]),
+      count: jest.fn().mockResolvedValue(0),
+      update: jest.fn().mockResolvedValue(undefined),
+      create: jest.fn().mockImplementation((v: any) => v),
+      save: jest.fn().mockImplementation(async (v: any) => ({ id: 'sess-new', ...v })),
+    };
+    const podManager = podManagerMock();
+    const batonRepo = {
+      create: jest.fn().mockImplementation((v: any) => v),
+      save: jest.fn().mockResolvedValue({}),
+    };
+    const service = buildService({ sessionRepo, podManager, batonRepo });
+
+    await (service as any).reconcileApp(makeFailedApp());
+
+    expect(podManager.deleteWorkerPod).toHaveBeenCalledWith('worker-sess-failed');
+    expect(podManager.deleteNetworkPolicy).toHaveBeenCalledWith('sess-failed');
+    // pod_name cleared so the reap is idempotent across ticks
+    expect(sessionRepo.update).toHaveBeenCalledWith('sess-failed', { pod_name: null });
+  });
+
+  it('still provisions a replacement — the FAILED session must not hold capacity', async () => {
+    process.env = { ...originalEnv, IDLE_SHUTDOWN_SECONDS: '0' };
+
+    const failed = {
+      id: 'sess-failed-2',
+      tenant_id: 'tenant-f',
+      app_id: 'app-f',
+      state: 'FAILED',
+      pod_name: 'worker-sess-failed-2',
+      started_at: new Date(),
+    };
+    const sessionRepo = {
+      find: jest.fn().mockResolvedValue([failed]),
+      count: jest.fn().mockResolvedValue(0),
+      update: jest.fn().mockResolvedValue(undefined),
+      create: jest.fn().mockImplementation((v: any) => v),
+      save: jest.fn().mockImplementation(async (v: any) => ({ id: 'sess-new', ...v })),
+    };
+    const podManager = podManagerMock();
+    const batonRepo = {
+      create: jest.fn().mockImplementation((v: any) => v),
+      save: jest.fn().mockResolvedValue({}),
+    };
+    const service = buildService({ sessionRepo, podManager, batonRepo });
+
+    await (service as any).reconcileApp(makeFailedApp());
+
+    expect(podManager.deleteWorkerPod).toHaveBeenCalledWith('worker-sess-failed-2');
+    expect(sessionRepo.save).toHaveBeenCalled(); // a fresh session was created
+  });
+
+  it('does not touch a FAILED session whose runtime was already released', async () => {
+    process.env = { ...originalEnv, IDLE_SHUTDOWN_SECONDS: '0' };
+
+    const failed = {
+      id: 'sess-failed-3',
+      tenant_id: 'tenant-f',
+      app_id: 'app-f',
+      state: 'FAILED',
+      pod_name: null, // already reaped on an earlier tick
+      started_at: new Date(),
+    };
+    const sessionRepo = {
+      find: jest.fn().mockResolvedValue([failed]),
+      count: jest.fn().mockResolvedValue(0),
+      update: jest.fn().mockResolvedValue(undefined),
+      create: jest.fn().mockImplementation((v: any) => v),
+      save: jest.fn().mockImplementation(async (v: any) => ({ id: 'sess-new', ...v })),
+    };
+    const podManager = podManagerMock();
+    const batonRepo = {
+      create: jest.fn().mockImplementation((v: any) => v),
+      save: jest.fn().mockResolvedValue({}),
+    };
+    const service = buildService({ sessionRepo, podManager, batonRepo });
+
+    await (service as any).reconcileApp(makeFailedApp());
+
+    expect(podManager.deleteWorkerPod).not.toHaveBeenCalled();
+    expect(sessionRepo.update).not.toHaveBeenCalledWith('sess-failed-3', { pod_name: null });
+  });
+});

--- a/apps/controller/src/reconcile.service.ts
+++ b/apps/controller/src/reconcile.service.ts
@@ -38,6 +38,7 @@ export class ReconcileService implements OnModuleInit, OnModuleDestroy {
   private readonly circuitCooldownMs: number;
   private readonly appCircuitFailureThreshold: number;
   private readonly tenantCircuitFailureThreshold: number;
+  private readonly disableNetworkPolicy: boolean;
 
   constructor(
     @InjectRepository(ApplicationEntity)
@@ -60,6 +61,7 @@ export class ReconcileService implements OnModuleInit, OnModuleDestroy {
     this.tenantCircuitFailureThreshold = this.readPositiveInt('CIRCUIT_BREAKER_TENANT_FAILURE_THRESHOLD', 15);
     this.circuitWindowMs = this.readPositiveInt('CIRCUIT_BREAKER_WINDOW_SECONDS', 900) * 1000;
     this.circuitCooldownMs = this.readPositiveInt('CIRCUIT_BREAKER_COOLDOWN_SECONDS', 300) * 1000;
+    this.disableNetworkPolicy = process.env.DISABLE_NETWORK_POLICY === 'true';
   }
 
   async onModuleInit() {
@@ -218,12 +220,13 @@ export class ReconcileService implements OnModuleInit, OnModuleDestroy {
 
     // Keep egress allowlist synced for all currently active runtime sessions.
     const { extraAllowlist, allowAll } = this.resolveEgressOptions(app);
+    const effectiveAllowAll = this.disableNetworkPolicy || allowAll;
     for (const session of activeSessions) {
       if (!session.pod_name) {
         continue;
       }
       try {
-        await this.podManager.syncEgressAllowlist(session.id, app.target_urls, extraAllowlist, allowAll, this.resolveResidential(session, app));
+        await this.podManager.syncEgressAllowlist(session.id, app.target_urls, extraAllowlist, effectiveAllowAll, this.resolveResidential(session, app));
       } catch (error) {
         this.logger.error(
           `Egress allowlist sync failed for session ${session.id}; terminating session fail-closed: ${error}`,
@@ -388,9 +391,13 @@ export class ReconcileService implements OnModuleInit, OnModuleDestroy {
         await this.podManager.createWorkerService(savedSession.id, podName);
       }
 
-      // Generate NetworkPolicy — open the 8091 ingress when the worker health
-      // Service exists (execute or recording drain).
-      await this.podManager.createNetworkPolicy(savedSession.id, podName, app.target_urls, streamingMode, needsWorkerHealth, extraAllowlist, allowAll, this.resolveResidential(savedSession, app));
+      if (this.disableNetworkPolicy) {
+        // Local dev: skip K8s NetworkPolicy, push allow_all to the egress proxy
+        await this.podManager.syncEgressAllowlist(savedSession.id, app.target_urls, extraAllowlist, true, this.resolveResidential(savedSession, app));
+        this.logger.log(`Skipped NetworkPolicy (DISABLE_NETWORK_POLICY=true), pushed allow_all for session ${savedSession.id}`);
+      } else {
+        await this.podManager.createNetworkPolicy(savedSession.id, podName, app.target_urls, streamingMode, needsWorkerHealth, extraAllowlist, allowAll, this.resolveResidential(savedSession, app));
+      }
 
       this.logger.log(`Created session ${savedSession.id} with pod ${podName} (mode=${streamingMode})`);
     } catch (error) {

--- a/apps/controller/src/reconcile.service.ts
+++ b/apps/controller/src/reconcile.service.ts
@@ -386,6 +386,10 @@ export class ReconcileService implements OnModuleInit, OnModuleDestroy {
       // both execute calls AND recording drain (POST /recording/stop). Recording
       // sessions don't set execute_enabled, so key off either.
       const { extraAllowlist, allowAll } = this.resolveEgressOptions(app);
+      // Deliberately keyed off the raw `allowAll` (recording_mode), NOT
+      // `effectiveAllowAll`: when DISABLE_NETWORK_POLICY is on there's no
+      // NetworkPolicy gating port 8091, so the worker Service isn't needed for
+      // reachability. Only genuine execute/recording sessions need it.
       const needsWorkerHealth = app.execute_enabled || allowAll;
       if (needsWorkerHealth) {
         await this.podManager.createWorkerService(savedSession.id, podName);

--- a/apps/controller/src/reconcile.service.ts
+++ b/apps/controller/src/reconcile.service.ts
@@ -609,9 +609,12 @@ export class ReconcileService implements OnModuleInit, OnModuleDestroy {
           // otherwise leave desired alone so reconcile provisions a fresh session
           // for the waiting user. A WARM pool spare never stands its (shared) pool
           // app down — that would drain the pool (mirrors the max-age path above).
-          const app = appById.get(session.app_id);
-          const template = app?.template_id ? templateById.get(app.template_id) : undefined;
-          const idleSeconds = template?.idle_shutdown_seconds ?? globalIdleShutdownSeconds;
+          // The global value, deliberately: appById/templateById are built only
+          // from the apps of HEALTHY sessions, and this branch only acts when the
+          // app has NO live session — so the per-template lookup always missed and
+          // silently fell back here anyway. Say what it does instead of implying a
+          // per-template override that never applied.
+          const idleSeconds = globalIdleShutdownSeconds;
           const idleMs = idleSeconds * 1000;
           const lastUsed =
             session.last_activity_at || session.last_credential_request_at || session.started_at;

--- a/apps/controller/src/reconcile.service.ts
+++ b/apps/controller/src/reconcile.service.ts
@@ -215,14 +215,43 @@ export class ReconcileService implements OnModuleInit, OnModuleDestroy {
       s => s.state !== SessionState.TERMINATED
     );
 
-    // FAILED sessions hold no live pod and are swept by the FAILED-cleanup pass
-    // below, but that runs only after a grace TTL (up to IDLE_SHUTDOWN/2). Until
-    // then a FAILED session must NOT count toward the app's session capacity —
+    // A FAILED session must NOT count toward the app's session capacity —
     // otherwise it blocks its own replacement and the app cannot provision on
     // demand for the whole cleanup window (a user requesting credentials just
     // waits and gets "no session"). Provisioning counts only sessions that are
     // live or on their way up; the circuit breaker (Step 3) bounds retries if
     // the replacements keep failing.
+    //
+    // Because it no longer holds capacity, its pod MUST be released here rather
+    // than waiting for the FAILED-cleanup pass: that pass is gated on
+    // IDLE_SHUTDOWN_SECONDS, which defaults to 0 (disabled), so on a default
+    // deployment it never runs at all — the pod would outlive the session
+    // forever while reconcile kept creating replacements on top of it, leaking
+    // one pod per failure. reconcileRuntimeDrift doesn't cover this either (it
+    // only reaps pods whose session is missing or TERMINATED).
+    //
+    // State-driven rather than hooked to the FAILED transition, so it self-heals
+    // no matter who marked the session failed (controller, worker, or API), and
+    // idempotent: pod_name is cleared once the runtime is gone.
+    for (const session of activeSessions) {
+      if (session.state !== SessionState.FAILED || !session.pod_name) {
+        continue;
+      }
+      try {
+        this.logger.log(
+          `Releasing runtime for FAILED session ${session.id} (pod ${session.pod_name})`,
+        );
+        await this.releaseSessionRuntime(session);
+        await this.sessionRepo.update(session.id, { pod_name: null as any });
+        session.pod_name = null as any;
+      } catch (error) {
+        // Never let a stuck reap block provisioning — the next tick retries.
+        this.logger.warn(
+          `Failed to release runtime for FAILED session ${session.id}: ${error}`,
+        );
+      }
+    }
+
     const liveSessions = activeSessions.filter(
       s => s.state !== SessionState.FAILED
     );
@@ -459,7 +488,17 @@ export class ReconcileService implements OnModuleInit, OnModuleDestroy {
     // Transition to TERMINATED
     await this.stateMachine.transition(session, SessionState.TERMINATED);
 
-    // Delete pod and NetworkPolicy
+    await this.releaseSessionRuntime(session);
+
+    this.logger.log(`Terminated session ${session.id}`);
+  }
+
+  /**
+   * Delete a session's Kubernetes runtime (pod, streaming services, NetworkPolicy)
+   * WITHOUT changing its state. Split out of terminateSession so a FAILED session
+   * can give its pod back while its row stays FAILED for the grace TTL.
+   */
+  private async releaseSessionRuntime(session: SessionEntity): Promise<void> {
     if (session.pod_name) {
       await this.podManager.deleteWorkerPod(session.pod_name);
     }
@@ -468,8 +507,6 @@ export class ReconcileService implements OnModuleInit, OnModuleDestroy {
     await this.podManager.deleteCdpService(session.id, session.pod_name || undefined);
     await this.podManager.deleteWorkerService(session.id, session.pod_name || undefined);
     await this.podManager.deleteNetworkPolicy(session.id);
-
-    this.logger.log(`Terminated session ${session.id}`);
   }
 
   /**

--- a/apps/controller/src/reconcile.service.ts
+++ b/apps/controller/src/reconcile.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, Logger, OnModuleDestroy, OnModuleInit } from '@nestjs/common';
 import * as Sentry from '@sentry/node';
 import { InjectRepository } from '@nestjs/typeorm';
-import { MoreThan, Repository, DataSource } from 'typeorm';
+import { MoreThan, Not, In, Repository, DataSource } from 'typeorm';
 import { SessionState, StreamingMode, RECORDING_POOL } from '@browser-hitl/shared';
 import { ApplicationEntity } from './entities/application.entity';
 import { SessionEntity } from './entities/session.entity';
@@ -215,8 +215,20 @@ export class ReconcileService implements OnModuleInit, OnModuleDestroy {
       s => s.state !== SessionState.TERMINATED
     );
 
+    // FAILED sessions hold no live pod and are swept by the FAILED-cleanup pass
+    // below, but that runs only after a grace TTL (up to IDLE_SHUTDOWN/2). Until
+    // then a FAILED session must NOT count toward the app's session capacity —
+    // otherwise it blocks its own replacement and the app cannot provision on
+    // demand for the whole cleanup window (a user requesting credentials just
+    // waits and gets "no session"). Provisioning counts only sessions that are
+    // live or on their way up; the circuit breaker (Step 3) bounds retries if
+    // the replacements keep failing.
+    const liveSessions = activeSessions.filter(
+      s => s.state !== SessionState.FAILED
+    );
+
     const desired = app.desired_session_count;
-    const actual = activeSessions.length;
+    const actual = liveSessions.length;
 
     // Keep egress allowlist synced for all currently active runtime sessions.
     const { extraAllowlist, allowAll } = this.resolveEgressOptions(app);
@@ -268,10 +280,12 @@ export class ReconcileService implements OnModuleInit, OnModuleDestroy {
       }
     }
 
-    // Step 4: Terminate excess sessions (oldest first)
+    // Step 4: Terminate excess LIVE sessions (oldest first). FAILED sessions are
+    // excluded from `actual` above and reaped by the dedicated FAILED-cleanup
+    // pass, so they must not be treated as excess capacity here.
     if (actual > desired) {
       const toTerminate = actual - desired;
-      const sorted = activeSessions.sort(
+      const sorted = liveSessions.sort(
         (a, b) => new Date(a.started_at).getTime() - new Date(b.started_at).getTime()
       );
 
@@ -547,7 +561,38 @@ export class ReconcileService implements OnModuleInit, OnModuleDestroy {
           this.logger.log(
             `Cleaning up FAILED session ${session.id} (age: ${Math.round(age / 60000)}min, threshold: ${Math.round(failedTtlMs / 60000)}min)`,
           );
-          await this.appRepo.update(session.app_id, { desired_session_count: 0 });
+
+          // Decide whether reaping this corpse should also stand the app down.
+          // Historically cleanup ALWAYS scaled desired→0. That is correct for an
+          // abandoned app, but wrong for one a user is actively driving: it wiped
+          // provisioning intent, so the next credential request found no session
+          // and no way to make one (the failed session had already blocked its
+          // replacement — see the liveSessions count in reconcileApp). Only stand
+          // down when the app has no other live session AND no recent demand;
+          // otherwise leave desired alone so reconcile provisions a fresh session
+          // for the waiting user. A WARM pool spare never stands its (shared) pool
+          // app down — that would drain the pool (mirrors the max-age path above).
+          const app = appById.get(session.app_id);
+          const template = app?.template_id ? templateById.get(app.template_id) : undefined;
+          const idleSeconds = template?.idle_shutdown_seconds ?? globalIdleShutdownSeconds;
+          const idleMs = idleSeconds * 1000;
+          const lastUsed =
+            session.last_activity_at || session.last_credential_request_at || session.started_at;
+          const appHasRecentDemand = idleMs > 0 && now - new Date(lastUsed).getTime() < idleMs;
+          const liveCount = await this.sessionRepo.count({
+            where: {
+              app_id: session.app_id,
+              state: Not(In([SessionState.TERMINATED, SessionState.FAILED])),
+            },
+          });
+
+          const isWarmPoolSpare = session.pool_state === RECORDING_POOL.WARM;
+          if (liveCount === 0 && !appHasRecentDemand && !isWarmPoolSpare) {
+            this.logger.log(
+              `App ${session.app_id}: no live session and idle (last used ${Math.round((now - new Date(lastUsed).getTime()) / 60000)}min ago, threshold ${idleSeconds}s) — scaling to 0 after failed-session cleanup`,
+            );
+            await this.appRepo.update(session.app_id, { desired_session_count: 0 });
+          }
           await this.terminateSession(session);
         }
       }

--- a/apps/worker/package.json
+++ b/apps/worker/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@browser-hitl/shared": "workspace:*",
     "@sentry/node": "^10.51.0",
-    "cloakbrowser": "^0.3.12",
+    "cloakbrowser": "^0.5.2",
     "express": "^4.21.2",
     "jsonwebtoken": "^9.0.3",
     "helmet": "^8.1.0",

--- a/apps/worker/src/agent-activity.ts
+++ b/apps/worker/src/agent-activity.ts
@@ -1,0 +1,88 @@
+/**
+ * Tracks whether an agent (the harness, via /execute/browser and /execute/fetch)
+ * is currently driving this worker's page, so the keepalive loop can stay out of
+ * its way.
+ *
+ * Keepalive exists to stop a portal's idle timer from expiring an unattended
+ * session. When an agent is actively working the page, that premise is false
+ * twice over:
+ *
+ *  1. The agent's own clicks/navigations already reset the portal's idle timer,
+ *     so the keepalive action is redundant.
+ *  2. Worse, it is destructive. A synthetic mouse-move/scroll landing between an
+ *     agent's locator resolution and its click moves the target and misclicks; a
+ *     'goto' keepalive reloads the page out from under a half-finished flow. The
+ *     robotic input is also exactly what reCAPTCHA v3 / fingerprint SDKs score,
+ *     and it is far more suspicious interleaved with real interaction than alone.
+ *
+ * Two distinct signals, because they answer different questions:
+ *
+ *  - `isAgentBusy()` — is a command in flight right now? Every command counts,
+ *    including read-only ones: a scroll injected during `screenshot` or
+ *    `get_page_summary` corrupts what those return.
+ *  - `msSinceAgentActivity()` — how long since the agent did something that
+ *    actually reset the portal's server-side idle timer? Only server-touching
+ *    commands count here. Per the platform gotcha that `screenshot` is not a
+ *    keepalive (it captures pixels, it makes no request), a session that has
+ *    only been screenshotted is still going stale and still needs the nudge.
+ *
+ * Module-level state is correct here: one worker pod owns exactly one page.
+ */
+
+/** Commands that hit the origin server, and so reset its idle timer. */
+const IDLE_RESETTING_COMMANDS = new Set([
+  'navigate',
+  'click_element',
+  'click_by_text',
+  'click_at',
+  'type_text',
+  'type_into_label',
+  'press_key',
+]);
+
+let inFlight = 0;
+let lastActivityAt = 0;
+
+/** True if the given browser command resets the origin's server-side idle timer. */
+export function isIdleResettingCommand(command: string): boolean {
+  return IDLE_RESETTING_COMMANDS.has(command);
+}
+
+/**
+ * Mark the start of an agent command. `resetsIdleTimer` should be false for
+ * read-only commands (screenshot, get_page_summary, har_status, ...): they still
+ * make the agent "busy", but they do not keep the portal session alive.
+ */
+export function beginAgentCommand(resetsIdleTimer: boolean): void {
+  inFlight += 1;
+  if (resetsIdleTimer) lastActivityAt = Date.now();
+}
+
+/** Mark the end of an agent command. Pair with `beginAgentCommand` in a finally. */
+export function endAgentCommand(resetsIdleTimer: boolean): void {
+  inFlight = Math.max(0, inFlight - 1);
+  // Stamp on completion too: a `navigate` that takes 40s kept the session alive
+  // for those 40s, and the idle clock should run from when it finished.
+  if (resetsIdleTimer) lastActivityAt = Date.now();
+}
+
+/** True while at least one agent command is executing against the page. */
+export function isAgentBusy(): boolean {
+  return inFlight > 0;
+}
+
+/**
+ * Milliseconds since the agent last did something that reset the origin's idle
+ * timer. `Infinity` when the agent has never touched this session — which is the
+ * common case (plain credential-vending sessions) and must behave exactly as it
+ * did before agent-awareness existed.
+ */
+export function msSinceAgentActivity(): number {
+  return lastActivityAt === 0 ? Infinity : Date.now() - lastActivityAt;
+}
+
+/** Test-only: clear module state between cases. */
+export function resetAgentActivity(): void {
+  inFlight = 0;
+  lastActivityAt = 0;
+}

--- a/apps/worker/src/dom-recorder.injected.spec.ts
+++ b/apps/worker/src/dom-recorder.injected.spec.ts
@@ -1,0 +1,199 @@
+import { domRecorderScript, REC_EVENT_PATH } from './dom-recorder.injected';
+
+/**
+ * The recorder runs inside the page, so there is no DOM here — we install a
+ * minimal fake `window`/`document` on globalThis, run the script, then drive the
+ * capture-phase listeners it registered with synthetic events.
+ *
+ * The behaviour under test is ORDER: `input` is debounced 500ms, so its payload
+ * is built long after the human typed. `seq` and `event_time` are added to carry
+ * the interaction itself — `timestamp` keeps its existing flush-time meaning so
+ * that consumers reading it (the NoUI login compiler) are untouched.
+ */
+
+type Listener = (e: unknown) => void;
+
+interface Harness {
+  listeners: Record<string, Listener>;
+  emitted: Array<Record<string, any>>;
+  teardown: () => void;
+}
+
+function installFakeDom(href = 'https://example.com/login'): Harness {
+  const listeners: Record<string, Listener> = {};
+  const emitted: Array<Record<string, any>> = [];
+
+  const fakeWindow: Record<string, any> = {
+    location: { href },
+    fetch: (url: string, init: { body: string }) => {
+      if (url === REC_EVENT_PATH) emitted.push(JSON.parse(init.body));
+      return Promise.resolve();
+    },
+  };
+  const fakeDocument = {
+    addEventListener: (type: string, fn: Listener) => {
+      listeners[type] = fn;
+    },
+    removeEventListener: () => undefined,
+  };
+
+  const g = globalThis as any;
+  const prev = { window: g.window, document: g.document };
+  g.window = fakeWindow;
+  g.document = fakeDocument;
+
+  return {
+    listeners,
+    emitted,
+    teardown: () => {
+      g.window = prev.window;
+      g.document = prev.document;
+    },
+  };
+}
+
+/** A stand-in for a DOM element: only the properties the recorder reads. */
+function el(props: Record<string, any> = {}): Record<string, any> {
+  const attrs: Record<string, string> = props.attrs || {};
+  const node: Record<string, any> = {
+    tagName: 'INPUT',
+    id: '',
+    name: '',
+    type: 'text',
+    value: '',
+    className: '',
+    placeholder: '',
+    textContent: '',
+    attributes: [],
+    getAttribute: (n: string) => attrs[n] ?? null,
+    ...props,
+  };
+  node.closest = () => node;
+  return node;
+}
+
+describe('domRecorderScript', () => {
+  let h: Harness;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-06-15T00:00:00.000Z'));
+    h = installFakeDom();
+    domRecorderScript();
+  });
+
+  afterEach(() => {
+    h.teardown();
+    jest.useRealTimers();
+  });
+
+  it('reports the keystroke in event_time and the flush in timestamp', () => {
+    const field = el({ id: 'user', name: 'username', value: 'a' });
+
+    h.listeners.input({ target: field });
+    jest.advanceTimersByTime(500);
+
+    expect(h.emitted).toHaveLength(1);
+    expect(h.emitted[0].event_type).toBe('input');
+    expect(h.emitted[0].event_time).toBe('2026-06-15T00:00:00.000Z');
+    // `timestamp` is untouched: still the flush, 500ms later. Existing consumers
+    // of this field must see exactly what they saw before.
+    expect(h.emitted[0].timestamp).toBe('2026-06-15T00:00:00.500Z');
+  });
+
+  it('keeps the first keystroke of a burst as the interaction time', () => {
+    const field = el({ id: 'user', name: 'username' });
+
+    field.value = 'a';
+    h.listeners.input({ target: field });
+    jest.advanceTimersByTime(200);
+    field.value = 'ab';
+    h.listeners.input({ target: field }); // resets the debounce
+    jest.advanceTimersByTime(500);
+
+    expect(h.emitted).toHaveLength(1);
+    expect(h.emitted[0].value).toBe('ab'); // final value...
+    expect(h.emitted[0].event_time).toBe('2026-06-15T00:00:00.000Z'); // ...first keystroke
+    expect(h.emitted[0].timestamp).toBe('2026-06-15T00:00:00.700Z'); // ...flushed at 700ms
+  });
+
+  it('orders a fill-then-submit inside the debounce window correctly', () => {
+    // The regression: typing and clicking submit within 500ms flushed the input
+    // AFTER the click, so a timestamp sort reconstructed "click" before "fill".
+    const field = el({ id: 'password', name: 'password', type: 'password', value: 'hunter2' });
+    const button = el({ tagName: 'BUTTON', id: 'signin', textContent: 'Sign in' });
+
+    h.listeners.input({ target: field });
+    jest.advanceTimersByTime(100);
+    h.listeners.click({ target: button, clientX: 10, clientY: 20 });
+    jest.advanceTimersByTime(400); // input flushes here — after the click
+
+    const byArrival = h.emitted.map((e) => e.event_type);
+    expect(byArrival).toEqual(['click', 'input']); // delivery order is still click-first
+
+    const bySeq = [...h.emitted].sort((a, b) => a.seq - b.seq).map((e) => e.event_type);
+    expect(bySeq).toEqual(['input', 'click']); // ...but seq recovers the true order
+
+    const input = h.emitted.find((e) => e.event_type === 'input') as Record<string, any>;
+    const click = h.emitted.find((e) => e.event_type === 'click') as Record<string, any>;
+    expect(input.seq).toBeLessThan(click.seq);
+    expect(input.event_time < click.event_time).toBe(true);
+    // The premise this whole change exists for: `timestamp` still inverts them,
+    // and is deliberately left that way.
+    expect(input.timestamp > click.timestamp).toBe(true);
+    expect(input.value).toBe('[REDACTED]'); // password redaction still applies
+  });
+
+  it('numbers every event type from one strictly increasing counter', () => {
+    const field = el({ id: 'user', name: 'username', value: 'x' });
+    const box = el({ id: 'remember', type: 'checkbox', checked: true });
+    const button = el({ tagName: 'BUTTON', id: 'go', textContent: 'Go' });
+    const form = el({ tagName: 'FORM', id: 'login-form' });
+
+    h.listeners.input({ target: field });
+    jest.advanceTimersByTime(500);
+    h.listeners.change({ target: box });
+    h.listeners.click({ target: button, clientX: 1, clientY: 2 });
+    h.listeners.submit({ target: form });
+
+    expect(h.emitted.map((e) => e.event_type)).toEqual(['input', 'change', 'click', 'submit']);
+    const seqs = h.emitted.map((e) => e.seq);
+    expect(seqs).toEqual([1, 2, 3, 4]);
+  });
+
+  it('starts a fresh stamp for the next burst on the same field', () => {
+    const field = el({ id: 'otp', name: 'otp', value: '1' });
+
+    h.listeners.input({ target: field });
+    jest.advanceTimersByTime(500);
+    jest.setSystemTime(new Date('2026-06-15T00:00:10.000Z'));
+    field.value = '123456';
+    h.listeners.input({ target: field });
+    jest.advanceTimersByTime(500);
+
+    expect(h.emitted.map((e) => e.event_time)).toEqual([
+      '2026-06-15T00:00:00.000Z',
+      '2026-06-15T00:00:10.000Z',
+    ]);
+    expect(h.emitted.map((e) => e.seq)).toEqual([1, 2]);
+  });
+
+  it('emits event_time no later than timestamp on non-debounced events', () => {
+    // These handlers emit inline, so the two clock reads are a statement apart.
+    // `timestamp` is deliberately still its own original read — not a copy of
+    // event_time — so equality is not guaranteed, only ordering.
+    const box = el({ id: 'remember', type: 'checkbox', checked: true });
+    const button = el({ tagName: 'BUTTON', id: 'go', textContent: 'Go' });
+    const form = el({ tagName: 'FORM', id: 'login-form' });
+
+    h.listeners.change({ target: box });
+    h.listeners.click({ target: button, clientX: 1, clientY: 2 });
+    h.listeners.submit({ target: form });
+
+    expect(h.emitted).toHaveLength(3);
+    for (const ev of h.emitted) {
+      expect(ev.event_time).toBeTruthy();
+      expect(ev.event_time <= ev.timestamp).toBe(true);
+    }
+  });
+});

--- a/apps/worker/src/dom-recorder.injected.ts
+++ b/apps/worker/src/dom-recorder.injected.ts
@@ -56,6 +56,37 @@ export function domRecorderScript(): void {
     }
   };
 
+  /**
+   * Ordinal + wall clock of an interaction, captured AT EVENT TIME. Every handler
+   * stamps once, up front, and carries the stamp to the payload it emits.
+   *
+   * These feed two ADDITIVE fields, `seq` and `event_time`. `timestamp` is not
+   * sourced from here at all: every handler keeps its own original
+   * `new Date().toISOString()` call, in its original position, so the value is
+   * byte-identical to what the recorder emitted before this change. It therefore
+   * keeps its existing meaning — the moment the payload was built, which for the
+   * debounced `input` handler is the FLUSH, not the keystroke. That is exactly
+   * why it cannot order the stream: a human who types a field and clicks submit
+   * inside the 500ms window flushes the input after the click, so a timestamp
+   * sort reconstructs "click submit" before "fill password". Consumers that need
+   * order read `seq`; consumers that need the interaction's wall clock read
+   * `event_time`. Nothing reading `timestamp` changes behaviour.
+   *
+   * For every handler but `handleInput` the two clock reads are the same
+   * statement apart, so `event_time` and `timestamp` are equal in practice —
+   * but only `event_time` is guaranteed to be the interaction.
+   *
+   * `seq` restarts at 1 in every document (and in every subframe — the recorder
+   * installs per document). RecordingRunner rebases each run onto a session-global
+   * counter as the beacons arrive, so consumers get a total order that survives
+   * navigation and does not depend on beacon delivery order.
+   */
+  let seq = 0;
+  const stamp = (): { seq: number; eventTime: string } => ({
+    seq: ++seq,
+    eventTime: new Date().toISOString(),
+  });
+
   const getDataAttrs = (el: any): string | null => {
     const attrs: Record<string, string> = {};
     for (const attr of el.attributes || []) {
@@ -121,6 +152,7 @@ export function domRecorderScript(): void {
     const target =
       e.target.closest('[id], [class], a, button, input, select, textarea, [role]') || e.target;
     if (!target || !target.tagName) return;
+    const at = stamp();
     emit({
       event_type: 'click',
       tag_name: target.tagName || '',
@@ -138,17 +170,33 @@ export function domRecorderScript(): void {
       aria_label: target.getAttribute ? target.getAttribute('aria-label') : null,
       role_attr: target.getAttribute ? target.getAttribute('role') : null,
       data_attrs_json: getDataAttrs(target),
+      seq: at.seq,
+      event_time: at.eventTime,
+      // Left as the ORIGINAL clock read, in its original position, so the value
+      // is byte-identical to what this handler produced before seq/event_time.
       timestamp: new Date().toISOString(),
     });
   };
 
   const inputTimers = new WeakMap<any, any>();
+  // Stamp of the FIRST keystroke in the field's current debounce burst, carried
+  // across the debounce so the flushed payload can report when the human
+  // actually started typing (`seq`/`event_time`) alongside its existing
+  // flush-time `timestamp` — see stamp().
+  const inputMarks = new WeakMap<any, { seq: number; eventTime: string }>();
 
   const handleInput = (e: any): void => {
     const target = e.target;
     if (!target || !target.tagName) return;
     const tag = target.tagName.toLowerCase();
     if (tag !== 'input' && tag !== 'textarea') return;
+
+    let mark = inputMarks.get(target);
+    if (!mark) {
+      mark = stamp();
+      inputMarks.set(target, mark);
+    }
+    const at = mark;
 
     const existing = inputTimers.get(target);
     if (existing) clearTimeout(existing);
@@ -157,6 +205,7 @@ export function domRecorderScript(): void {
       target,
       setTimeout(() => {
         inputTimers.delete(target);
+        inputMarks.delete(target); // next burst on this field starts a new stamp
         const fieldRole = detectFieldRole(target);
         const redact = shouldRedact(fieldRole);
         const rawValue = (target.value || '').slice(0, 500);
@@ -177,6 +226,10 @@ export function domRecorderScript(): void {
           aria_label: target.getAttribute('aria-label') || null,
           role_attr: target.getAttribute('role') || null,
           data_attrs_json: getDataAttrs(target),
+          seq: at.seq,
+          event_time: at.eventTime,
+          // Flush time, NOT the keystroke — preserved verbatim so every existing
+          // consumer of this field is untouched. Order by `seq` instead.
           timestamp: new Date().toISOString(),
         });
       }, 500),
@@ -190,6 +243,7 @@ export function domRecorderScript(): void {
     if (tag === 'input' && !['checkbox', 'radio'].includes(target.type)) return;
     if (tag !== 'select' && tag !== 'input') return;
 
+    const at = stamp();
     const fieldRole = detectFieldRole(target);
     const redact = shouldRedact(fieldRole);
     let val: string;
@@ -215,13 +269,16 @@ export function domRecorderScript(): void {
       aria_label: target.getAttribute('aria-label') || null,
       role_attr: target.getAttribute('role') || null,
       data_attrs_json: getDataAttrs(target),
-      timestamp: new Date().toISOString(),
+      seq: at.seq,
+      event_time: at.eventTime,
+      timestamp: new Date().toISOString(), // original clock read, original position
     });
   };
 
   const handleSubmit = (e: any): void => {
     const form = e.target;
     if (!form || (form.tagName && form.tagName.toLowerCase() !== 'form')) return;
+    const at = stamp();
     emit({
       event_type: 'submit',
       tag_name: 'FORM',
@@ -235,7 +292,9 @@ export function domRecorderScript(): void {
       field_role: null,
       is_redacted: false,
       data_attrs_json: null,
-      timestamp: new Date().toISOString(),
+      seq: at.seq,
+      event_time: at.eventTime,
+      timestamp: new Date().toISOString(), // original clock read, original position
     });
   };
 

--- a/apps/worker/src/download-capture.spec.ts
+++ b/apps/worker/src/download-capture.spec.ts
@@ -1,0 +1,78 @@
+import * as fs from 'fs/promises';
+import { enableDownloadCapture, listDownloads, getDownload } from './download-capture';
+
+// Drive the module with a mock Playwright context/page/download. enableDownloadCapture
+// attaches page.on('download'); we capture that handler and fire it with a fake
+// Download whose saveAs writes real bytes to the temp path the module chose.
+function setup() {
+  let dlHandler: (d: any) => Promise<void>;
+  const ctx: any = {
+    on: () => {},
+    pages: () => [page],
+  };
+  const page: any = {
+    on: (ev: string, cb: any) => {
+      if (ev === 'download') dlHandler = cb;
+    },
+    context: () => ctx,
+  };
+  enableDownloadCapture(ctx);
+  return { page, fire: (d: any) => dlHandler(d) };
+}
+
+function fakeDownload(name: string, bytes: Buffer) {
+  return {
+    suggestedFilename: () => name,
+    url: () => `https://bank.test/${name}`,
+    saveAs: async (dest: string) => {
+      await fs.writeFile(dest, bytes);
+    },
+  };
+}
+
+describe('download-capture', () => {
+  it('captures a download, lists it (path-free), and returns base64 bytes', async () => {
+    const { page, fire } = setup();
+    const bytes = Buffer.from('%PDF-1.4 fake statement body');
+    await fire(fakeDownload('statement.pdf', bytes));
+
+    const list = listDownloads(page);
+    expect(list.downloads).toHaveLength(1);
+    const meta = list.downloads[0];
+    expect(meta.suggested_filename).toBe('statement.pdf');
+    expect(meta.state).toBe('completed');
+    expect(meta.mime_type).toBe('application/pdf');
+    expect(meta.size_bytes).toBe(bytes.length);
+    expect((meta as any).path).toBeUndefined(); // never leak the on-disk path
+
+    const got = await getDownload(page); // latest completed
+    expect(got.filename).toBe('statement.pdf');
+    expect(got.mime_type).toBe('application/pdf');
+    expect(Buffer.from(got.base64, 'base64').equals(bytes)).toBe(true);
+  });
+
+  it('get_download returns a specific id and defaults to the newest completed', async () => {
+    const { page, fire } = setup();
+    await fire(fakeDownload('a.csv', Buffer.from('col1,col2')));
+    await fire(fakeDownload('b.pdf', Buffer.from('%PDF b')));
+
+    const first = listDownloads(page).downloads[0];
+    const byId = await getDownload(page, first.id);
+    expect(byId.filename).toBe('a.csv');
+    expect(byId.mime_type).toBe('text/csv');
+
+    const latest = await getDownload(page); // newest
+    expect(latest.filename).toBe('b.pdf');
+  });
+
+  it('throws a clear error when no completed download exists', async () => {
+    const { page } = setup();
+    await expect(getDownload(page)).rejects.toThrow(/no completed download/);
+  });
+
+  it('throws for an unknown id', async () => {
+    const { page, fire } = setup();
+    await fire(fakeDownload('x.pdf', Buffer.from('x')));
+    await expect(getDownload(page, 'dl-nope')).rejects.toThrow(/no download with id/);
+  });
+});

--- a/apps/worker/src/download-capture.ts
+++ b/apps/worker/src/download-capture.ts
@@ -36,6 +36,11 @@ const downloadsByContext = new WeakMap<BrowserContext, DownloadRecord[]>();
 const MAX_DOWNLOADS = 20; // keep only the most recent N per context
 // Every captured file is saved under this dir; get_download reads only from here.
 const DOWNLOADS_DIR = path.join(os.tmpdir(), 'tabby-downloads');
+// Monotonic so ids stay unique once the index caps: `records.length` is read
+// BEFORE the push, so past MAX_DOWNLOADS it is always the cap and two downloads
+// in the same millisecond collided — get_download(id) then returned whichever
+// find() hit first.
+let downloadSeq = 0;
 
 function mimeFromName(name: string): string {
   const ext = path.extname(name || '').toLowerCase();
@@ -80,7 +85,7 @@ export function enableDownloadCapture(context: BrowserContext): void {
     page.on('download', async (download: Download) => {
       const suggested = download.suggestedFilename() || 'download';
       const rec: DownloadRecord = {
-        id: `dl-${Date.now()}-${records.length}`,
+        id: `dl-${Date.now()}-${++downloadSeq}`,
         suggested_filename: suggested,
         url: download.url(),
         mime_type: mimeFromName(suggested),
@@ -91,7 +96,15 @@ export function enableDownloadCapture(context: BrowserContext): void {
       };
       records.push(rec);
       if (records.length > MAX_DOWNLOADS) {
-        records.splice(0, records.length - MAX_DOWNLOADS);
+        // Delete the evicted files too. Dropping only the index entry leaked the
+        // bytes: nothing else unlinks them, so a long-lived worker with downloads
+        // enabled accumulated every export on the pod's ephemeral disk until the
+        // kubelet evicted it.
+        for (const dropped of records.splice(0, records.length - MAX_DOWNLOADS)) {
+          if (dropped.path) {
+            fs.unlink(dropped.path).catch(() => undefined);
+          }
+        }
       }
       try {
         await fs.mkdir(dir, { recursive: true });

--- a/apps/worker/src/download-capture.ts
+++ b/apps/worker/src/download-capture.ts
@@ -1,0 +1,159 @@
+import { BrowserContext, Download, Page } from 'playwright';
+import { EXECUTE_LIMITS } from '@browser-hitl/shared';
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+
+/**
+ * Server-side download capture via Playwright `download` events.
+ *
+ * By default the worker cancels every download (browser_policy.downloads=false
+ * in main.ts). When an app opts in (browser_policy.downloads=true), the context
+ * is created with acceptDownloads and this module saves each download to a temp
+ * file and keeps a small in-memory index. The `/execute/browser` commands
+ * `list_downloads` and `get_download` expose them — `get_download` returns the
+ * bytes as base64 (mirroring `screenshot`) so the harness can write the file to
+ * its OUTPUTS. Bounded to EXECUTE_LIMITS.MAX_RESPONSE_BODY_BYTES; larger exports
+ * would need an out-of-band artifact path.
+ */
+
+export interface DownloadRecord {
+  id: string;
+  suggested_filename: string;
+  url: string;
+  mime_type: string;
+  state: 'in_progress' | 'completed' | 'failed';
+  size_bytes: number | null;
+  path: string | null;
+  created_at: string;
+  error?: string;
+}
+
+/** Public (path-free) view returned by list_downloads. */
+export type DownloadMeta = Omit<DownloadRecord, 'path'>;
+
+const downloadsByContext = new WeakMap<BrowserContext, DownloadRecord[]>();
+const MAX_DOWNLOADS = 20; // keep only the most recent N per context
+
+function mimeFromName(name: string): string {
+  const ext = path.extname(name || '').toLowerCase();
+  switch (ext) {
+    case '.pdf':
+      return 'application/pdf';
+    case '.csv':
+      return 'text/csv';
+    case '.xlsx':
+      return 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
+    case '.xls':
+      return 'application/vnd.ms-excel';
+    case '.json':
+      return 'application/json';
+    case '.txt':
+      return 'text/plain';
+    case '.zip':
+      return 'application/zip';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+function sanitize(name: string): string {
+  return (name || 'download').replace(/[^a-zA-Z0-9._-]+/g, '_').slice(0, 128) || 'download';
+}
+
+/**
+ * Attach download capture to a context (idempotent). Saves each download to a
+ * temp file and indexes it. Call only when browser_policy.downloads is enabled;
+ * the context must have been created with acceptDownloads: true.
+ */
+export function enableDownloadCapture(context: BrowserContext): void {
+  if (downloadsByContext.has(context)) {
+    return;
+  }
+  const records: DownloadRecord[] = [];
+  downloadsByContext.set(context, records);
+  const dir = path.join(os.tmpdir(), 'tabby-downloads');
+
+  const attach = (page: Page) => {
+    page.on('download', async (download: Download) => {
+      const suggested = download.suggestedFilename() || 'download';
+      const rec: DownloadRecord = {
+        id: `dl-${Date.now()}-${records.length}`,
+        suggested_filename: suggested,
+        url: download.url(),
+        mime_type: mimeFromName(suggested),
+        state: 'in_progress',
+        size_bytes: null,
+        path: null,
+        created_at: new Date().toISOString(),
+      };
+      records.push(rec);
+      if (records.length > MAX_DOWNLOADS) {
+        records.splice(0, records.length - MAX_DOWNLOADS);
+      }
+      try {
+        await fs.mkdir(dir, { recursive: true });
+        const dest = path.join(dir, `${rec.id}-${sanitize(suggested)}`);
+        await download.saveAs(dest);
+        const stat = await fs.stat(dest);
+        rec.path = dest;
+        rec.size_bytes = stat.size;
+        rec.state = 'completed';
+      } catch (err) {
+        rec.state = 'failed';
+        rec.error = err instanceof Error ? err.message : String(err);
+      }
+    });
+  };
+
+  context.on('page', attach);
+  for (const p of context.pages()) {
+    attach(p);
+  }
+}
+
+/** Metadata for every captured download on this page's context (newest last). */
+export function listDownloads(page: Page): { downloads: DownloadMeta[] } {
+  const records = downloadsByContext.get(page.context()) || [];
+  return { downloads: records.map(({ path: _p, ...meta }) => meta) };
+}
+
+/**
+ * Return a captured download's bytes as base64. Without `id`, returns the most
+ * recent COMPLETED download. Throws if none, if the target is not completed, or
+ * if it exceeds the inline size cap.
+ */
+export async function getDownload(
+  page: Page,
+  id?: string,
+): Promise<{ id: string; filename: string; mime_type: string; size_bytes: number; base64: string }> {
+  const records = downloadsByContext.get(page.context()) || [];
+  const completed = records.filter((r) => r.state === 'completed');
+  const rec = id
+    ? records.find((r) => r.id === id)
+    : completed[completed.length - 1];
+
+  if (!rec) {
+    throw new Error(
+      id
+        ? `get_download: no download with id "${id}"`
+        : 'get_download: no completed download available (trigger the download first, then retry)',
+    );
+  }
+  if (rec.state !== 'completed' || !rec.path) {
+    throw new Error(`get_download: download "${rec.suggested_filename}" is ${rec.state}${rec.error ? ` (${rec.error})` : ''}`);
+  }
+  if (rec.size_bytes !== null && rec.size_bytes > EXECUTE_LIMITS.MAX_RESPONSE_BODY_BYTES) {
+    throw new Error(
+      `get_download: "${rec.suggested_filename}" is ${rec.size_bytes} bytes, over the ${EXECUTE_LIMITS.MAX_RESPONSE_BODY_BYTES}-byte inline limit`,
+    );
+  }
+  const buf = await fs.readFile(rec.path);
+  return {
+    id: rec.id,
+    filename: rec.suggested_filename,
+    mime_type: rec.mime_type,
+    size_bytes: buf.length,
+    base64: buf.toString('base64'),
+  };
+}

--- a/apps/worker/src/download-capture.ts
+++ b/apps/worker/src/download-capture.ts
@@ -34,6 +34,8 @@ export type DownloadMeta = Omit<DownloadRecord, 'path'>;
 
 const downloadsByContext = new WeakMap<BrowserContext, DownloadRecord[]>();
 const MAX_DOWNLOADS = 20; // keep only the most recent N per context
+// Every captured file is saved under this dir; get_download reads only from here.
+const DOWNLOADS_DIR = path.join(os.tmpdir(), 'tabby-downloads');
 
 function mimeFromName(name: string): string {
   const ext = path.extname(name || '').toLowerCase();
@@ -72,7 +74,7 @@ export function enableDownloadCapture(context: BrowserContext): void {
   }
   const records: DownloadRecord[] = [];
   downloadsByContext.set(context, records);
-  const dir = path.join(os.tmpdir(), 'tabby-downloads');
+  const dir = DOWNLOADS_DIR;
 
   const attach = (page: Page) => {
     page.on('download', async (download: Download) => {
@@ -147,6 +149,13 @@ export async function getDownload(
     throw new Error(
       `get_download: "${rec.suggested_filename}" is ${rec.size_bytes} bytes, over the ${EXECUTE_LIMITS.MAX_RESPONSE_BODY_BYTES}-byte inline limit`,
     );
+  }
+  // Defense-in-depth: rec.path is always a saveAs() destination we built under
+  // DOWNLOADS_DIR from a generated id + sanitize()-d name, but confirm it stays
+  // inside that dir before reading (path-traversal containment).
+  const rel = path.relative(DOWNLOADS_DIR, rec.path);
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    throw new Error('get_download: refusing to read a path outside the download directory');
   }
   const buf = await fs.readFile(rec.path);
   return {

--- a/apps/worker/src/execute-browser-handler.spec.ts
+++ b/apps/worker/src/execute-browser-handler.spec.ts
@@ -82,6 +82,7 @@ describe('execute-browser-handler validation', () => {
         'get_page_summary', 'get_page_info', 'screenshot',
         'wait_for_selector', 'scroll_page',
         'har_start', 'har_stop', 'har_status',
+        'list_downloads', 'get_download',
       ];
       for (const cmd of expectedCommands) {
         expect(BROWSER_COMMANDS.includes(cmd as any)).toBe(true);

--- a/apps/worker/src/execute-browser-handler.spec.ts
+++ b/apps/worker/src/execute-browser-handler.spec.ts
@@ -10,6 +10,8 @@ function makeLocator(overrides: Record<string, any> = {}): any {
     filter: jest.fn(),
     nth: jest.fn(),
     getByText: jest.fn(),
+    scrollIntoViewIfNeeded: jest.fn().mockResolvedValue(undefined),
+    dispatchEvent: jest.fn().mockResolvedValue(undefined),
   };
   loc.filter.mockImplementation((opts: any) => {
     loc._lastFilter = opts;
@@ -70,6 +72,54 @@ describe('execute-browser-handler click_by_text resolution', () => {
 
     expect(matches.nth).toHaveBeenCalledWith(0); // fell back to the raw matches
     expect(matches.click).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to a DOM-dispatched click when a real click is intercepted by an overlay', async () => {
+    // Regression for the HSBCnet statement "Download": a sticky news/service-update
+    // banner obscured the link's click point, so Playwright refused the real click
+    // ("intercepts pointer events") and no download ever fired. The DOM-level
+    // dispatch bypasses the overlay hit-test, mirroring a manual click.
+    const visible = makeLocator({ count: 1 });
+    visible.click.mockRejectedValueOnce(
+      new Error('locator.click: Timeout 30000ms exceeded.\n<div class="newsNotification"> intercepts pointer events'),
+    );
+    const matches = makeLocator({ count: 3, filtered: visible });
+    const page: any = { getByText: jest.fn().mockReturnValue(matches) };
+
+    await dispatchCommand(page, 'click_by_text', { text: 'Download' }, 30000);
+
+    expect(visible.click).toHaveBeenCalledTimes(1);
+    expect(visible.scrollIntoViewIfNeeded).toHaveBeenCalledTimes(1);
+    expect(visible.dispatchEvent).toHaveBeenCalledWith('click');
+  });
+
+  it('rethrows a non-interception click error instead of dispatching (a genuine failure still surfaces)', async () => {
+    const visible = makeLocator({ count: 1 });
+    visible.click.mockRejectedValueOnce(new Error('locator.click: strict mode violation'));
+    const matches = makeLocator({ count: 1, filtered: visible });
+    const page: any = { getByText: jest.fn().mockReturnValue(matches) };
+
+    await expect(dispatchCommand(page, 'click_by_text', { text: 'Download' }, 30000)).rejects.toThrow(
+      /strict mode violation/,
+    );
+    expect(visible.dispatchEvent).not.toHaveBeenCalled();
+  });
+
+  it('rethrows a plain not-found timeout without dispatching (wrong label ≠ overlay)', async () => {
+    // A bare "Timeout exceeded" (no "intercepts pointer events") means the target
+    // text simply isn't on the page (e.g. a wrong recorded label). A DOM dispatch
+    // can't help and would just burn a second 30s — so it must re-throw fast.
+    const visible = makeLocator({ count: 1 });
+    visible.click.mockRejectedValueOnce(
+      new Error('locator.click: Timeout 30000ms exceeded.\nwaiting for getByText(\'Last Month Statement\')'),
+    );
+    const matches = makeLocator({ count: 1, filtered: visible });
+    const page: any = { getByText: jest.fn().mockReturnValue(matches) };
+
+    await expect(dispatchCommand(page, 'click_by_text', { text: 'Last Month Statement' }, 30000)).rejects.toThrow(
+      /Timeout 30000ms exceeded/,
+    );
+    expect(visible.dispatchEvent).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/worker/src/execute-browser-handler.spec.ts
+++ b/apps/worker/src/execute-browser-handler.spec.ts
@@ -1,4 +1,77 @@
 import { BROWSER_COMMANDS, EXECUTE_LIMITS } from '@browser-hitl/shared';
+import { dispatchCommand } from './execute-browser-handler';
+
+// A minimal Playwright Locator/Page mock that records how click_by_text resolves
+// its target. getByText → filter({visible}) → nth → click is the chain we assert.
+function makeLocator(overrides: Record<string, any> = {}): any {
+  const loc: any = {
+    click: jest.fn().mockResolvedValue(undefined),
+    count: jest.fn().mockResolvedValue(overrides.count ?? 1),
+    filter: jest.fn(),
+    nth: jest.fn(),
+    getByText: jest.fn(),
+  };
+  loc.filter.mockImplementation((opts: any) => {
+    loc._lastFilter = opts;
+    return overrides.filtered ?? loc;
+  });
+  loc.nth.mockImplementation((i: number) => {
+    loc._lastNth = i;
+    return loc;
+  });
+  return loc;
+}
+
+describe('execute-browser-handler click_by_text resolution', () => {
+  it('defaults to non-exact matching and clicks the first VISIBLE match', async () => {
+    const visible = makeLocator({ count: 1 });
+    const matches = makeLocator({ count: 3, filtered: visible });
+    const page: any = { getByText: jest.fn().mockReturnValue(matches) };
+
+    await dispatchCommand(page, 'click_by_text', { text: 'Cards' }, 30000);
+
+    // exact defaults to false (Playwright's natural substring match)
+    expect(page.getByText).toHaveBeenCalledWith('Cards', { exact: false });
+    // duplicate matches → filter to visible, take the first, then click
+    expect(matches.filter).toHaveBeenCalledWith({ visible: true });
+    expect(visible.nth).toHaveBeenCalledWith(0);
+    expect(visible.click).toHaveBeenCalledTimes(1);
+  });
+
+  it('honors exact:true, a within-scope, and an nth index', async () => {
+    const visible = makeLocator({ count: 2 });
+    const matches = makeLocator({ count: 2, filtered: visible });
+    const scope = makeLocator();
+    scope.getByText.mockReturnValue(matches);
+    const page: any = {
+      locator: jest.fn().mockReturnValue(scope),
+      getByText: jest.fn(),
+    };
+
+    await dispatchCommand(
+      page,
+      'click_by_text',
+      { text: 'Credit Card', exact: true, within: '#sidenavNew', nth: 1 },
+      30000,
+    );
+
+    expect(page.locator).toHaveBeenCalledWith('#sidenavNew');
+    expect(scope.getByText).toHaveBeenCalledWith('Credit Card', { exact: true });
+    expect(visible.nth).toHaveBeenCalledWith(1);
+    expect(visible.click).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to all matches when none are visible (so a real miss still errors)', async () => {
+    const visible = makeLocator({ count: 0 });
+    const matches = makeLocator({ count: 1, filtered: visible });
+    const page: any = { getByText: jest.fn().mockReturnValue(matches) };
+
+    await dispatchCommand(page, 'click_by_text', { text: 'Ghost' }, 30000);
+
+    expect(matches.nth).toHaveBeenCalledWith(0); // fell back to the raw matches
+    expect(matches.click).toHaveBeenCalledTimes(1);
+  });
+});
 
 describe('execute-browser-handler validation', () => {
   describe('command validation', () => {

--- a/apps/worker/src/execute-browser-handler.spec.ts
+++ b/apps/worker/src/execute-browser-handler.spec.ts
@@ -10,6 +10,7 @@ function makeLocator(overrides: Record<string, any> = {}): any {
     filter: jest.fn(),
     nth: jest.fn(),
     getByText: jest.fn(),
+    first: jest.fn(),
     scrollIntoViewIfNeeded: jest.fn().mockResolvedValue(undefined),
     dispatchEvent: jest.fn().mockResolvedValue(undefined),
   };
@@ -17,6 +18,7 @@ function makeLocator(overrides: Record<string, any> = {}): any {
     loc._lastFilter = opts;
     return overrides.filtered ?? loc;
   });
+  loc.first.mockImplementation(() => loc);
   loc.nth.mockImplementation((i: number) => {
     loc._lastNth = i;
     return loc;
@@ -25,19 +27,55 @@ function makeLocator(overrides: Record<string, any> = {}): any {
 }
 
 describe('execute-browser-handler click_by_text resolution', () => {
-  it('defaults to non-exact matching and clicks the first VISIBLE match', async () => {
+  it('prefers an EXACT match by default, and clicks the first VISIBLE one', async () => {
+    // Defaulting straight to substring silently widened every already-compiled
+    // skill that omits `exact`: a sidebar with "Log out" and "Log out of all
+    // devices" made click_by_text('Log out') ambiguous, and nth(0) then picks DOM
+    // order. Exact is tried first; substring is only a rescue (below).
     const visible = makeLocator({ count: 1 });
     const matches = makeLocator({ count: 3, filtered: visible });
     const page: any = { getByText: jest.fn().mockReturnValue(matches) };
 
     await dispatchCommand(page, 'click_by_text', { text: 'Cards' }, 30000);
 
-    // exact defaults to false (Playwright's natural substring match)
-    expect(page.getByText).toHaveBeenCalledWith('Cards', { exact: false });
+    expect(page.getByText).toHaveBeenCalledWith('Cards', { exact: true });
     // duplicate matches → filter to visible, take the first, then click
     expect(matches.filter).toHaveBeenCalledWith({ visible: true });
     expect(visible.nth).toHaveBeenCalledWith(0);
     expect(visible.click).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to substring when no exact match exists (near-miss labels)', async () => {
+    // The reason substring matching exists: a skill records "Credit Cards" but
+    // the DOM says "Credit Card".
+    const visible = makeLocator({ count: 1 });
+    const exactMatches = makeLocator({ count: 0 });
+    const looseMatches = makeLocator({ count: 2, filtered: visible });
+    const page: any = {
+      getByText: jest.fn().mockImplementation((_t: string, opts: any) =>
+        opts?.exact ? exactMatches : looseMatches,
+      ),
+    };
+
+    await dispatchCommand(page, 'click_by_text', { text: 'Credit Cards' }, 30000);
+
+    expect(page.getByText).toHaveBeenCalledWith('Credit Cards', { exact: true });
+    expect(page.getByText).toHaveBeenCalledWith('Credit Cards', { exact: false });
+    expect(visible.click).toHaveBeenCalledTimes(1);
+  });
+
+  it('click_element prefers visible matches and clicks through an overlay', async () => {
+    const visible = makeLocator({ count: 1 });
+    visible.click.mockRejectedValueOnce(
+      new Error('locator.click: Timeout 30000ms exceeded.\n<div class="newsNotification"> intercepts pointer events'),
+    );
+    const all = makeLocator({ count: 3, filtered: visible });
+    const page: any = { locator: jest.fn().mockReturnValue(all) };
+
+    await dispatchCommand(page, 'click_element', { selector: '.stmt a.dl' }, 30000);
+
+    expect(all.filter).toHaveBeenCalledWith({ visible: true });
+    expect(visible.dispatchEvent).toHaveBeenCalledWith('click');
   });
 
   it('honors exact:true, a within-scope, and an nth index', async () => {

--- a/apps/worker/src/execute-browser-handler.ts
+++ b/apps/worker/src/execute-browser-handler.ts
@@ -7,6 +7,7 @@ import {
   type ExecuteBrowserResponse,
 } from '@browser-hitl/shared';
 import { startHarCapture, stopHarCapture, getHarStatus, cleanupHarListeners } from './har-capture';
+import { listDownloads, getDownload } from './download-capture';
 
 export { cleanupHarListeners };
 
@@ -160,6 +161,15 @@ export async function dispatchCommand(
 
     case 'har_status': {
       return getHarStatus(page);
+    }
+
+    case 'list_downloads': {
+      return listDownloads(page);
+    }
+
+    case 'get_download': {
+      const id = typeof params.id === 'string' && params.id ? params.id : undefined;
+      return getDownload(page, id);
     }
 
     default:

--- a/apps/worker/src/execute-browser-handler.ts
+++ b/apps/worker/src/execute-browser-handler.ts
@@ -65,7 +65,13 @@ export async function dispatchCommand(
 
     case 'click_element': {
       const selector = requireParam(params, 'selector', 'string');
-      await page.locator(selector).click({ timeout: timeoutMs });
+      // Same visible-first + overlay handling as click_by_text: a selector can
+      // match hidden analytics/off-screen copies (strict-mode violation), and the
+      // sticky-banner interception is not text-specific.
+      const all = page.locator(selector);
+      const vis = all.filter({ visible: true });
+      const el = (await vis.count()) > 0 ? vis.first() : all.first();
+      await clickThroughOverlays(el, timeoutMs);
       return {};
     }
 
@@ -222,6 +228,39 @@ export async function dispatchCommand(
 }
 
 /**
+ * Click a resolved locator, falling back to a DOM-dispatched click when a real
+ * mouse click cannot be delivered.
+ *
+ * Real SPA/bank portals overlay sticky banners (news / service-update
+ * notifications, cookie notices) that cover a target's click point. Playwright
+ * correctly refuses a click it cannot deliver ("<div …> intercepts pointer
+ * events") and times out — even though THIS is the right, visible element and a
+ * human clicking it directly works (observed on HSBCnet: a `newsNotification`
+ * widget obscured the per-row statement "Download" link, so the click never
+ * landed and no download fired). The DOM dispatch bypasses the pointer-event
+ * hit-test, the same effect as the manual click.
+ *
+ * Only for a genuine OVERLAY interception — Playwright always includes
+ * "intercepts pointer events" in that error. A plain "Timeout exceeded" means
+ * the element was never found/actionable (e.g. a wrong selector or label), where
+ * a DOM dispatch cannot help and would just burn a second timeout, so those
+ * re-throw unchanged.
+ */
+async function clickThroughOverlays(target: any, timeoutMs: number): Promise<void> {
+  try {
+    await target.click({ timeout: timeoutMs });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (/intercepts pointer events/i.test(msg)) {
+      await target.scrollIntoViewIfNeeded({ timeout: timeoutMs }).catch(() => undefined);
+      await target.dispatchEvent('click');
+    } else {
+      throw err;
+    }
+  }
+}
+
+/**
  * Click an element by its visible text, tolerant of the two things that make a
  * naive `getByText(text, { exact: true }).click()` fail on real SPA portals:
  *
@@ -245,45 +284,35 @@ async function clickByText(
   text: string,
   timeoutMs: number,
 ): Promise<void> {
-  const exact = params.exact === true;
+  const explicitExact = typeof params.exact === 'boolean' ? params.exact : undefined;
   const within = typeof params.within === 'string' && params.within ? params.within : '';
   const nth = Number.isInteger(params.nth) ? params.nth : 0;
 
   const scope = within ? page.locator(within) : page;
-  const matches = scope.getByText(text, { exact });
 
   // Prefer visible matches so the hidden analytics/off-screen copies never cause
   // a strict-mode violation. Only fall back to all matches when nothing is
   // currently visible, so a genuinely-missing target still errors clearly.
-  const visible = matches.filter({ visible: true });
-  const target = (await visible.count()) > 0 ? visible.nth(nth) : matches.nth(nth);
-  try {
-    await target.click({ timeout: timeoutMs });
-  } catch (err) {
-    // Real SPA/bank portals overlay sticky banners (news / service-update
-    // notifications, cookie notices) that cover a target's click point.
-    // Playwright correctly refuses a real mouse click it cannot deliver
-    // ("<div …> intercepts pointer events") and times out — even though THIS is
-    // the right, visible element and a human clicking the link directly works
-    // (observed on HSBCnet: a `newsNotification` widget obscured the per-row
-    // statement "Download" link, so the click never landed and no download
-    // fired). Fall back to a DOM-level click dispatched straight to the element,
-    // which bypasses the pointer-event hit-test — the same effect as the manual
-    // click. Only for interception/stability timeouts; a genuinely missing or
-    // detached target still surfaces its original error.
-    // Only fall back for a genuine OVERLAY interception — Playwright always
-    // includes "intercepts pointer events" in that error. A plain "Timeout
-    // exceeded" instead means the element was never found/actionable (e.g. a
-    // wrong text label), where a DOM dispatch can't help and would just burn a
-    // second timeout — so re-throw those unchanged.
-    const msg = err instanceof Error ? err.message : String(err);
-    if (/intercepts pointer events/i.test(msg)) {
-      await target.scrollIntoViewIfNeeded({ timeout: timeoutMs }).catch(() => undefined);
-      await target.dispatchEvent('click');
-    } else {
-      throw err;
-    }
+  const resolve = async (exact: boolean) => {
+    const matches = scope.getByText(text, { exact });
+    const visible = matches.filter({ visible: true });
+    return (await visible.count()) > 0 ? visible.nth(nth) : matches.nth(nth);
+  };
+
+  // Default is EXACT-first, substring only as a rescue. Defaulting straight to
+  // substring silently widened every already-compiled skill that omits `exact`:
+  // a sidebar with "Log out" and "Log out of all devices" made click_by_text
+  // "Log out" ambiguous, and nth(0) then picks DOM order. Trying exact first
+  // keeps those precise while still rescuing the near-miss labels substring
+  // matching exists for ("Credit Cards" recorded, "Credit Card" in the DOM).
+  let target;
+  if (explicitExact !== undefined) {
+    target = await resolve(explicitExact);
+  } else {
+    const exactCount = await scope.getByText(text, { exact: true }).count();
+    target = await resolve(exactCount > 0);
   }
+  await clickThroughOverlays(target, timeoutMs);
 }
 
 function requireParam(params: Record<string, any>, name: string, type: string): any {

--- a/apps/worker/src/execute-browser-handler.ts
+++ b/apps/worker/src/execute-browser-handler.ts
@@ -104,15 +104,58 @@ export async function dispatchCommand(
 
     case 'get_page_summary': {
       const summary = await page.evaluate(() => {
+        // Only report what the USER can actually see. The raw DOM keeps
+        // display:none / aria-hidden / zero-size leftovers — e.g. a modal from
+        // an earlier navigation that was closed but not removed. Feeding those
+        // to the model makes it "see" phantom UI (blocking modals, stale
+        // overlays) that isn't on screen and chase it. Mirror click_by_text,
+        // which already prefers visible matches, so summary and clicks agree.
+        const isVisible = (el: Element): boolean => {
+          const e = el as HTMLElement;
+          try {
+            // checkVisibility() covers display:none, visibility:hidden/collapse,
+            // content-visibility, and (with the flag) opacity:0. It is TRUE for
+            // elements merely scrolled out of view, which is what we want —
+            // "rendered", not "in the current viewport".
+            const cv = (e as unknown as {
+              checkVisibility?: (opts?: Record<string, boolean>) => boolean;
+            }).checkVisibility;
+            if (typeof cv === 'function') {
+              if (!cv.call(e, { checkVisibilityCSS: true, checkOpacity: true, contentVisibilityAuto: true })) {
+                return false;
+              }
+            } else {
+              const s = window.getComputedStyle(e);
+              if (
+                s.display === 'none' ||
+                s.visibility === 'hidden' ||
+                s.visibility === 'collapse' ||
+                parseFloat(s.opacity || '1') === 0
+              ) {
+                return false;
+              }
+              if (!(e.offsetWidth || e.offsetHeight || e.getClientRects().length)) return false;
+            }
+            // aria-hidden subtree = intentionally removed from the accessibility
+            // tree; treat as not-shown so hidden dialogs don't leak through.
+            if (e.closest('[aria-hidden="true"]')) return false;
+            return true;
+          } catch {
+            return true; // never let a visibility probe drop a real element
+          }
+        };
         const title = document.title;
         const url = window.location.href;
         const links = Array.from(document.querySelectorAll('a[href]'))
+          .filter(isVisible)
           .slice(0, 50)
           .map(a => ({ text: (a as HTMLAnchorElement).textContent?.trim() || '', href: (a as HTMLAnchorElement).href }));
         const buttons = Array.from(document.querySelectorAll('button, [role="button"], input[type="submit"]'))
+          .filter(isVisible)
           .slice(0, 50)
           .map(b => ({ text: (b as HTMLElement).textContent?.trim() || '', tag: b.tagName.toLowerCase() }));
         const inputs = Array.from(document.querySelectorAll('input, textarea, select'))
+          .filter(isVisible)
           .slice(0, 50)
           .map(i => ({
             tag: i.tagName.toLowerCase(),
@@ -122,6 +165,7 @@ export async function dispatchCommand(
             placeholder: (i as HTMLInputElement).placeholder || '',
           }));
         const headings = Array.from(document.querySelectorAll('h1, h2, h3'))
+          .filter(isVisible)
           .slice(0, 20)
           .map(h => ({ level: h.tagName, text: (h as HTMLElement).textContent?.trim() || '' }));
         return { title, url, links, buttons, inputs, headings };
@@ -213,7 +257,33 @@ async function clickByText(
   // currently visible, so a genuinely-missing target still errors clearly.
   const visible = matches.filter({ visible: true });
   const target = (await visible.count()) > 0 ? visible.nth(nth) : matches.nth(nth);
-  await target.click({ timeout: timeoutMs });
+  try {
+    await target.click({ timeout: timeoutMs });
+  } catch (err) {
+    // Real SPA/bank portals overlay sticky banners (news / service-update
+    // notifications, cookie notices) that cover a target's click point.
+    // Playwright correctly refuses a real mouse click it cannot deliver
+    // ("<div …> intercepts pointer events") and times out — even though THIS is
+    // the right, visible element and a human clicking the link directly works
+    // (observed on HSBCnet: a `newsNotification` widget obscured the per-row
+    // statement "Download" link, so the click never landed and no download
+    // fired). Fall back to a DOM-level click dispatched straight to the element,
+    // which bypasses the pointer-event hit-test — the same effect as the manual
+    // click. Only for interception/stability timeouts; a genuinely missing or
+    // detached target still surfaces its original error.
+    // Only fall back for a genuine OVERLAY interception — Playwright always
+    // includes "intercepts pointer events" in that error. A plain "Timeout
+    // exceeded" instead means the element was never found/actionable (e.g. a
+    // wrong text label), where a DOM dispatch can't help and would just burn a
+    // second timeout — so re-throw those unchanged.
+    const msg = err instanceof Error ? err.message : String(err);
+    if (/intercepts pointer events/i.test(msg)) {
+      await target.scrollIntoViewIfNeeded({ timeout: timeoutMs }).catch(() => undefined);
+      await target.dispatchEvent('click');
+    } else {
+      throw err;
+    }
+  }
 }
 
 function requireParam(params: Record<string, any>, name: string, type: string): any {

--- a/apps/worker/src/execute-browser-handler.ts
+++ b/apps/worker/src/execute-browser-handler.ts
@@ -45,7 +45,7 @@ export function registerBrowserHandler(app: Express, page: Page): void {
   });
 }
 
-async function dispatchCommand(
+export async function dispatchCommand(
   page: Page,
   command: string,
   params: Record<string, any>,
@@ -70,8 +70,7 @@ async function dispatchCommand(
 
     case 'click_by_text': {
       const text = requireParam(params, 'text', 'string');
-      const exact = params.exact !== false;
-      await page.getByText(text, { exact }).click({ timeout: timeoutMs });
+      await clickByText(page, params, text, timeoutMs);
       return {};
     }
 
@@ -166,6 +165,45 @@ async function dispatchCommand(
     default:
       throw new Error(`Unhandled command: ${command}`);
   }
+}
+
+/**
+ * Click an element by its visible text, tolerant of the two things that make a
+ * naive `getByText(text, { exact: true }).click()` fail on real SPA portals:
+ *
+ *  1. Duplicate text. A nav label like "Cards" is rendered in several nodes —
+ *     the visible sidebar item plus hidden copies (analytics/telemetry trackers,
+ *     off-screen scroll clones). A plain locator click throws a Playwright
+ *     strict-mode violation on >1 match. We prefer the VISIBLE match(es) and
+ *     click the nth (first by default), which is what a human does.
+ *  2. Near-miss labels. The exact text a skill recorded ("Credit Cards") often
+ *     differs slightly from the DOM ("Credit Card"); exact matching then times
+ *     out. We default to Playwright's natural substring + normalized-whitespace
+ *     matching. Callers can still force exact with `exact: true`.
+ *
+ * Optional params: `exact` (default false), `within` (CSS selector to scope the
+ * search to a container — e.g. a specific sidenav), `nth` (0-based index among
+ * the visible matches, default 0).
+ */
+async function clickByText(
+  page: Page,
+  params: Record<string, any>,
+  text: string,
+  timeoutMs: number,
+): Promise<void> {
+  const exact = params.exact === true;
+  const within = typeof params.within === 'string' && params.within ? params.within : '';
+  const nth = Number.isInteger(params.nth) ? params.nth : 0;
+
+  const scope = within ? page.locator(within) : page;
+  const matches = scope.getByText(text, { exact });
+
+  // Prefer visible matches so the hidden analytics/off-screen copies never cause
+  // a strict-mode violation. Only fall back to all matches when nothing is
+  // currently visible, so a genuinely-missing target still errors clearly.
+  const visible = matches.filter({ visible: true });
+  const target = (await visible.count()) > 0 ? visible.nth(nth) : matches.nth(nth);
+  await target.click({ timeout: timeoutMs });
 }
 
 function requireParam(params: Record<string, any>, name: string, type: string): any {

--- a/apps/worker/src/execute-browser-handler.ts
+++ b/apps/worker/src/execute-browser-handler.ts
@@ -8,6 +8,7 @@ import {
 } from '@browser-hitl/shared';
 import { startHarCapture, stopHarCapture, getHarStatus, cleanupHarListeners } from './har-capture';
 import { listDownloads, getDownload } from './download-capture';
+import { beginAgentCommand, endAgentCommand, isIdleResettingCommand } from './agent-activity';
 
 export { cleanupHarListeners };
 
@@ -35,7 +36,16 @@ export function registerBrowserHandler(app: Express, page: Page): void {
         EXECUTE_LIMITS.MAX_TIMEOUT_MS,
       );
 
-      const result = await dispatchCommand(page, body.command, params, timeoutMs);
+      // Tell the keepalive loop an agent is driving the page, so it does not
+      // inject a mouse-move/scroll/reload into the middle of this command.
+      const resetsIdle = isIdleResettingCommand(body.command);
+      beginAgentCommand(resetsIdle);
+      let result: unknown;
+      try {
+        result = await dispatchCommand(page, body.command, params, timeoutMs);
+      } finally {
+        endAgentCommand(resetsIdle);
+      }
       const response: ExecuteBrowserResponse = { success: true, data: result };
       res.json(response);
     } catch (err: unknown) {

--- a/apps/worker/src/execute-handler.ts
+++ b/apps/worker/src/execute-handler.ts
@@ -5,6 +5,7 @@ import {
   type ExecuteFetchRequest,
   type ExecuteFetchResponse,
 } from '@browser-hitl/shared';
+import { beginAgentCommand, endAgentCommand } from './agent-activity';
 
 export function registerExecuteHandler(app: Express, page: Page): void {
   app.post('/execute/fetch', async (req: Request, res: Response) => {
@@ -137,14 +138,21 @@ export function registerExecuteHandler(app: Express, page: Page): void {
         };
       };
 
+      // A fetch is a real request to the origin, so it both makes the agent
+      // "busy" and resets the portal's idle timer — the keepalive nudge is
+      // redundant while these are flowing (see agent-activity.ts).
       if (isCrossOrigin) {
-        const response = await fetchViaContext().catch((err: Error) => {
-          throw new ExecuteError(502, `Cross-origin fetch failed: ${err.message}`);
-        });
+        beginAgentCommand(true);
+        const response = await fetchViaContext()
+          .catch((err: Error) => {
+            throw new ExecuteError(502, `Cross-origin fetch failed: ${err.message}`);
+          })
+          .finally(() => endAgentCommand(true));
         res.json(response);
         return;
       }
 
+      beginAgentCommand(true);
       const result = await page.evaluate(
         async ({
           url, method: m, headers: h, body: b, maxBytes,
@@ -231,7 +239,7 @@ export function registerExecuteHandler(app: Express, page: Page): void {
         } catch {
           throw new ExecuteError(502, `Browser fetch failed: ${err.message}`);
         }
-      });
+      }).finally(() => endAgentCommand(true));
 
       const response: ExecuteFetchResponse = result;
       res.json(response);

--- a/apps/worker/src/execute-handler.ts
+++ b/apps/worker/src/execute-handler.ts
@@ -75,7 +75,18 @@ export function registerExecuteHandler(app: Express, page: Page): void {
       // context (interceptors that mint per-request tokens still run).
       const context = page.context();
       const pageOrigin = (() => {
-        try { return new URL(page.url()).origin; } catch { return null; }
+        try {
+          const origin = new URL(page.url()).origin;
+          // about:blank and other opaque origins serialize to the STRING "null"
+          // rather than throwing, so this used to be "cross-origin" only by
+          // accident (the string never equals a real origin). Keep that routing —
+          // an in-page fetch from an opaque origin cannot pass CORS anyway — but
+          // say so explicitly. Note the consequence: while the page sits on
+          // about:blank (worker boot, warm-pool spare, post-crash) every fetch
+          // goes off-page, and off-page traffic never fires page.on('request'),
+          // so har_start/har_stop records nothing for it.
+          return origin === 'null' ? null : origin;
+        } catch { return null; }
       })();
       const isCrossOrigin = pageOrigin === null || pageOrigin !== parsed.origin;
 

--- a/apps/worker/src/execute-handler.ts
+++ b/apps/worker/src/execute-handler.ts
@@ -57,6 +57,83 @@ export function registerExecuteHandler(app: Express, page: Page): void {
       const fetchBody = body.body ?? null;
       const maxResponseBytes = EXECUTE_LIMITS.MAX_RESPONSE_BODY_BYTES;
 
+      // An in-page fetch() is bound by the page's origin and the target's CORS
+      // policy. Multi-origin apps therefore cannot be driven from a single page:
+      // ICICI, for example, serves its dashboard from retailnetbanking.icici.bank.in
+      // but its statement APIs from infinity.icici.bank.in, which sends no CORS
+      // headers — the call dies as "TypeError: Failed to fetch" even though the
+      // session is perfectly valid. That shape (auth portal + separate core-banking
+      // host) is the norm for bank portals, not an ICICI quirk.
+      //
+      // Playwright's APIRequestContext is the way out: it shares the BrowserContext's
+      // cookie jar and proxy (same primitive health-predicate-runner uses) but is not
+      // a page fetch, so no origin is attached and CORS never applies. It also lifts
+      // the browser's forbidden-header rules, so a captured Cookie/Authorization can
+      // be sent explicitly.
+      //
+      // Same-origin calls keep using the in-page fetch, which preserves the page's JS
+      // context (interceptors that mint per-request tokens still run).
+      const context = page.context();
+      const pageOrigin = (() => {
+        try { return new URL(page.url()).origin; } catch { return null; }
+      })();
+      const isCrossOrigin = pageOrigin === null || pageOrigin !== parsed.origin;
+
+      const fetchViaContext = async (): Promise<ExecuteFetchResponse> => {
+        const resp = await context.request.fetch(fetchUrl, {
+          method,
+          headers,
+          ...(fetchBody !== null && method !== 'GET' && method !== 'HEAD'
+            ? { data: fetchBody }
+            : {}),
+          timeout: timeoutMs,
+          maxRedirects: 10,
+          // Report the target's own status rather than throwing on 4xx/5xx — callers
+          // need to see a 401/403 to react to it.
+          failOnStatusCode: false,
+        });
+
+        const respHeaders = resp.headers();
+        const contentType = (respHeaders['content-type'] || '').toLowerCase();
+        const isTextual =
+          contentType === '' ||
+          contentType.startsWith('text/') ||
+          contentType.includes('json') ||
+          contentType.includes('xml') ||
+          contentType.includes('javascript') ||
+          contentType.includes('x-www-form-urlencoded') ||
+          contentType.includes('svg');
+
+        const buf = await resp.body();
+        if (isTextual) {
+          const text = buf.toString('utf-8');
+          const wasTruncated = text.length > maxResponseBytes;
+          return {
+            status: resp.status(),
+            headers: respHeaders,
+            body: wasTruncated ? text.slice(0, maxResponseBytes) : text,
+            encoding: 'utf-8',
+            truncated: wasTruncated,
+          };
+        }
+        const wasTruncated = buf.length > maxResponseBytes;
+        return {
+          status: resp.status(),
+          headers: respHeaders,
+          body: (wasTruncated ? buf.subarray(0, maxResponseBytes) : buf).toString('base64'),
+          encoding: 'base64',
+          truncated: wasTruncated,
+        };
+      };
+
+      if (isCrossOrigin) {
+        const response = await fetchViaContext().catch((err: Error) => {
+          throw new ExecuteError(502, `Cross-origin fetch failed: ${err.message}`);
+        });
+        res.json(response);
+        return;
+      }
+
       const result = await page.evaluate(
         async ({
           url, method: m, headers: h, body: b, maxBytes,
@@ -134,8 +211,15 @@ export function registerExecuteHandler(app: Express, page: Page): void {
           body: fetchBody,
           maxBytes: maxResponseBytes,
         },
-      ).catch((err: Error) => {
-        throw new ExecuteError(502, `Browser fetch failed: ${err.message}`);
+      ).catch(async (err: Error) => {
+        // Same-origin fetches can still be refused by the page — a CSP connect-src
+        // rule, or a service worker. Retry off-page before giving up, for the same
+        // reason cross-origin goes there directly.
+        try {
+          return await fetchViaContext();
+        } catch {
+          throw new ExecuteError(502, `Browser fetch failed: ${err.message}`);
+        }
       });
 
       const response: ExecuteFetchResponse = result;

--- a/apps/worker/src/execute-integration.spec.ts
+++ b/apps/worker/src/execute-integration.spec.ts
@@ -17,9 +17,23 @@ function signToken(claims: Record<string, any> = {}, expiresIn: string = '2m'): 
   );
 }
 
-function mockPage(): any {
+function mockApiResponse(overrides: Record<string, any> = {}) {
+  return {
+    status: jest.fn().mockReturnValue(200),
+    headers: jest.fn().mockReturnValue({ 'content-type': 'application/json' }),
+    body: jest.fn().mockResolvedValue(Buffer.from('{"via":"context"}')),
+    ...overrides,
+  };
+}
+
+function mockPage(overrides: { contextFetch?: jest.Mock } = {}): any {
+  const contextFetch = overrides.contextFetch
+    ?? jest.fn().mockResolvedValue(mockApiResponse());
   return {
     evaluate: jest.fn().mockResolvedValue({ status: 200, headers: {}, body: 'ok' }),
+    // Cross-origin / CSP-refused fetches are served off-page through the
+    // BrowserContext's APIRequestContext, which shares its cookie jar.
+    context: jest.fn().mockReturnValue({ request: { fetch: contextFetch } }),
     goto: jest.fn().mockResolvedValue(undefined),
     url: jest.fn().mockReturnValue('https://example.com'),
     title: jest.fn().mockResolvedValue('Example'),
@@ -188,8 +202,9 @@ describe('execute handlers (integration)', () => {
     });
 
     it('returns 200 with page.evaluate result for valid request', async () => {
+      // Same-origin as page.url() so this still exercises the in-page path.
       const res = await request(server, 'POST', '/execute/fetch', {
-        url: 'https://api.example.com/data',
+        url: 'https://example.com/data',
         method: 'GET',
       }, auth());
       expect(res.status).toBe(200);
@@ -198,10 +213,14 @@ describe('execute handlers (integration)', () => {
       expect(page.evaluate).toHaveBeenCalled();
     });
 
-    it('returns 502 when page.evaluate throws', async () => {
+    it('returns 502 only when both the in-page and off-page fetches fail', async () => {
+      // A failed in-page fetch now retries through the BrowserContext (CSP /
+      // service-worker refusals are recoverable there), so 502 means both failed.
       page.evaluate.mockRejectedValueOnce(new Error('page crashed'));
+      (page.context().request.fetch as jest.Mock)
+        .mockRejectedValueOnce(new Error('context unreachable'));
       const res = await request(server, 'POST', '/execute/fetch', {
-        url: 'https://api.example.com/data',
+        url: 'https://example.com/data',
       }, auth());
       expect(res.status).toBe(502);
       expect(res.body.error).toMatch(/Browser fetch failed/);
@@ -216,7 +235,7 @@ describe('execute handlers (integration)', () => {
         truncated: false,
       });
       const res = await request(server, 'POST', '/execute/fetch', {
-        url: 'https://api.example.com/statement.pdf',
+        url: 'https://example.com/statement.pdf',
       }, auth());
       expect(res.status).toBe(200);
       expect(res.body.encoding).toBe('base64');
@@ -284,6 +303,78 @@ describe('execute handlers (integration)', () => {
       expect(res.status).toBe(200);
       expect(res.body.success).toBe(false);
       expect(res.body.error).toMatch(/not allowed/);
+    });
+  });
+
+
+  // ─── Cross-origin routing ────────────────────────────────────────
+
+  describe('cross-origin routing', () => {
+    // An in-page fetch() carries the page's origin, so a target that sends no CORS
+    // headers fails as "TypeError: Failed to fetch" even with a perfectly valid
+    // session. Multi-origin apps are the norm for bank portals (ICICI serves its
+    // dashboard from retailnetbanking.icici.bank.in and its statement APIs from
+    // infinity.icici.bank.in), so those calls must go off-page through the
+    // BrowserContext, which shares cookies but attaches no origin.
+    let contextFetch: jest.Mock;
+
+    beforeEach(() => {
+      contextFetch = page.context().request.fetch as jest.Mock;
+      contextFetch.mockReset();
+      contextFetch.mockResolvedValue(mockApiResponse());
+      (page.evaluate as jest.Mock).mockReset();
+      (page.evaluate as jest.Mock).mockResolvedValue({
+        status: 200, headers: {}, body: 'in-page', encoding: 'utf-8', truncated: false,
+      });
+      (page.url as jest.Mock).mockReturnValue('https://example.com/dashboard');
+    });
+
+    it('routes a cross-origin target off-page so CORS cannot block it', async () => {
+      const res = await request(
+        server, 'POST', '/execute/fetch',
+        { url: 'https://other-host.example/v1/statement' },
+        { Authorization: `Bearer ${signToken()}` },
+      );
+      expect(res.status).toBe(200);
+      expect(contextFetch).toHaveBeenCalledTimes(1);
+      expect(page.evaluate).not.toHaveBeenCalled();
+      expect(res.body.body).toBe('{"via":"context"}');
+    });
+
+    it('keeps same-origin calls in the page so JS interceptors still run', async () => {
+      const res = await request(
+        server, 'POST', '/execute/fetch',
+        { url: 'https://example.com/dashboardAPI/summary' },
+        { Authorization: `Bearer ${signToken()}` },
+      );
+      expect(res.status).toBe(200);
+      expect(page.evaluate).toHaveBeenCalledTimes(1);
+      expect(contextFetch).not.toHaveBeenCalled();
+      expect(res.body.body).toBe('in-page');
+    });
+
+    it('falls back off-page when a same-origin fetch is refused (CSP, service worker)', async () => {
+      (page.evaluate as jest.Mock).mockRejectedValue(new Error('TypeError: Failed to fetch'));
+      const res = await request(
+        server, 'POST', '/execute/fetch',
+        { url: 'https://example.com/dashboardAPI/summary' },
+        { Authorization: `Bearer ${signToken()}` },
+      );
+      expect(res.status).toBe(200);
+      expect(contextFetch).toHaveBeenCalledTimes(1);
+      expect(res.body.body).toBe('{"via":"context"}');
+    });
+
+    it('reports the target status instead of throwing on 4xx', async () => {
+      // Callers need to see a 401/403 to react to it; failOnStatusCode must stay off.
+      contextFetch.mockResolvedValue(mockApiResponse({ status: jest.fn().mockReturnValue(403) }));
+      const res = await request(
+        server, 'POST', '/execute/fetch',
+        { url: 'https://other-host.example/v1/statement' },
+        { Authorization: `Bearer ${signToken()}` },
+      );
+      expect(res.status).toBe(200);
+      expect(res.body.status).toBe(403);
     });
   });
 });

--- a/apps/worker/src/health-predicate-runner.spec.ts
+++ b/apps/worker/src/health-predicate-runner.spec.ts
@@ -32,6 +32,46 @@ function runner(page: any, check: Record<string, unknown>) {
   return new HealthPredicateRunner(page, CONTEXT, { health_checks: [check], policy: 'all' });
 }
 
+/** Page + context stubs for url_check: page.url() is the LIVE browser URL; the
+ *  APIRequestContext GET returns a fixed 200 (the SPA shell, served on every
+ *  route regardless of auth). */
+function makeUrlCheckPage(liveUrl: string) {
+  const page = { url: jest.fn().mockReturnValue(liveUrl) } as any;
+  const context = {
+    request: {
+      get: jest.fn(async () => ({ url: () => liveUrl, status: () => 200 })),
+    },
+  } as any;
+  return { page, context };
+}
+
+describe('HealthPredicateRunner — url_check live-page detection', () => {
+  const CHECK = {
+    type: 'url_check',
+    url: 'https://bank.test/credit-card',
+    expect_status: 200,
+    auth_redirect_pattern: '/login|/session-expire|/logout',
+  };
+
+  it('AUTH_FAIL when the live browser is on an auth/expiry URL, even though the HTTP probe 200s', async () => {
+    // The ICICI case: SPA route-changed the browser to /session-expire client-
+    // side, but the server still serves the shell with 200 on every route, so
+    // the APIRequestContext GET alone would wrongly PASS.
+    const { page, context } = makeUrlCheckPage('https://bank.test/session-expire');
+    const r = new HealthPredicateRunner(page, context, { health_checks: [CHECK], policy: 'all' });
+    const res = await r.evaluate();
+    expect(res.checks[0].result).toBe(HealthResultType.AUTH_FAIL);
+    expect(res.checks[0].detail).toMatch(/Live page is on an auth/);
+  });
+
+  it('PASS when the live page is on a normal authenticated route', async () => {
+    const { page, context } = makeUrlCheckPage('https://bank.test/credit-card');
+    const r = new HealthPredicateRunner(page, context, { health_checks: [CHECK], policy: 'all' });
+    const res = await r.evaluate();
+    expect(res.checks[0].result).toBe(HealthResultType.PASS);
+  });
+});
+
 describe('HealthPredicateRunner — dom_check', () => {
   it('passes when an expected selector is present', async () => {
     const res = await runner(makePage(true), {

--- a/apps/worker/src/health-predicate-runner.spec.ts
+++ b/apps/worker/src/health-predicate-runner.spec.ts
@@ -128,4 +128,40 @@ describe('HealthPredicateRunner — dom_check', () => {
       expect.objectContaining({ state: 'detached' }),
     );
   });
+
+  // DOM presence is right for SPA portals, but it silently redefined `exists`
+  // for every stored config: a portal that HIDES rather than unmounts its
+  // logged-in chrome on sign-out keeps the marker attached on the login page, so
+  // 'attached' reports PASS on a dead session and it never reaches LOGIN_NEEDED.
+  // `match: 'visible'` is the opt-out for those.
+  it('honors match:visible as an opt-out to strict CSS visibility', async () => {
+    const page = makePage(true);
+    await runner(page, {
+      type: 'dom_check', selector: '#x', exists: true, match: 'visible',
+    }).evaluate();
+    expect(page.locator().first().waitFor).toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'visible' }),
+    );
+  });
+
+  // Under strict visibility, "the logged-out marker is gone" means Playwright's
+  // 'hidden' (detached OR present-but-invisible) — which is what the comment at
+  // the top of runDomCheck always claimed, while the code used 'detached'.
+  it('uses hidden (not detached) for a negative check under match:visible', async () => {
+    const page = makePage(false);
+    await runner(page, {
+      type: 'dom_check', selector: '#x', exists: false, match: 'visible',
+    }).evaluate();
+    expect(page.locator().first().waitFor).toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'hidden' }),
+    );
+  });
+
+  it('reports which mode failed so a false AUTH_FAIL is diagnosable', async () => {
+    const res = await runner(makePage(false), {
+      type: 'dom_check', selector: '#dashboard', exists: true, match: 'visible',
+    }).evaluate();
+    expect(res.checks[0].result).toBe(HealthResultType.AUTH_FAIL);
+    expect(res.checks[0].detail).toMatch(/not visible/);
+  });
 });

--- a/apps/worker/src/health-predicate-runner.spec.ts
+++ b/apps/worker/src/health-predicate-runner.spec.ts
@@ -165,3 +165,72 @@ describe('HealthPredicateRunner — dom_check', () => {
     expect(res.checks[0].detail).toMatch(/not visible/);
   });
 });
+
+/**
+ * A dom_check that could not be EVALUATED is not evidence about authentication.
+ *
+ * Every failure used to map to AUTH_FAIL, which is not a neutral verdict: it
+ * drives the session to LOGIN_NEEDED, raises HITL and shows a human a sign-in
+ * card. These three classes say nothing about whether anyone is signed in.
+ */
+describe('HealthPredicateRunner — dom_check cannot claim AUTH_FAIL on its own failure', () => {
+  function pageThatThrows(message: string) {
+    return {
+      locator: jest.fn().mockReturnValue({
+        first: jest.fn().mockReturnValue({
+          waitFor: jest.fn(async () => {
+            throw new Error(message);
+          }),
+        }),
+      }),
+      url: jest.fn().mockReturnValue('https://app.test/dashboard'),
+    } as any;
+  }
+
+  it('reports TRANSIENT_FAIL when the page navigated out from under the locator', async () => {
+    const res = await runner(
+      pageThatThrows('Execution context was destroyed, most likely because of a navigation.'),
+      { type: 'dom_check', selector: '#dashboard', exists: true },
+    ).evaluate();
+    expect(res.checks[0].result).toBe(HealthResultType.TRANSIENT_FAIL);
+    expect(res.checks[0].detail).toMatch(/raced a navigation/);
+  });
+
+  it('reports TRANSIENT_FAIL when the page is closed (pod teardown)', async () => {
+    // Otherwise the worker writes a final AUTH_FAIL on its way out and leaves
+    // the session looking signed out to everyone downstream.
+    const res = await runner(
+      pageThatThrows('Target page, context or browser has been closed'),
+      { type: 'dom_check', selector: '#dashboard', exists: true },
+    ).evaluate();
+    expect(res.checks[0].result).toBe(HealthResultType.TRANSIENT_FAIL);
+  });
+
+  it('reports TRANSIENT_FAIL when the configured selector is malformed', async () => {
+    // The worst shape of this bug: one typo in an app's health_checks turned
+    // every session for that app permanently "signed out", silently.
+    const res = await runner(
+      pageThatThrows('Unexpected token "=" while parsing selector "[data-test-id=value]"'),
+      { type: 'dom_check', selector: '[data-test-id=value]', exists: true },
+    ).evaluate();
+    expect(res.checks[0].result).toBe(HealthResultType.TRANSIENT_FAIL);
+    expect(res.checks[0].detail).toMatch(/fix the app's health_checks config/);
+  });
+
+  it('still reports AUTH_FAIL on a plain timeout — the marker really is gone', async () => {
+    // The carve-outs above must not swallow the genuine signed-out verdict.
+    const res = await runner(
+      pageThatThrows('Timeout 5000ms exceeded waiting for locator("#dashboard")'),
+      { type: 'dom_check', selector: '#dashboard', exists: true },
+    ).evaluate();
+    expect(res.checks[0].result).toBe(HealthResultType.AUTH_FAIL);
+  });
+
+  it('applies the same classification to negative checks', async () => {
+    const res = await runner(
+      pageThatThrows('Execution context was destroyed, most likely because of a navigation.'),
+      { type: 'dom_check', selector: 'text=Sign in', exists: false },
+    ).evaluate();
+    expect(res.checks[0].result).toBe(HealthResultType.TRANSIENT_FAIL);
+  });
+});

--- a/apps/worker/src/health-predicate-runner.spec.ts
+++ b/apps/worker/src/health-predicate-runner.spec.ts
@@ -1,0 +1,80 @@
+import { HealthPredicateRunner } from './health-predicate-runner';
+import { HealthResultType } from '@browser-hitl/shared';
+
+/**
+ * Page stub whose locator resolves waitFor() per requested state.
+ *
+ * `present` models whether the selector is on the page: Playwright resolves
+ * `state: 'visible'` only when it is, and `state: 'hidden'` only when it is not
+ * (detached counts as hidden).
+ */
+function makePage(present: boolean) {
+  return {
+    locator: jest.fn().mockReturnValue({
+      waitFor: jest.fn(async ({ state }: { state?: string }) => {
+        const wanted = state === 'hidden' ? !present : present;
+        if (!wanted) throw new Error('Timeout waiting for selector');
+      }),
+    }),
+    url: jest.fn().mockReturnValue('https://app.test/dashboard'),
+  } as any;
+}
+
+const CONTEXT = { request: {} } as any;
+
+function runner(page: any, check: Record<string, unknown>) {
+  return new HealthPredicateRunner(page, CONTEXT, { health_checks: [check], policy: 'all' });
+}
+
+describe('HealthPredicateRunner — dom_check', () => {
+  it('passes when an expected selector is present', async () => {
+    const res = await runner(makePage(true), {
+      type: 'dom_check', selector: '#dashboard', exists: true,
+    }).evaluate();
+    expect(res.checks[0].result).toBe(HealthResultType.PASS);
+  });
+
+  it('fails when an expected selector is missing', async () => {
+    const res = await runner(makePage(false), {
+      type: 'dom_check', selector: '#dashboard', exists: true,
+    }).evaluate();
+    expect(res.checks[0].result).toBe(HealthResultType.AUTH_FAIL);
+  });
+
+  // The regression this file exists for.
+  //
+  // `exists: false` asserts the selector is ABSENT — the way to say "the
+  // logged-out marker is gone". The old implementation always waited for the
+  // element to appear and mapped the resulting timeout to AUTH_FAIL, so the
+  // passing condition reported failure and a negative check could never pass.
+  // That left no way to detect "signed out" on an SPA portal, where every route
+  // returns 200 whether or not anyone is authenticated.
+  it('passes when a selector asserted absent really is absent', async () => {
+    const res = await runner(makePage(false), {
+      type: 'dom_check', selector: 'text=Please click the login button', exists: false,
+    }).evaluate();
+    expect(res.checks[0].result).toBe(HealthResultType.PASS);
+  });
+
+  it('fails when a selector asserted absent is present', async () => {
+    const res = await runner(makePage(true), {
+      type: 'dom_check', selector: 'text=Please click the login button', exists: false,
+    }).evaluate();
+    expect(res.checks[0].result).toBe(HealthResultType.AUTH_FAIL);
+    expect(res.checks[0].detail).toMatch(/found/);
+  });
+
+  it('waits for the right Playwright state in each mode', async () => {
+    const page = makePage(true);
+    await runner(page, { type: 'dom_check', selector: '#x', exists: true }).evaluate();
+    expect(page.locator().waitFor).toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'visible' }),
+    );
+
+    const page2 = makePage(false);
+    await runner(page2, { type: 'dom_check', selector: '#x', exists: false }).evaluate();
+    expect(page2.locator().waitFor).toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'hidden' }),
+    );
+  });
+});

--- a/apps/worker/src/health-predicate-runner.spec.ts
+++ b/apps/worker/src/health-predicate-runner.spec.ts
@@ -11,9 +11,13 @@ import { HealthResultType } from '@browser-hitl/shared';
 function makePage(present: boolean) {
   return {
     locator: jest.fn().mockReturnValue({
-      waitFor: jest.fn(async ({ state }: { state?: string }) => {
-        const wanted = state === 'hidden' ? !present : present;
-        if (!wanted) throw new Error('Timeout waiting for selector');
+      // .first() is what the runner actually waits on — a bare locator throws a
+      // strict-mode violation when the selector matches several nodes.
+      first: jest.fn().mockReturnValue({
+        waitFor: jest.fn(async ({ state }: { state?: string }) => {
+          const wanted = state === 'hidden' ? !present : present;
+          if (!wanted) throw new Error('Timeout waiting for selector');
+        }),
       }),
     }),
     url: jest.fn().mockReturnValue('https://app.test/dashboard'),
@@ -61,19 +65,19 @@ describe('HealthPredicateRunner — dom_check', () => {
       type: 'dom_check', selector: 'text=Please click the login button', exists: false,
     }).evaluate();
     expect(res.checks[0].result).toBe(HealthResultType.AUTH_FAIL);
-    expect(res.checks[0].detail).toMatch(/found/);
+    expect(res.checks[0].detail).toMatch(/still visible/);
   });
 
   it('waits for the right Playwright state in each mode', async () => {
     const page = makePage(true);
     await runner(page, { type: 'dom_check', selector: '#x', exists: true }).evaluate();
-    expect(page.locator().waitFor).toHaveBeenCalledWith(
+    expect(page.locator().first().waitFor).toHaveBeenCalledWith(
       expect.objectContaining({ state: 'visible' }),
     );
 
     const page2 = makePage(false);
     await runner(page2, { type: 'dom_check', selector: '#x', exists: false }).evaluate();
-    expect(page2.locator().waitFor).toHaveBeenCalledWith(
+    expect(page2.locator().first().waitFor).toHaveBeenCalledWith(
       expect.objectContaining({ state: 'hidden' }),
     );
   });

--- a/apps/worker/src/health-predicate-runner.spec.ts
+++ b/apps/worker/src/health-predicate-runner.spec.ts
@@ -4,9 +4,11 @@ import { HealthResultType } from '@browser-hitl/shared';
 /**
  * Page stub whose locator resolves waitFor() per requested state.
  *
- * `present` models whether the selector is on the page: Playwright resolves
- * `state: 'visible'` only when it is, and `state: 'hidden'` only when it is not
- * (detached counts as hidden).
+ * `present` models whether the selector is in the DOM: Playwright resolves
+ * `state: 'attached'` only when it is, and `state: 'detached'` only when it is
+ * not. The runner deliberately asks about DOM presence rather than CSS
+ * visibility — SPA portals render logged-in chrome that Playwright reports as
+ * hidden, which made signed-in sessions fail.
  */
 function makePage(present: boolean) {
   return {
@@ -15,7 +17,7 @@ function makePage(present: boolean) {
       // strict-mode violation when the selector matches several nodes.
       first: jest.fn().mockReturnValue({
         waitFor: jest.fn(async ({ state }: { state?: string }) => {
-          const wanted = state === 'hidden' ? !present : present;
+          const wanted = state === 'detached' ? !present : present;
           if (!wanted) throw new Error('Timeout waiting for selector');
         }),
       }),
@@ -65,20 +67,25 @@ describe('HealthPredicateRunner — dom_check', () => {
       type: 'dom_check', selector: 'text=Please click the login button', exists: false,
     }).evaluate();
     expect(res.checks[0].result).toBe(HealthResultType.AUTH_FAIL);
-    expect(res.checks[0].detail).toMatch(/still visible/);
+    expect(res.checks[0].detail).toMatch(/still in DOM/);
   });
 
-  it('waits for the right Playwright state in each mode', async () => {
+  // Regression: asking for 'visible' made a fully signed-in ICICI dashboard
+  // report AUTH_FAIL — Playwright resolved its sidebar link to
+  // "hidden <a class=\"mb-0\">Payment & Transfer</a>" 20 times in a row while the
+  // user was looking at it on screen. The check is named `exists`; DOM presence
+  // is what it must test.
+  it('tests DOM presence, not CSS visibility', async () => {
     const page = makePage(true);
     await runner(page, { type: 'dom_check', selector: '#x', exists: true }).evaluate();
     expect(page.locator().first().waitFor).toHaveBeenCalledWith(
-      expect.objectContaining({ state: 'visible' }),
+      expect.objectContaining({ state: 'attached' }),
     );
 
     const page2 = makePage(false);
     await runner(page2, { type: 'dom_check', selector: '#x', exists: false }).evaluate();
     expect(page2.locator().first().waitFor).toHaveBeenCalledWith(
-      expect.objectContaining({ state: 'hidden' }),
+      expect.objectContaining({ state: 'detached' }),
     );
   });
 });

--- a/apps/worker/src/health-predicate-runner.ts
+++ b/apps/worker/src/health-predicate-runner.ts
@@ -166,6 +166,9 @@ export class HealthPredicateRunner {
 
   /**
    * DOM check: verify selector exists on current page (spec section 9.9).
+   *
+   * Note the failure classification below (`classifyDomCheckError`): a dom_check
+   * that could not be *evaluated* is not evidence about authentication.
    */
   private async runDomCheck(check: any): Promise<{ result: HealthResultType; detail?: string }> {
     const locator = this.page.locator(check.selector);
@@ -212,6 +215,8 @@ export class HealthPredicateRunner {
         await first.waitFor({ state: strictVisibility ? 'visible' : 'attached', timeout });
         return { result: HealthResultType.PASS };
       } catch (error) {
+        const unevaluable = classifyDomCheckError(error);
+        if (unevaluable) return unevaluable;
         return {
           result: HealthResultType.AUTH_FAIL,
           detail: strictVisibility
@@ -229,6 +234,8 @@ export class HealthPredicateRunner {
       await first.waitFor({ state: strictVisibility ? 'hidden' : 'detached', timeout });
       return { result: HealthResultType.PASS };
     } catch (error) {
+      const unevaluable = classifyDomCheckError(error);
+      if (unevaluable) return unevaluable;
       // Report WHY. A bare "found" hid the difference between the marker really
       // being on the page and the check itself misfiring.
       return {
@@ -272,4 +279,64 @@ export class HealthPredicateRunner {
       return { result: HealthResultType.TRANSIENT_FAIL, detail: `Request error: ${error}` };
     }
   }
+}
+
+/**
+ * Separate "the marker is not there" from "the check could not be run".
+ *
+ * Every failure inside runDomCheck used to map to AUTH_FAIL, which conflates a
+ * genuine timeout (the logged-in marker really is gone — signed out, the verdict
+ * we want) with failures that say nothing at all about authentication:
+ *
+ *   - the page navigated while the locator was resolving, so the execution
+ *     context was destroyed under it. Common on any portal that redirects or
+ *     re-renders on a timer, and on every SPA route change.
+ *   - the page/context/browser closed, i.e. the pod is shutting down. This wrote
+ *     a final AUTH_FAIL on the way out and left the session looking signed out.
+ *   - the selector itself is malformed. A typo in a profile's health_checks
+ *     turned every session for that app permanently "signed out" — the worst
+ *     shape of this bug, because it is silent, total, and looks like a real auth
+ *     failure to everyone downstream.
+ *
+ * AUTH_FAIL is not a neutral verdict: it drives the session to LOGIN_NEEDED,
+ * raises HITL, and shows a human a sign-in card. Claiming it on no evidence is
+ * strictly worse than admitting the check did not run, which is what
+ * TRANSIENT_FAIL means and which the caller already handles.
+ *
+ * Returns null when the error is NOT one of these — so an unrecognised error
+ * keeps the previous AUTH_FAIL behaviour rather than silently becoming
+ * TRANSIENT_FAIL. A plain Playwright timeout is the overwhelmingly common case
+ * and must stay AUTH_FAIL; this only carves out the classes we can positively
+ * identify as uninformative.
+ */
+export function classifyDomCheckError(
+  error: unknown,
+): { result: HealthResultType; detail: string } | null {
+  const message = error instanceof Error ? error.message : String(error);
+
+  // Page moved (navigation / SPA re-render) while the locator was resolving.
+  if (/execution context was destroyed|because of a navigation|frame (was |got )?detached/i.test(message)) {
+    return {
+      result: HealthResultType.TRANSIENT_FAIL,
+      detail: `dom_check raced a navigation, no auth signal: ${message}`,
+    };
+  }
+
+  // Pod teardown, or the browser died.
+  if (/target (page, context or browser )?(has been )?closed|browser has been closed|page has been closed|target closed/i.test(message)) {
+    return {
+      result: HealthResultType.TRANSIENT_FAIL,
+      detail: `dom_check ran against a closed page, no auth signal: ${message}`,
+    };
+  }
+
+  // Malformed selector in the app's health_checks config.
+  if (/not a valid selector|while parsing selector|failed to parse selector|unknown engine/i.test(message)) {
+    return {
+      result: HealthResultType.TRANSIENT_FAIL,
+      detail: `dom_check selector is invalid — fix the app's health_checks config: ${message}`,
+    };
+  }
+
+  return null;
 }

--- a/apps/worker/src/health-predicate-runner.ts
+++ b/apps/worker/src/health-predicate-runner.ts
@@ -64,6 +64,14 @@ export class HealthPredicateRunner {
         detail,
         duration_ms: Date.now() - start,
       });
+
+      // A failing health check drives the whole session lifecycle (AUTH_FAIL ->
+      // LOGIN_NEEDED, and every consumer that reads session health), so the reason
+      // must be visible in the pod log. Debugging a wrong verdict without it means
+      // guessing at the selector.
+      if (result !== HealthResultType.PASS) {
+        console.log(`[Health] ${check.type} -> ${result}${detail ? `: ${detail}` : ''}`);
+      }
     }
 
     const overall = evaluateHealthPolicy(results, policy, quorumN);
@@ -152,20 +160,35 @@ export class HealthPredicateRunner {
     // Wait for the state each mode actually wants. Playwright's 'hidden' resolves
     // when the element is detached OR present-but-invisible, which is what "not
     // showing the logged-out marker" means in practice.
+    // .first() throughout: a selector matching several nodes (very easy with a
+    // text= selector on a rich page) makes a bare locator.waitFor throw a strict-mode
+    // violation, and the catch below cannot tell that apart from the element genuinely
+    // being there — so a logged-IN page reported AUTH_FAIL. Matching the first node is
+    // the right semantics for a presence check anyway.
+    const first = locator.first();
+
     if (check.exists) {
       try {
-        await locator.waitFor({ state: 'visible', timeout });
+        await first.waitFor({ state: 'visible', timeout });
         return { result: HealthResultType.PASS };
-      } catch {
-        return { result: HealthResultType.AUTH_FAIL, detail: `Selector ${check.selector} not found` };
+      } catch (error) {
+        return {
+          result: HealthResultType.AUTH_FAIL,
+          detail: `Selector ${check.selector} not visible: ${error}`,
+        };
       }
     }
 
     try {
-      await locator.waitFor({ state: 'hidden', timeout });
+      await first.waitFor({ state: 'hidden', timeout });
       return { result: HealthResultType.PASS };
-    } catch {
-      return { result: HealthResultType.AUTH_FAIL, detail: `Selector ${check.selector} found` };
+    } catch (error) {
+      // Report WHY. A bare "found" hid the difference between the marker really
+      // being on the page and the check itself misfiring.
+      return {
+        result: HealthResultType.AUTH_FAIL,
+        detail: `Selector ${check.selector} still visible: ${error}`,
+      };
     }
   }
 

--- a/apps/worker/src/health-predicate-runner.ts
+++ b/apps/worker/src/health-predicate-runner.ts
@@ -189,38 +189,53 @@ export class HealthPredicateRunner {
     // the right semantics for a presence check anyway.
     const first = locator.first();
 
-    // attached/detached, NOT visible/hidden. The check is named `exists`, and DOM
-    // presence is what it should mean — CSS visibility is a different question that
-    // SPA portals answer badly. Playwright reports the sidebar link of a fully
-    // logged-in ICICI dashboard as hidden:
+    // What `exists` means is selectable via `match`, defaulting to DOM presence:
     //
-    //   20 x locator resolved to hidden <a class="mb-0">Payment & Transfer</a>
+    //   'attached' (default) — the marker is in the DOM at all. CSS visibility is
+    //     a different question that SPA portals answer badly: Playwright reports
+    //     the sidebar link of a fully logged-in ICICI dashboard as hidden
+    //     (`20 x locator resolved to hidden <a class="mb-0">Payment & Transfer</a>`),
+    //     so a signed-in session reported AUTH_FAIL. Salesforce Lightning and
+    //     Workday do the same (see the gotchas in CLAUDE.md); it is the single
+    //     most common cause of a false AUTH_FAIL on this platform.
     //
-    // ...so a signed-in session reported AUTH_FAIL. Salesforce Lightning and
-    // Workday do the same thing (see the gotchas in CLAUDE.md); it is the single
-    // most common cause of a false AUTH_FAIL on this platform. A marker rendered
-    // into the DOM at all is the signal worth having.
+    //   'visible' — opt back in to strict CSS visibility. Needed by portals that
+    //     HIDE rather than unmount their logged-in chrome on sign-out: there the
+    //     marker stays attached on the login page, so 'attached' would report
+    //     PASS on a dead session and it would never transition to LOGIN_NEEDED.
+    //     Opt-in rather than default, because defaulting to it reintroduces the
+    //     dominant false-AUTH_FAIL above for every SPA app.
+    const strictVisibility = check.match === 'visible';
+
     if (check.exists) {
       try {
-        await first.waitFor({ state: 'attached', timeout });
+        await first.waitFor({ state: strictVisibility ? 'visible' : 'attached', timeout });
         return { result: HealthResultType.PASS };
       } catch (error) {
         return {
           result: HealthResultType.AUTH_FAIL,
-          detail: `Selector ${check.selector} not in DOM: ${error}`,
+          detail: strictVisibility
+            ? `Selector ${check.selector} not visible: ${error}`
+            : `Selector ${check.selector} not in DOM: ${error}`,
         };
       }
     }
 
+    // Negative check: assert the logged-OUT marker is gone. Mirror the mode —
+    // under strict visibility "gone" means Playwright's 'hidden' (detached OR
+    // present-but-invisible), which is what "not showing the marker" means to a
+    // user; under DOM presence it means fully detached.
     try {
-      await first.waitFor({ state: 'detached', timeout });
+      await first.waitFor({ state: strictVisibility ? 'hidden' : 'detached', timeout });
       return { result: HealthResultType.PASS };
     } catch (error) {
       // Report WHY. A bare "found" hid the difference between the marker really
       // being on the page and the check itself misfiring.
       return {
         result: HealthResultType.AUTH_FAIL,
-        detail: `Selector ${check.selector} still in DOM: ${error}`,
+        detail: strictVisibility
+          ? `Selector ${check.selector} still showing: ${error}`
+          : `Selector ${check.selector} still in DOM: ${error}`,
       };
     }
   }

--- a/apps/worker/src/health-predicate-runner.ts
+++ b/apps/worker/src/health-predicate-runner.ts
@@ -138,22 +138,34 @@ export class HealthPredicateRunner {
    * DOM check: verify selector exists on current page (spec section 9.9).
    */
   private async runDomCheck(check: any): Promise<{ result: HealthResultType; detail?: string }> {
+    const locator = this.page.locator(check.selector);
+    const timeout = check.timeout_ms ?? 5000;
+
+    // `exists: false` asserts the selector is ABSENT — which is the whole point of
+    // a negative check: assert the logged-out marker (a login form, an auth error
+    // page) is gone. The previous implementation always waited for the element to
+    // appear and treated the resulting timeout as AUTH_FAIL, so an absent selector
+    // — the passing condition — reported failure. A negative check could therefore
+    // never pass, and the only way to detect "signed out" on an SPA portal was
+    // unavailable.
+    //
+    // Wait for the state each mode actually wants. Playwright's 'hidden' resolves
+    // when the element is detached OR present-but-invisible, which is what "not
+    // showing the logged-out marker" means in practice.
+    if (check.exists) {
+      try {
+        await locator.waitFor({ state: 'visible', timeout });
+        return { result: HealthResultType.PASS };
+      } catch {
+        return { result: HealthResultType.AUTH_FAIL, detail: `Selector ${check.selector} not found` };
+      }
+    }
+
     try {
-      const locator = this.page.locator(check.selector);
-      await locator.waitFor({ timeout: 5000 });
-
-      const visible = await locator.isVisible();
-      if (check.exists && visible) {
-        return { result: HealthResultType.PASS };
-      }
-      if (!check.exists && !visible) {
-        return { result: HealthResultType.PASS };
-      }
-
-      return { result: HealthResultType.AUTH_FAIL, detail: `Selector ${check.exists ? 'not found' : 'found'}` };
+      await locator.waitFor({ state: 'hidden', timeout });
+      return { result: HealthResultType.PASS };
     } catch {
-      // Timeout or page loading
-      return { result: HealthResultType.AUTH_FAIL, detail: `Selector ${check.selector} not found` };
+      return { result: HealthResultType.AUTH_FAIL, detail: `Selector ${check.selector} found` };
     }
   }
 

--- a/apps/worker/src/health-predicate-runner.ts
+++ b/apps/worker/src/health-predicate-runner.ts
@@ -91,6 +91,28 @@ export class HealthPredicateRunner {
   private async runUrlCheck(check: any): Promise<{ result: HealthResultType; detail?: string }> {
     const timeoutMs = check.timeout_ms ?? 15000;
 
+    // Where the LIVE browser actually is, checked FIRST. An SPA enforces session
+    // expiry client-side: the JS detects a dead session and route-changes to a
+    // /session-expire page, but the server still serves the app shell with HTTP
+    // 200 on every route. So the APIRequestContext GET below can't see it — it
+    // gets 200 and PASSes while the user is staring at "Your session has
+    // expired" (observed on ICICI: HEALTHY/PASS on /session-expire). If the
+    // browser page itself is already sitting on an auth/expiry URL, that is
+    // ground truth the HTTP probe cannot override.
+    if (check.auth_redirect_pattern) {
+      try {
+        const liveUrl = this.page.url();
+        if (new RegExp(check.auth_redirect_pattern, 'i').test(liveUrl)) {
+          return {
+            result: HealthResultType.AUTH_FAIL,
+            detail: `Live page is on an auth/expiry URL: ${liveUrl}`,
+          };
+        }
+      } catch {
+        // page.url() should never throw, but never let it break the check.
+      }
+    }
+
     try {
       // Use Playwright's APIRequestContext — it inherits the browser's proxy
       // and cookies, so it can reach external URLs through the egress proxy.

--- a/apps/worker/src/health-predicate-runner.ts
+++ b/apps/worker/src/health-predicate-runner.ts
@@ -167,27 +167,38 @@ export class HealthPredicateRunner {
     // the right semantics for a presence check anyway.
     const first = locator.first();
 
+    // attached/detached, NOT visible/hidden. The check is named `exists`, and DOM
+    // presence is what it should mean — CSS visibility is a different question that
+    // SPA portals answer badly. Playwright reports the sidebar link of a fully
+    // logged-in ICICI dashboard as hidden:
+    //
+    //   20 x locator resolved to hidden <a class="mb-0">Payment & Transfer</a>
+    //
+    // ...so a signed-in session reported AUTH_FAIL. Salesforce Lightning and
+    // Workday do the same thing (see the gotchas in CLAUDE.md); it is the single
+    // most common cause of a false AUTH_FAIL on this platform. A marker rendered
+    // into the DOM at all is the signal worth having.
     if (check.exists) {
       try {
-        await first.waitFor({ state: 'visible', timeout });
+        await first.waitFor({ state: 'attached', timeout });
         return { result: HealthResultType.PASS };
       } catch (error) {
         return {
           result: HealthResultType.AUTH_FAIL,
-          detail: `Selector ${check.selector} not visible: ${error}`,
+          detail: `Selector ${check.selector} not in DOM: ${error}`,
         };
       }
     }
 
     try {
-      await first.waitFor({ state: 'hidden', timeout });
+      await first.waitFor({ state: 'detached', timeout });
       return { result: HealthResultType.PASS };
     } catch (error) {
       // Report WHY. A bare "found" hid the difference between the marker really
       // being on the page and the check itself misfiring.
       return {
         result: HealthResultType.AUTH_FAIL,
-        detail: `Selector ${check.selector} still visible: ${error}`,
+        detail: `Selector ${check.selector} still in DOM: ${error}`,
       };
     }
   }

--- a/apps/worker/src/keepalive-runner.spec.ts
+++ b/apps/worker/src/keepalive-runner.spec.ts
@@ -1,0 +1,72 @@
+import { KeepaliveRunner } from './keepalive-runner';
+
+// Drive runCycle() directly with mocked deps to assert the HEALTHY-gate on the
+// 'activity' nudge: robotic mouse/scroll must not run once the session is on a
+// login/expired page (health != PASS), or reCAPTCHA v3 scores it as a bot.
+function build(healthSeq: string[]) {
+  let i = 0;
+  const execCalls: any[][] = [];
+  const dslRunner = {
+    execute: jest.fn(async (actions: any[]) => {
+      execCalls.push(actions);
+    }),
+  };
+  const healthRunner = {
+    evaluate: jest.fn(async () => ({
+      overall: healthSeq[Math.min(i++, healthSeq.length - 1)],
+      checks: [],
+    })),
+    setKeepaliveConfig: jest.fn(),
+  };
+  const page = { waitForTimeout: jest.fn(async () => undefined) };
+  const db = {
+    loadAppConfig: jest.fn(async () => null), // keep the constructor's appConfig
+    updateHealthResult: jest.fn(async () => undefined),
+    getLastExportedAt: jest.fn(async () => new Date().toISOString()), // fresh → no extract
+    updateLastExportedAt: jest.fn(async () => undefined),
+  };
+  const artifactExtractor = { extractAndUpload: jest.fn(async () => undefined) };
+  const appConfig = {
+    keepalive_config: { interval_seconds: 60, actions: [{ action: 'activity' }] },
+    export_policy: { refresh_interval_seconds: 3600 },
+  };
+  const runner = new KeepaliveRunner(
+    page as any,
+    {} as any,
+    dslRunner as any,
+    healthRunner as any,
+    artifactExtractor as any,
+    db as any,
+    appConfig,
+    'app-1',
+    'sess-1',
+    { username: '', password: '' },
+    false,
+  );
+  return { runner, execCalls, dslRunner };
+}
+
+describe('KeepaliveRunner activity HEALTHY-gate', () => {
+  it('runs the activity nudge on the first cycle and while the session stays healthy', async () => {
+    const { runner, execCalls } = build(['PASS', 'PASS']);
+    await (runner as any).runCycle(); // lastHealth null → runs
+    await (runner as any).runCycle(); // lastHealth PASS → runs
+    expect(execCalls).toEqual([[{ action: 'activity' }], [{ action: 'activity' }]]);
+  });
+
+  it('stops the activity nudge once the session is no longer PASS (bounced to login)', async () => {
+    const { runner, execCalls, dslRunner } = build(['AUTH_FAIL', 'AUTH_FAIL']);
+    await (runner as any).runCycle(); // lastHealth null → runs once, then records AUTH_FAIL
+    await (runner as any).runCycle(); // lastHealth AUTH_FAIL → 'activity' filtered → no execute
+    expect(dslRunner.execute).toHaveBeenCalledTimes(1);
+    expect(execCalls).toEqual([[{ action: 'activity' }]]);
+  });
+
+  it('resumes the nudge if the session returns to PASS', async () => {
+    const { runner, dslRunner } = build(['AUTH_FAIL', 'PASS', 'PASS']);
+    await (runner as any).runCycle(); // null → runs
+    await (runner as any).runCycle(); // AUTH_FAIL → skips
+    await (runner as any).runCycle(); // PASS → runs again
+    expect(dslRunner.execute).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/worker/src/keepalive-runner.spec.ts
+++ b/apps/worker/src/keepalive-runner.spec.ts
@@ -155,3 +155,60 @@ describe('KeepaliveRunner agent-driven gate', () => {
     expect(dslRunner.execute).not.toHaveBeenCalled(); // but never any actions
   });
 });
+
+/**
+ * The skip cap deliberately lets a cycle through while a command is STILL in
+ * flight, so health cannot stall behind a busy agent. Health is safe to run
+ * there; injected input never is. Neither elapsed-time condition covers this,
+ * which is why the busy check is repeated at the action gate.
+ */
+describe('KeepaliveRunner never injects input on the capped cycle', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    resetAgentActivity();
+  });
+  afterEach(() => {
+    resetAgentActivity();
+    jest.useRealTimers();
+  });
+
+  it('suppresses actions when a single command outlives the keepalive interval', async () => {
+    // A 'navigate' can legitimately run longer than a 60s interval. Once
+    // agentIdleMs passes intervalMs the elapsed check stops firing, so without
+    // the busy check a mouse-move/scroll lands mid-navigation.
+    const { runner, dslRunner, healthRunner } = build(['PASS']);
+    beginAgentCommand(true); // still in flight for every cycle below
+    jest.advanceTimersByTime(61_000); // 61s > 60s interval
+
+    for (let i = 0; i < 4; i++) await (runner as any).runCycle();
+
+    expect(healthRunner.evaluate).toHaveBeenCalledTimes(1); // capped cycle ran health
+    expect(dslRunner.execute).not.toHaveBeenCalled(); // but injected nothing
+  });
+
+  it('suppresses actions during an in-flight read-only command', async () => {
+    // Read-only commands never stamp activity (a screenshot is not a keepalive),
+    // so msSinceAgentActivity() stays Infinity and the elapsed check can never
+    // fire — busy is the only thing standing between the agent and a scroll
+    // landing in the middle of its get_page_summary.
+    const { runner, dslRunner, healthRunner } = build(['PASS']);
+    beginAgentCommand(false); // in flight, but not idle-resetting
+
+    for (let i = 0; i < 4; i++) await (runner as any).runCycle();
+
+    expect(healthRunner.evaluate).toHaveBeenCalledTimes(1);
+    expect(dslRunner.execute).not.toHaveBeenCalled();
+  });
+
+  it('resumes actions once the command finishes and the interval has passed', async () => {
+    const { runner, execCalls } = build(['PASS']);
+    beginAgentCommand(true);
+    jest.advanceTimersByTime(61_000);
+    endAgentCommand(true); // stamps activity on completion
+    jest.advanceTimersByTime(61_000); // idle again for a full interval
+
+    await (runner as any).runCycle();
+
+    expect(execCalls).toEqual([[{ action: 'activity' }]]);
+  });
+});

--- a/apps/worker/src/keepalive-runner.spec.ts
+++ b/apps/worker/src/keepalive-runner.spec.ts
@@ -1,4 +1,5 @@
 import { KeepaliveRunner } from './keepalive-runner';
+import { beginAgentCommand, endAgentCommand, resetAgentActivity } from './agent-activity';
 
 // Drive runCycle() directly with mocked deps to assert the HEALTHY-gate on the
 // 'activity' nudge: robotic mouse/scroll must not run once the session is on a
@@ -43,7 +44,7 @@ function build(healthSeq: string[]) {
     { username: '', password: '' },
     false,
   );
-  return { runner, execCalls, dslRunner };
+  return { runner, execCalls, dslRunner, healthRunner };
 }
 
 describe('KeepaliveRunner activity HEALTHY-gate', () => {
@@ -81,5 +82,76 @@ describe('KeepaliveRunner activity gate is AUTH_FAIL-only', () => {
     await (runner as any).runCycle();
     await (runner as any).runCycle();
     expect(dslRunner.execute).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('KeepaliveRunner agent-driven gate', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    resetAgentActivity();
+  });
+  afterEach(() => {
+    resetAgentActivity();
+    jest.useRealTimers();
+  });
+
+  it('skips keepalive actions when the agent touched the origin within the interval', async () => {
+    // The agent's own click already reset the portal's idle timer, so the nudge
+    // is redundant — and a synthetic scroll can misplace the agent's next click.
+    const { runner, dslRunner } = build(['PASS']);
+    beginAgentCommand(true);
+    endAgentCommand(true);
+    jest.advanceTimersByTime(1_000); // 1s < 60s interval
+
+    await (runner as any).runCycle();
+
+    expect(dslRunner.execute).not.toHaveBeenCalled();
+  });
+
+  it('runs keepalive actions once the agent has been idle longer than the interval', async () => {
+    const { runner, execCalls } = build(['PASS']);
+    beginAgentCommand(true);
+    endAgentCommand(true);
+    jest.advanceTimersByTime(61_000); // 61s > 60s interval
+
+    await (runner as any).runCycle();
+
+    expect(execCalls).toEqual([[{ action: 'activity' }]]);
+  });
+
+  it('does not treat read-only commands as activity (a screenshot is not a keepalive)', async () => {
+    // Mirrors the platform rule that `screenshot` makes no request, so the
+    // portal's idle timer keeps running and the session still needs the nudge.
+    const { runner, execCalls } = build(['PASS']);
+    beginAgentCommand(false);
+    endAgentCommand(false);
+    jest.advanceTimersByTime(1_000);
+
+    await (runner as any).runCycle();
+
+    expect(execCalls).toEqual([[{ action: 'activity' }]]);
+  });
+
+  it('skips the entire cycle, health included, while a command is in flight', async () => {
+    // dom_check mid-navigation cannot find its selector and reports AUTH_FAIL,
+    // which would push a working session to LOGIN_NEEDED and show a sign-in card.
+    const { runner, dslRunner, healthRunner } = build(['PASS']);
+    beginAgentCommand(true); // never ended → still in flight
+
+    await (runner as any).runCycle();
+
+    expect(dslRunner.execute).not.toHaveBeenCalled();
+    expect(healthRunner.evaluate).not.toHaveBeenCalled();
+  });
+
+  it('evaluates health anyway after too many consecutive busy skips', async () => {
+    // Health must not stall forever behind an agent that is always working.
+    const { runner, dslRunner, healthRunner } = build(['PASS']);
+    beginAgentCommand(true); // stays in flight for every cycle below
+
+    for (let i = 0; i < 4; i++) await (runner as any).runCycle();
+
+    expect(healthRunner.evaluate).toHaveBeenCalledTimes(1); // 3 skipped, 4th ran
+    expect(dslRunner.execute).not.toHaveBeenCalled(); // but never any actions
   });
 });

--- a/apps/worker/src/keepalive-runner.spec.ts
+++ b/apps/worker/src/keepalive-runner.spec.ts
@@ -70,3 +70,16 @@ describe('KeepaliveRunner activity HEALTHY-gate', () => {
     expect(dslRunner.execute).toHaveBeenCalledTimes(2);
   });
 });
+
+describe('KeepaliveRunner activity gate is AUTH_FAIL-only', () => {
+  it('keeps nudging through a TRANSIENT_FAIL', async () => {
+    // A 5xx / probe timeout / egress blip does not mean the session is signed
+    // out. Suppressing the nudge there lets the portal's own idle timer run out
+    // and turns a recoverable blip into a real expiry — the outcome 'activity'
+    // exists to prevent. Only a login page (AUTH_FAIL) should stop it.
+    const { runner, dslRunner } = build(['TRANSIENT_FAIL', 'TRANSIENT_FAIL']);
+    await (runner as any).runCycle();
+    await (runner as any).runCycle();
+    expect(dslRunner.execute).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/worker/src/keepalive-runner.ts
+++ b/apps/worker/src/keepalive-runner.ts
@@ -107,11 +107,16 @@ export class KeepaliveRunner {
       // reCAPTCHA v3 / a fingerprint SDK is scoring reads as a bot and tanks the
       // score before the human can re-login. Non-interactive actions (e.g. goto
       // for header capture) are unaffected, and health checks below still run.
-      if (this.lastHealthOverall !== null && this.lastHealthOverall !== 'PASS') {
+      // AUTH_FAIL only, NOT any non-PASS. TRANSIENT_FAIL is a 5xx / probe
+      // timeout / egress blip — the session is still signed in, so suppressing
+      // the nudge there lets the portal's own idle timer run out and converts a
+      // recoverable blip into a real expiry, the exact outcome 'activity' exists
+      // to prevent. The bot-scoring rationale only applies to a login page.
+      if (this.lastHealthOverall === 'AUTH_FAIL') {
         const before = actions.length;
         actions = actions.filter((a: { action?: string }) => a.action !== 'activity');
         if (actions.length < before) {
-          console.log(`Keepalive: skipping 'activity' nudge (last health ${this.lastHealthOverall}, likely on login page)`);
+          console.log(`Keepalive: skipping 'activity' nudge (last health AUTH_FAIL, likely on login page)`);
         }
       }
       if (actions.length > 0) {

--- a/apps/worker/src/keepalive-runner.ts
+++ b/apps/worker/src/keepalive-runner.ts
@@ -5,6 +5,13 @@ import { LoginDslRunner } from './login-dsl-runner';
 import { HealthPredicateRunner } from './health-predicate-runner';
 import { ArtifactExtractor } from './artifact-extractor';
 import { SessionDb } from './session-db';
+import { isAgentBusy, msSinceAgentActivity } from './agent-activity';
+
+// A cycle skipped because an agent command was in flight is retried on the next
+// tick, but health must not go stale forever behind a continuously busy agent.
+// After this many consecutive skips the cycle runs its health checks anyway
+// (still without actions).
+const MAX_CONSECUTIVE_BUSY_SKIPS = 3;
 
 /**
  * Keepalive Runner per spec section 9.9.
@@ -28,6 +35,7 @@ export class KeepaliveRunner {
   // SDKs score the page as a bot before the human can re-login. null until the
   // first cycle's health check (session enters keepalive already logged in).
   private lastHealthOverall: string | null = null;
+  private consecutiveBusySkips = 0;
 
   constructor(
     private readonly page: Page,
@@ -97,10 +105,49 @@ export class KeepaliveRunner {
     this.running = true;
 
     try {
+      // Step 0: Stay out of an agent's way. If a browser command is in flight,
+      // skip the whole cycle — not just the actions. Health checks read the live
+      // page (dom_check resolves a locator, and returns AUTH_FAIL when it cannot
+      // find it) so evaluating mid-navigation reports a signed-in session as
+      // signed out, which drives it to LOGIN_NEEDED and shows the human a
+      // sign-in card in the middle of a working task. The agent's own traffic is
+      // keeping the session alive meanwhile, so there is nothing to lose by
+      // waiting for the next tick.
+      if (isAgentBusy() && this.consecutiveBusySkips < MAX_CONSECUTIVE_BUSY_SKIPS) {
+        this.consecutiveBusySkips += 1;
+        console.log(
+          `Keepalive: agent command in flight, skipping cycle ` +
+            `(${this.consecutiveBusySkips}/${MAX_CONSECUTIVE_BUSY_SKIPS})`,
+        );
+        return;
+      }
+      this.consecutiveBusySkips = 0;
+
       await this.refreshConfig();
 
       // Step 1: Execute keepalive actions (suppressed in recording mode).
       let actions = this.recordingMode ? [] : (this.appConfig.keepalive_config?.actions || []);
+
+      // Agent-driven gate: if the agent touched the origin within the last
+      // keepalive interval, every action here is redundant — its clicks and
+      // navigations already reset the portal's idle timer, which is the only
+      // thing keepalive exists to do. Running anyway is actively harmful: a
+      // synthetic scroll/mouse-move can move an element between the agent's
+      // locator resolution and its click, and a 'goto' reloads the page out from
+      // under a half-finished flow. Robotic input interleaved with real
+      // interaction also reads worse to reCAPTCHA v3 than either alone.
+      // Read-only commands (screenshot, get_page_summary) deliberately do not
+      // count as activity — they make no request, so the idle timer keeps
+      // running and the nudge is still needed.
+      const intervalMs = (this.appConfig.keepalive_config?.interval_seconds || 300) * 1000;
+      const agentIdleMs = msSinceAgentActivity();
+      if (actions.length > 0 && agentIdleMs < intervalMs) {
+        console.log(
+          `Keepalive: skipping ${actions.length} action(s) — agent active ` +
+            `${Math.round(agentIdleMs / 1000)}s ago (interval ${Math.round(intervalMs / 1000)}s)`,
+        );
+        actions = [];
+      }
       // HEALTHY-gate the 'activity' nudge: if the previous cycle found the
       // session NOT healthy (it has likely bounced to the app's login/expired
       // page), skip the trusted mouse-move + scroll — robotic input on a page
@@ -171,7 +218,11 @@ export class KeepaliveRunner {
   }
 
   private async checkExtractRequest(): Promise<void> {
-    if (!this.redis || this.extracting || this.running) return;
+    // Also hold off while an agent command is in flight: extraction navigates
+    // the page when export_policy.extract_urls is configured, which would yank
+    // the agent off whatever it was working on. The request stays in Redis and
+    // is picked up by the next 2s poll.
+    if (!this.redis || this.extracting || this.running || isAgentBusy()) return;
 
     try {
       const key = REDIS_KEYS.extractRequest(this.sessionId);

--- a/apps/worker/src/keepalive-runner.ts
+++ b/apps/worker/src/keepalive-runner.ts
@@ -22,6 +22,12 @@ export class KeepaliveRunner {
   private running = false;
   private extracting = false;
   private redis: Redis | null = null;
+  // Last health verdict, used to gate the human-simulation 'activity' nudge:
+  // once a session bounces to a login/expired page (health != PASS), we must
+  // stop feeding it robotic mouse/scroll input, or reCAPTCHA v3 / fingerprint
+  // SDKs score the page as a bot before the human can re-login. null until the
+  // first cycle's health check (session enters keepalive already logged in).
+  private lastHealthOverall: string | null = null;
 
   constructor(
     private readonly page: Page,
@@ -93,8 +99,21 @@ export class KeepaliveRunner {
     try {
       await this.refreshConfig();
 
-      // Step 1: Execute keepalive actions (suppressed in recording mode)
-      const actions = this.recordingMode ? [] : (this.appConfig.keepalive_config?.actions || []);
+      // Step 1: Execute keepalive actions (suppressed in recording mode).
+      let actions = this.recordingMode ? [] : (this.appConfig.keepalive_config?.actions || []);
+      // HEALTHY-gate the 'activity' nudge: if the previous cycle found the
+      // session NOT healthy (it has likely bounced to the app's login/expired
+      // page), skip the trusted mouse-move + scroll — robotic input on a page
+      // reCAPTCHA v3 / a fingerprint SDK is scoring reads as a bot and tanks the
+      // score before the human can re-login. Non-interactive actions (e.g. goto
+      // for header capture) are unaffected, and health checks below still run.
+      if (this.lastHealthOverall !== null && this.lastHealthOverall !== 'PASS') {
+        const before = actions.length;
+        actions = actions.filter((a: { action?: string }) => a.action !== 'activity');
+        if (actions.length < before) {
+          console.log(`Keepalive: skipping 'activity' nudge (last health ${this.lastHealthOverall}, likely on login page)`);
+        }
+      }
       if (actions.length > 0) {
         try {
           await this.dslRunner.execute(actions, this.credentials);
@@ -108,6 +127,9 @@ export class KeepaliveRunner {
 
       // Step 3-4: Execute health predicates and write results
       const healthResult = await this.healthRunner.evaluate();
+      // Remember the verdict so the NEXT cycle can gate the 'activity' nudge
+      // (see Step 1) — a not-PASS session is likely sitting on a login page.
+      this.lastHealthOverall = healthResult.overall;
       await this.db.updateHealthResult(this.sessionId, healthResult.overall);
 
       console.log(`Health check: ${healthResult.overall} (${healthResult.checks.length} checks)`);

--- a/apps/worker/src/keepalive-runner.ts
+++ b/apps/worker/src/keepalive-runner.ts
@@ -113,7 +113,8 @@ export class KeepaliveRunner {
       // sign-in card in the middle of a working task. The agent's own traffic is
       // keeping the session alive meanwhile, so there is nothing to lose by
       // waiting for the next tick.
-      if (isAgentBusy() && this.consecutiveBusySkips < MAX_CONSECUTIVE_BUSY_SKIPS) {
+      const agentBusy = isAgentBusy();
+      if (agentBusy && this.consecutiveBusySkips < MAX_CONSECUTIVE_BUSY_SKIPS) {
         this.consecutiveBusySkips += 1;
         console.log(
           `Keepalive: agent command in flight, skipping cycle ` +
@@ -139,12 +140,23 @@ export class KeepaliveRunner {
       // Read-only commands (screenshot, get_page_summary) deliberately do not
       // count as activity — they make no request, so the idle timer keeps
       // running and the nudge is still needed.
+      //
+      // `agentBusy` is checked here as well as in Step 0, and is NOT redundant:
+      // reaching this line with a command still in flight is exactly what the
+      // skip cap above allows, and neither of the elapsed-time conditions covers
+      // it. A command running longer than the keepalive interval pushes
+      // agentIdleMs past intervalMs, and a read-only command never stamps
+      // activity at all (msSinceAgentActivity() stays Infinity), so the elapsed
+      // check would wave both through and fire a mouse-move into the middle of a
+      // live command. Health may go ahead on the capped cycle; input never does.
       const intervalMs = (this.appConfig.keepalive_config?.interval_seconds || 300) * 1000;
       const agentIdleMs = msSinceAgentActivity();
-      if (actions.length > 0 && agentIdleMs < intervalMs) {
+      if (actions.length > 0 && (agentBusy || agentIdleMs < intervalMs)) {
         console.log(
-          `Keepalive: skipping ${actions.length} action(s) — agent active ` +
-            `${Math.round(agentIdleMs / 1000)}s ago (interval ${Math.round(intervalMs / 1000)}s)`,
+          agentBusy
+            ? `Keepalive: skipping ${actions.length} action(s) — agent command still in flight`
+            : `Keepalive: skipping ${actions.length} action(s) — agent active ` +
+              `${Math.round(agentIdleMs / 1000)}s ago (interval ${Math.round(intervalMs / 1000)}s)`,
         );
         actions = [];
       }

--- a/apps/worker/src/login-dsl-runner.spec.ts
+++ b/apps/worker/src/login-dsl-runner.spec.ts
@@ -46,6 +46,11 @@ function createMockPage() {
     evaluate: jest.fn().mockResolvedValue(undefined),
     screenshot: jest.fn().mockResolvedValue(undefined),
     reload: jest.fn().mockResolvedValue(undefined),
+    viewportSize: jest.fn().mockReturnValue({ width: 1200, height: 800 }),
+    mouse: {
+      move: jest.fn().mockResolvedValue(undefined),
+      wheel: jest.fn().mockResolvedValue(undefined),
+    },
     _locator: locator,
     _frameLocatorObj: frameLocatorObj,
   };
@@ -561,5 +566,27 @@ describe('LoginDslRunner', () => {
 
       expect(page.goto).toHaveBeenCalledWith('https://example.com/quote/abc123', expect.any(Object));
     });
+  });
+});
+
+describe('activity keepalive action', () => {
+  it('nudges the mouse and scrolls (trusted events) without clicking or navigating', async () => {
+    const { runner, page } = buildRunner();
+    await runner.execute([{ action: 'activity' } as any], { username: '', password: '' });
+    // real Playwright input → trusted events a bank's idle listener resets on
+    expect(page.mouse.move).toHaveBeenCalled();
+    expect(page.mouse.wheel).toHaveBeenCalled();
+    // and it must NOT reload / navigate (that is what expires the session)
+    expect(page.goto).not.toHaveBeenCalled();
+    expect(page.reload).not.toHaveBeenCalled();
+  });
+
+  it('never throws even if input fails (must not break the keepalive loop)', async () => {
+    const page = createMockPage();
+    (page.mouse.move as jest.Mock).mockRejectedValue(new Error('detached'));
+    const { runner } = buildRunner({ page });
+    await expect(
+      runner.execute([{ action: 'activity' } as any], { username: '', password: '' }),
+    ).resolves.not.toThrow();
   });
 });

--- a/apps/worker/src/login-dsl-runner.ts
+++ b/apps/worker/src/login-dsl-runner.ts
@@ -204,6 +204,30 @@ export class LoginDslRunner {
         await this.page.reload({ timeout });
         break;
 
+      case 'activity': {
+        // Human-like idle-reset keepalive. Banks typically detect idle via DOM
+        // interaction events (mousemove / scroll / keypress reset a client-side
+        // countdown that redirects to /session-expire), NOT via HTTP activity —
+        // which is why an open page still expires and a fetch heartbeat may not
+        // help. Playwright's mouse input generates TRUSTED events (isTrusted =
+        // true), indistinguishable from a real user, so a small move + a scroll
+        // nudge resets that timer the way a human would. No clicks, no keys, no
+        // navigation — safe on any page (including the login/expiry page).
+        try {
+          const vp = this.page.viewportSize() || { width: 1200, height: 800 };
+          const cx = Math.floor(vp.width / 2);
+          const cy = Math.floor(vp.height / 2);
+          await this.page.mouse.move(cx, cy, { steps: 3 });
+          await this.page.mouse.move(cx + 25, cy + 18, { steps: 3 });
+          await this.page.mouse.wheel(0, 40);
+          await this.page.mouse.wheel(0, -40);
+        } catch (error) {
+          // Never let a keepalive nudge fail the loop.
+          console.warn(`[DSL] activity keepalive nudge failed: ${error}`);
+        }
+        break;
+      }
+
       case 'request_human_input':
         await this.handleHumanInputRequest(step, stepIndex);
         break;

--- a/apps/worker/src/main.ts
+++ b/apps/worker/src/main.ts
@@ -22,6 +22,7 @@ import { SessionDb } from './session-db';
 import { RecyclingMonitor } from './recycling-monitor';
 import { ScreenshotFallback } from './screenshot-fallback';
 import { resolveCredentials } from './credential-resolver';
+import { enableDownloadCapture } from './download-capture';
 import { RecordingRunner } from './recording-runner';
 import type { RecordingMode } from '@browser-hitl/shared';
 
@@ -172,19 +173,28 @@ async function main() {
       browser = await chromium.launch(launchOptions);
     }
 
+    // Read policy before creating the context: acceptDownloads must be set at
+    // context-creation time for Playwright to save downloads at all.
+    const browserPolicy = appConfig.browser_policy || { downloads: false, clipboard: false, file_chooser: false };
+    const recordingMode = (browserPolicy as { recording_mode?: RecordingMode }).recording_mode;
+    const downloadsEnabled = browserPolicy.downloads === true;
+
     context = await browser.newContext({
       // VNC: null viewport => the page fills the actual browser window (which we
       // sized to the Xvfb display), so the human sees a full, properly-sized
       // page. CDP/headless keeps a fixed 1920x1080 viewport.
       viewport: streamingMode === 'cdp' ? { width: 1920, height: 1080 } : null,
+      // Without this Playwright silently cancels every download.
+      acceptDownloads: downloadsEnabled,
     });
 
-    // Disable downloads, clipboard, file chooser per browser_policy
-    const browserPolicy = appConfig.browser_policy || { downloads: false, clipboard: false, file_chooser: false };
-    const recordingMode = (browserPolicy as { recording_mode?: RecordingMode }).recording_mode;
-    if (!browserPolicy.downloads) {
-      // Playwright doesn't have a direct "disable downloads" API,
-      // but we intercept and cancel download events
+    // Downloads, clipboard, file chooser per browser_policy.
+    if (downloadsEnabled) {
+      // Opt-in: capture downloads to temp files + an index the /execute/browser
+      // `list_downloads`/`get_download` commands read (see download-capture.ts).
+      enableDownloadCapture(context);
+    } else {
+      // Default: Playwright has no "disable downloads" API, so intercept + cancel.
       context.on('page', (page) => {
         page.on('download', (download) => download.cancel());
       });

--- a/apps/worker/src/recording-runner.spec.ts
+++ b/apps/worker/src/recording-runner.spec.ts
@@ -68,6 +68,14 @@ const pageEvent = (seq: number, selector: string): RecordedInteractionEvent => (
   seq,
 });
 
+/**
+ * The ordinal of a drained event. `seq` is optional on the wire — bundles from
+ * before schema_version 2 have none — but RecordingRunner assigns one to every
+ * event it drains, so -1 here means the guarantee broke and the assertion fails
+ * rather than silently comparing undefined.
+ */
+const seqOf = (e: { seq?: number }): number => e.seq ?? -1;
+
 describe('RecordingRunner', () => {
   it('injects the recorder on start', async () => {
     const f = makeFakes('https://example.com/login');
@@ -156,7 +164,12 @@ describe('RecordingRunner', () => {
 
     const bundle = await runner.drain();
 
-    const timeline = [...bundle.click_events, ...bundle.url_events].sort((a, b) => a.seq - b.seq);
+    // `seq` is optional on the wire (pre-schema_version-2 bundles have none), so
+    // assert the producer guarantee before relying on it to sort.
+    const all = [...bundle.click_events, ...bundle.url_events];
+    expect(all.every((e) => typeof e.seq === 'number')).toBe(true);
+
+    const timeline = [...all].sort((a, b) => seqOf(a) - seqOf(b));
     expect(timeline.map((e) => ('selector' in e ? e.selector : e.to_url))).toEqual([
       '#user',
       '#next',
@@ -164,7 +177,7 @@ describe('RecordingRunner', () => {
       '#password',
       '#signin',
     ]);
-    const seqs = timeline.map((e) => e.seq);
+    const seqs = timeline.map(seqOf);
     expect(seqs).toEqual([...seqs].sort((a, b) => a - b));
     expect(new Set(seqs).size).toBe(seqs.length);
   });
@@ -174,7 +187,7 @@ describe('RecordingRunner', () => {
     const runner = new RecordingRunner(f.page, f.context, 'sess-1', 'login');
     await runner.start();
 
-    f.emit({ ...clickEvent, seq: undefined as unknown as number, selector: '#a' });
+    f.emit({ ...clickEvent, seq: undefined, selector: '#a' });
     f.emit(pageEvent(1, '#b'));
 
     const bundle = await runner.drain();
@@ -182,7 +195,8 @@ describe('RecordingRunner', () => {
       '#a',
       '#b',
     ]);
-    expect(bundle.click_events[0].seq).toBeLessThan(bundle.click_events[1].seq);
+    // The runner still numbers it, from arrival order.
+    expect(seqOf(bundle.click_events[0])).toBeLessThan(seqOf(bundle.click_events[1]));
   });
 
   it('does not record a url event when the url is unchanged', async () => {

--- a/apps/worker/src/recording-runner.spec.ts
+++ b/apps/worker/src/recording-runner.spec.ts
@@ -56,8 +56,17 @@ const clickEvent: RecordedInteractionEvent = {
   class_name: null,
   selector: '#submit',
   url: 'https://example.com/login',
+  seq: 1,
+  event_time: '2026-06-15T00:00:00.000Z',
   timestamp: '2026-06-15T00:00:00.000Z',
 };
+
+/** A page-side event carrying the per-document ordinal the recorder assigned. */
+const pageEvent = (seq: number, selector: string): RecordedInteractionEvent => ({
+  ...clickEvent,
+  selector,
+  seq,
+});
 
 describe('RecordingRunner', () => {
   it('injects the recorder on start', async () => {
@@ -103,6 +112,8 @@ describe('RecordingRunner', () => {
     expect(bundle.har.log.version).toBe('1.2');
     expect(bundle.started_at).toBeTruthy();
     expect(bundle.stopped_at).toBeTruthy();
+    // Marks the event contract as the one that carries seq/event_time.
+    expect(bundle.schema_version).toBe(2);
   });
 
   it('reset() drops pre-bind capture so the bundle starts at the real target', async () => {
@@ -128,6 +139,50 @@ describe('RecordingRunner', () => {
     expect(bundle.url_events).toEqual([
       expect.objectContaining({ from_url: '', to_url: 'https://www.airbnb.com/' }),
     ]);
+  });
+
+  it('rebases per-document ordinals onto one increasing session-global order', async () => {
+    // A two-page login: the recorder's counter restarts at 1 on the second
+    // document, so the raw ordinals alone would interleave the pages.
+    const f = makeFakes('https://example.com/login');
+    const runner = new RecordingRunner(f.page, f.context, 'sess-1', 'login');
+    await runner.start();
+
+    f.emit(pageEvent(1, '#user'));
+    f.emit(pageEvent(2, '#next'));
+    f.navigate('https://example.com/login/password');
+    f.emit(pageEvent(1, '#password')); // new document — counter restarted
+    f.emit(pageEvent(2, '#signin'));
+
+    const bundle = await runner.drain();
+
+    const timeline = [...bundle.click_events, ...bundle.url_events].sort((a, b) => a.seq - b.seq);
+    expect(timeline.map((e) => ('selector' in e ? e.selector : e.to_url))).toEqual([
+      '#user',
+      '#next',
+      'https://example.com/login/password',
+      '#password',
+      '#signin',
+    ]);
+    const seqs = timeline.map((e) => e.seq);
+    expect(seqs).toEqual([...seqs].sort((a, b) => a - b));
+    expect(new Set(seqs).size).toBe(seqs.length);
+  });
+
+  it('falls back to arrival order for events with no page-side ordinal', async () => {
+    const f = makeFakes('https://example.com/login');
+    const runner = new RecordingRunner(f.page, f.context, 'sess-1', 'login');
+    await runner.start();
+
+    f.emit({ ...clickEvent, seq: undefined as unknown as number, selector: '#a' });
+    f.emit(pageEvent(1, '#b'));
+
+    const bundle = await runner.drain();
+    expect(bundle.click_events.map((e: RecordedInteractionEvent) => e.selector)).toEqual([
+      '#a',
+      '#b',
+    ]);
+    expect(bundle.click_events[0].seq).toBeLessThan(bundle.click_events[1].seq);
   });
 
   it('does not record a url event when the url is unchanged', async () => {

--- a/apps/worker/src/recording-runner.ts
+++ b/apps/worker/src/recording-runner.ts
@@ -5,6 +5,7 @@ import type {
   RecordedInteractionEvent,
   RecordedUrlEvent,
 } from '@browser-hitl/shared';
+import { RECORDING_SCHEMA_VERSION } from '@browser-hitl/shared';
 import { startHarCapture, stopHarCapture, cleanupHarListeners } from './har-capture';
 import { REC_BEACON, REC_INSTALL_PATH, domRecorderScript } from './dom-recorder.injected';
 import { sanitizeHar } from './har-sanitizer';
@@ -31,6 +32,18 @@ export class RecordingRunner {
   private started = false;
   private installSeen = false;
 
+  // Session-global event ordering. The injected recorder numbers events per
+  // DOCUMENT — its counter dies with the page — so a two-page login (username
+  // page, then password page) would restart at 1 and a global sort on the raw
+  // ordinal would interleave the pages. Each document's run is rebased onto a
+  // running counter here: a raw ordinal that fails to advance means a new
+  // document (or a subframe's recorder), so the base moves past everything
+  // numbered so far. URL events draw from the same counter, giving consumers one
+  // total order over interactions and navigations.
+  private seqMax = 0;
+  private seqBase = 0;
+  private lastRawSeq = 0;
+
   constructor(
     private readonly page: Page,
     private readonly context: BrowserContext,
@@ -38,6 +51,29 @@ export class RecordingRunner {
     private readonly recordingMode: RecordingMode,
   ) {
     this.startedAt = new Date().toISOString();
+  }
+
+  /** Next session-global ordinal, for events we number ourselves (URL transitions). */
+  private nextSeq(): number {
+    this.seqMax += 1;
+    // Force the next page-side ordinal to rebase past this one, whatever it is.
+    this.seqBase = this.seqMax;
+    this.lastRawSeq = Number.MAX_SAFE_INTEGER;
+    return this.seqMax;
+  }
+
+  /** Map a page-local ordinal onto the session-global one. See seqMax/seqBase. */
+  private rebaseSeq(raw: unknown): number {
+    if (typeof raw !== 'number' || !Number.isFinite(raw) || raw < 1) {
+      // A recorder too old to number its events, or a mangled beacon: fall back
+      // to arrival order so the event still sorts where it landed.
+      return this.nextSeq();
+    }
+    if (raw <= this.lastRawSeq) this.seqBase = this.seqMax; // counter restarted
+    this.lastRawSeq = raw;
+    const seq = this.seqBase + raw;
+    if (seq > this.seqMax) this.seqMax = seq;
+    return seq;
   }
 
   async start(): Promise<void> {
@@ -72,7 +108,10 @@ export class RecordingRunner {
         const body = typeof req.postData === 'function' ? req.postData() : '';
         if (!body) return;
         const ev = JSON.parse(body) as RecordedInteractionEvent;
-        if (ev && typeof ev === 'object') this.events.push(ev);
+        if (ev && typeof ev === 'object') {
+          ev.seq = this.rebaseSeq(ev.seq);
+          this.events.push(ev);
+        }
       } catch {
         /* malformed beacon — ignore */
       }
@@ -104,6 +143,7 @@ export class RecordingRunner {
         this.urlEvents.push({
           from_url: this.lastUrl,
           to_url: to,
+          seq: this.nextSeq(),
           timestamp: new Date().toISOString(),
         });
         this.lastUrl = to;
@@ -133,6 +173,9 @@ export class RecordingRunner {
     this.events.length = 0;
     this.urlEvents.length = 0;
     this.lastUrl = '';
+    this.seqMax = 0;
+    this.seqBase = 0;
+    this.lastRawSeq = 0;
     // Re-arm HAR capture: startHarCapture detaches the existing listeners and
     // installs fresh ones over a new (empty) entries buffer, dropping any
     // placeholder-page requests captured while the spare was warm.
@@ -184,6 +227,7 @@ export class RecordingRunner {
     );
 
     return {
+      schema_version: RECORDING_SCHEMA_VERSION,
       session_id: this.sessionId,
       recording_mode: this.recordingMode,
       started_at: this.startedAt,

--- a/charts/browser-hitl/Chart.yaml
+++ b/charts/browser-hitl/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: browser-hitl
 description: Browser Human-in-the-Loop MVP - Kubernetes-native service stack
 type: application
-version: 1.19.14
-appVersion: "1.19.14"
+version: 1.19.15
+appVersion: "1.19.15"
 keywords:
   - browser
   - hitl

--- a/charts/browser-hitl/Chart.yaml
+++ b/charts/browser-hitl/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: browser-hitl
 description: Browser Human-in-the-Loop MVP - Kubernetes-native service stack
 type: application
-version: 1.19.11
-appVersion: "1.19.11"
+version: 1.19.12
+appVersion: "1.19.12"
 keywords:
   - browser
   - hitl

--- a/charts/browser-hitl/Chart.yaml
+++ b/charts/browser-hitl/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: browser-hitl
 description: Browser Human-in-the-Loop MVP - Kubernetes-native service stack
 type: application
-version: 1.19.13
-appVersion: "1.19.13"
+version: 1.19.14
+appVersion: "1.19.14"
 keywords:
   - browser
   - hitl

--- a/charts/browser-hitl/Chart.yaml
+++ b/charts/browser-hitl/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: browser-hitl
 description: Browser Human-in-the-Loop MVP - Kubernetes-native service stack
 type: application
-version: 1.19.12
-appVersion: "1.19.12"
+version: 1.19.13
+appVersion: "1.19.13"
 keywords:
   - browser
   - hitl

--- a/charts/browser-hitl/Chart.yaml
+++ b/charts/browser-hitl/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: browser-hitl
 description: Browser Human-in-the-Loop MVP - Kubernetes-native service stack
 type: application
-version: 1.19.15
-appVersion: "1.19.15"
+version: 1.19.16
+appVersion: "1.19.16"
 keywords:
   - browser
   - hitl

--- a/charts/browser-hitl/Chart.yaml
+++ b/charts/browser-hitl/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: browser-hitl
 description: Browser Human-in-the-Loop MVP - Kubernetes-native service stack
 type: application
-version: 1.19.10
-appVersion: "1.19.10"
+version: 1.19.11
+appVersion: "1.19.11"
 keywords:
   - browser
   - hitl

--- a/charts/browser-hitl/files/egress-proxy/server.js
+++ b/charts/browser-hitl/files/egress-proxy/server.js
@@ -703,7 +703,12 @@ function proxyConnect(req, clientSocket, head) {
     clientSocket.pipe(upstreamSocket);
   });
 
-  upstreamSocket.on('error', () => {
+  upstreamSocket.on('error', (err) => {
+    if (!clientSocket.destroyed) {
+      try {
+        clientSocket.write(`HTTP/1.1 502 Bad Gateway\r\nX-Proxy-Error: ${String(err?.message || 'upstream connect failed').replace(/[\r\n]/g, ' ')}\r\nConnection: close\r\n\r\n`);
+      } catch {}
+    }
     clientSocket.destroy();
   });
 }

--- a/charts/browser-hitl/files/egress-proxy/server.js
+++ b/charts/browser-hitl/files/egress-proxy/server.js
@@ -707,9 +707,24 @@ function proxyConnect(req, clientSocket, head) {
   });
 
   upstreamSocket.on('error', (err) => {
+    // Only surface the 502 before the tunnel is established — once piping starts,
+    // writing HTTP bytes would corrupt the tunneled TLS stream.
     if (!tunnelEstablished && !clientSocket.destroyed) {
+      const reason = String(err?.message || 'upstream connect failed').replace(/[\r\n]/g, ' ');
+      // Log before responding (mirrors residential fail() at server.js:519) — a
+      // declined/failed CONNECT with no log is exactly the class of silent bug
+      // that has cost this path debugging time before.
+      log('direct CONNECT failed', { session_id: sessionId, target: `${hostname}:${port}`, reason });
       try {
-        clientSocket.write(`HTTP/1.1 502 Bad Gateway\r\nX-Proxy-Error: ${String(err?.message || 'upstream connect failed').replace(/[\r\n]/g, ' ')}\r\nConnection: close\r\n\r\n`);
+        const body = JSON.stringify({ error: 'upstream_connect_error', reason });
+        clientSocket.write(
+          'HTTP/1.1 502 Bad Gateway\r\n' +
+            'Connection: close\r\n' +
+            'Content-Type: application/json; charset=utf-8\r\n' +
+            `Content-Length: ${Buffer.byteLength(body)}\r\n` +
+            '\r\n' +
+            body,
+        );
       } catch {}
     }
     clientSocket.destroy();

--- a/charts/browser-hitl/files/egress-proxy/server.js
+++ b/charts/browser-hitl/files/egress-proxy/server.js
@@ -694,8 +694,11 @@ function proxyConnect(req, clientSocket, head) {
     upstreamSocket?.destroy();
   });
 
+  let tunnelEstablished = false;
+
   const upstreamSocket = net.connect(port, hostname, () => {
     clientSocket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+    tunnelEstablished = true;
     if (head && head.length > 0) {
       upstreamSocket.write(head);
     }
@@ -704,7 +707,7 @@ function proxyConnect(req, clientSocket, head) {
   });
 
   upstreamSocket.on('error', (err) => {
-    if (!clientSocket.destroyed) {
+    if (!tunnelEstablished && !clientSocket.destroyed) {
       try {
         clientSocket.write(`HTTP/1.1 502 Bad Gateway\r\nX-Proxy-Error: ${String(err?.message || 'upstream connect failed').replace(/[\r\n]/g, ' ')}\r\nConnection: close\r\n\r\n`);
       } catch {}

--- a/charts/browser-hitl/templates/configmap.yaml
+++ b/charts/browser-hitl/templates/configmap.yaml
@@ -100,3 +100,4 @@ data:
   DB_POOL_SIZE: {{ .Values.config.dbPoolSize | default "20" | quote }}
   EXTRACT_TAB_TIMEOUT_MS: {{ .Values.config.extractTabTimeoutMs | default "15000" | quote }}
   EXTRACT_TAB_POLL_INTERVAL_MS: {{ .Values.config.extractTabPollIntervalMs | default "3000" | quote }}
+  DISABLE_NETWORK_POLICY: {{ .Values.config.disableNetworkPolicy | default "false" | quote }}

--- a/charts/browser-hitl/templates/egress-proxy-deployment.yaml
+++ b/charts/browser-hitl/templates/egress-proxy-deployment.yaml
@@ -46,6 +46,17 @@ spec:
             - node
             - /app/server.js
           env:
+            # Node's Happy Eyeballs (autoSelectFamily, on by default since 20) races the
+            # A and AAAA connects but caps EACH attempt at 250ms. When a target publishes
+            # an AAAA we cannot route, the v6 attempt fails instantly and the v4 fallback
+            # is aborted at 250ms — so any host further away than that never connects and
+            # the browser sees ERR_TUNNEL_CONNECTION_FAILED. Real-world example: ICICI
+            # (retailnetbanking.icici.bank.in) has an AAAA and a ~500ms v4 RTT from
+            # outside India, which fails 100% at the default budget.
+            # Raise the per-attempt budget rather than disabling autoselection, so
+            # dual-stack targets still work where v6 IS routable.
+            - name: NODE_OPTIONS
+              value: "--network-family-autoselection-attempt-timeout={{ .Values.egressProxy.familyAutoselectionTimeoutMs }}"
             - name: EGRESS_PROXY_PORT
               value: {{ .Values.egressProxy.port | quote }}
             - name: EGRESS_PROXY_ADMIN_PORT

--- a/charts/browser-hitl/values-local.secret.yaml.example
+++ b/charts/browser-hitl/values-local.secret.yaml.example
@@ -1,0 +1,14 @@
+# Local-only secret overrides for `make kind-reload-all` / Tilt `tabby-deploy`.
+#
+# Copy to `values-local.secret.yaml` (gitignored) and fill in real values. The
+# Kind helm command auto-includes it with a second `-f` when present, so it
+# survives every reload — unlike a manual `kubectl patch` on the Secret.
+#
+#   cp charts/browser-hitl/values-local.secret.yaml.example \
+#      charts/browser-hitl/values-local.secret.yaml
+#
+# Residential upstream proxy (Oxylabs), used when a session is flagged
+# residential_proxy_enabled. India-targeted + sticky session for bank logins.
+# The {sessionId} placeholder is substituted per session by the egress-proxy.
+secrets:
+  egressUpstreamProxyUrl: "http://customer-<USER>-cc-in-sessid-{sessionId}:<PASS>@pr.oxylabs.io:7777"

--- a/charts/browser-hitl/values-local.yaml
+++ b/charts/browser-hitl/values-local.yaml
@@ -152,6 +152,7 @@ config:
   reconcileBatchSize: "50"
   extractTabTimeoutMs: "15000"
   extractTabPollIntervalMs: "3000"
+  disableNetworkPolicy: "true"
   # Warm recording-session pool (off by default locally — set recordingPoolTenants
   # to "*" or a tenant id to warm spares; residential spares also need
   # EGRESS_UPSTREAM_PROXY_URL on the egress-proxy). IfNotPresent is required for

--- a/charts/browser-hitl/values-local.yaml
+++ b/charts/browser-hitl/values-local.yaml
@@ -319,6 +319,8 @@ egressProxy:
     - ".icici.bank.in"
     - ".icicibank.com"
     - ".hsbcnet.com"
+    # --- HDFC Life (myaccount portal) ---
+    - ".hdfclife.com"
     # --- Dev/test ---
     - ".dontpad.com"
     - ".api.dontpad.com"

--- a/charts/browser-hitl/values-local.yaml
+++ b/charts/browser-hitl/values-local.yaml
@@ -313,6 +313,12 @@ egressProxy:
     # --- Workday ---
     - ".workday.com"
     - ".workdaycdn.com"
+    # --- ICICI Net Banking ---
+    # Scoped to .icici.bank.in rather than .bank.in: leading-dot entries are suffix
+    # matches, so the broader form would open every *.bank.in registrar domain.
+    - ".icici.bank.in"
+    - ".icicibank.com"
+    - ".hsbcnet.com"
     # --- Dev/test ---
     - ".dontpad.com"
     - ".api.dontpad.com"

--- a/charts/browser-hitl/values.yaml
+++ b/charts/browser-hitl/values.yaml
@@ -388,6 +388,12 @@ egressProxy:
 # =============================================================================
 # Network Policies (H12 remediation) — restrict inter-service traffic
 # =============================================================================
+# NOTE: distinct from `config.disableNetworkPolicy` below — opposite polarity,
+# different scope. This flag governs CHART-LEVEL inter-service NetworkPolicies
+# (H12). `config.disableNetworkPolicy` governs PER-SESSION `np-{sessionId}` NPs
+# created by the controller. The two are independent — do not derive one from the
+# other (this defaults off, so that would silently disable per-session NPs where
+# they're currently on).
 networkPolicies:
   enabled: false  # Enable in production
 
@@ -484,8 +490,10 @@ config:
   reconcileBatchSize: "50"
   extractTabTimeoutMs: "15000"
   extractTabPollIntervalMs: "3000"
-  # Local dev: skip K8s NetworkPolicy creation and force egress allow_all.
-  # Leave "false" in staging/production — NPs are essential for isolation.
+  # Local dev: skip PER-SESSION `np-{sessionId}` NetworkPolicy creation and force
+  # egress allow_all. Distinct from `networkPolicies.enabled` above (chart-level
+  # inter-service NPs, opposite polarity). Leave "false" in staging/production —
+  # per-session NPs are essential for worker egress isolation.
   disableNetworkPolicy: "false"
 
 # =============================================================================

--- a/charts/browser-hitl/values.yaml
+++ b/charts/browser-hitl/values.yaml
@@ -365,6 +365,12 @@ egressProxy:
     tag: "20.18.1-alpine"
     pullPolicy: IfNotPresent
   port: 3128
+  # Per-address-family connect budget for Node's Happy Eyeballs (default 250ms).
+  # Must exceed the slowest legitimate target RTT: when a host publishes an AAAA
+  # this cluster cannot route, the v6 attempt fails instantly and the v4 fallback
+  # is cancelled at this deadline, surfacing as ERR_TUNNEL_CONNECTION_FAILED.
+  # 2000ms comfortably covers intercontinental targets.
+  familyAutoselectionTimeoutMs: 2000
   adminPort: 8095
   allowInsecureAdmin: false
   allowInsecureSessionAllowlist: false

--- a/charts/browser-hitl/values.yaml
+++ b/charts/browser-hitl/values.yaml
@@ -484,6 +484,9 @@ config:
   reconcileBatchSize: "50"
   extractTabTimeoutMs: "15000"
   extractTabPollIntervalMs: "3000"
+  # Local dev: skip K8s NetworkPolicy creation and force egress allow_all.
+  # Leave "false" in staging/production — NPs are essential for isolation.
+  disableNetworkPolicy: "false"
 
 # =============================================================================
 # Secrets (sensitive values - override in production)

--- a/infra/docker/Dockerfile.api
+++ b/infra/docker/Dockerfile.api
@@ -19,6 +19,21 @@ COPY apps/api/src ./apps/api/src
 RUN pnpm install --frozen-lockfile
 RUN pnpm --filter @browser-hitl/shared build && pnpm --filter @browser-hitl/api build
 
+# Vendor the noVNC browser client so the VNC viewer does not fetch it at page load.
+# It must come from the GitHub tree, not the @novnc/novnc npm package: npm publishes
+# only `lib/`, which is a CommonJS (Babel) build, and the viewer loads the client with
+# `import RFB from '/vnc/assets/rfb.js'` — a browser ES-module import of CommonJS fails.
+# Only GitHub's `core/` is ESM. Keep NOVNC_VERSION in step with noVncRootBaseUrl in
+# streaming.controller.ts, which stays as the runtime fallback.
+# Downloaded with node's global fetch since this base image has no curl/wget.
+ARG NOVNC_VERSION=1.5.0
+RUN node -e "const fs=require('fs');fetch('https://github.com/novnc/noVNC/archive/refs/tags/v${NOVNC_VERSION}.tar.gz').then(r=>{if(!r.ok)throw new Error('HTTP '+r.status);return r.arrayBuffer()}).then(b=>fs.writeFileSync('/tmp/novnc.tgz',Buffer.from(b)))" \
+    && tar -xzf /tmp/novnc.tgz -C /tmp \
+    && mkdir -p /app/vendor/novnc \
+    && cp -r /tmp/noVNC-${NOVNC_VERSION}/core /tmp/noVNC-${NOVNC_VERSION}/vendor /app/vendor/novnc/ \
+    && rm -rf /tmp/novnc.tgz /tmp/noVNC-${NOVNC_VERSION} \
+    && test -f /app/vendor/novnc/core/rfb.js
+
 EXPOSE 8000
 
 USER node

--- a/infra/docker/Dockerfile.worker
+++ b/infra/docker/Dockerfile.worker
@@ -14,6 +14,26 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     xvfb x11vnc xclip autocutsel && \
     rm -rf /var/lib/apt/lists/*
 
+# Windows core fonts for CloakBrowser's Windows spoof. A Windows-claiming browser
+# that enumerates only Linux fonts is an anti-bot fingerprint tell — bank login
+# risk engines decline it ("Unable to process your request"). ttf-mscorefonts-
+# installer provides the real MS font *names* (Arial, Times New Roman, Verdana,
+# Georgia, Courier New, Trebuchet, ...) that font probing checks for;
+# fonts-liberation adds metric-compatible fallbacks. Enable multiverse (Noble
+# deb822 format) and auto-accept the EULA. See CloakBrowser font-setup-on-linux.
+RUN set -eux; \
+    if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then \
+      sed -i -E 's/^(Components:.*)$/\1 multiverse/; s/multiverse( multiverse)+/multiverse/' /etc/apt/sources.list.d/ubuntu.sources; \
+    else \
+      echo "deb http://archive.ubuntu.com/ubuntu noble multiverse" > /etc/apt/sources.list.d/multiverse.list; \
+    fi; \
+    apt-get update; \
+    echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | debconf-set-selections; \
+    apt-get install -y --no-install-recommends \
+      ttf-mscorefonts-installer fonts-liberation fontconfig cabextract; \
+    fc-cache -f; \
+    rm -rf /var/lib/apt/lists/*
+
 # Install pnpm
 RUN npm install -g pnpm@10
 

--- a/infra/kind/cluster-config.yaml
+++ b/infra/kind/cluster-config.yaml
@@ -1,0 +1,15 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  # Default 65535 breaks TLS handshakes with external sites (GitHub, LinkedIn CDN)
+  # whose certificates produce packets larger than the real internet path MTU.
+  podSubnet: "10.244.0.0/16"
+  serviceSubnet: "10.96.0.0/16"
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: ClusterConfiguration
+        apiServer:
+          extraArgs:
+            "service-node-port-range": "1-65535"

--- a/infra/kind/cluster-config.yaml
+++ b/infra/kind/cluster-config.yaml
@@ -1,15 +1,11 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 networking:
-  # Default 65535 breaks TLS handshakes with external sites (GitHub, LinkedIn CDN)
-  # whose certificates produce packets larger than the real internet path MTU.
+  # NOTE: Kind exposes no MTU setting. The pod MTU (which defaults to 65535 and
+  # breaks TLS handshakes to external sites like GitHub / LinkedIn CDN whose certs
+  # produce large packets) is patched to 1500 *after* create by `make kind-fix-mtu`.
+  # These two subnets are Kind's own defaults, pinned here only to be explicit.
   podSubnet: "10.244.0.0/16"
   serviceSubnet: "10.96.0.0/16"
 nodes:
   - role: control-plane
-    kubeadmConfigPatches:
-      - |
-        kind: ClusterConfiguration
-        apiServer:
-          extraArgs:
-            "service-node-port-range": "1-65535"

--- a/infra/tfy/deploy.yaml
+++ b/infra/tfy/deploy.yaml
@@ -356,6 +356,14 @@ values:
       # --- Workday ---
       - ".workday.com"
       - ".workdaycdn.com"
+      # --- ICICI Net Banking ---
+      # Scoped to .icici.bank.in rather than .bank.in: leading-dot entries are
+      # suffix matches, so the broader form would open every *.bank.in registrar
+      # domain.
+      - ".icici.bank.in"
+      - ".icicibank.com"
+      # --- HSBCnet ---
+      - ".hsbcnet.com"
       # --- Adopt platform assets + Frontegg-hosted logins (Spendflo etc.) ---
       - ".adopt.ai"
       - ".frontegg.com"

--- a/packages/shared/src/config.types.ts
+++ b/packages/shared/src/config.types.ts
@@ -31,6 +31,17 @@ export interface UrlCheck {
   type: 'url_check';
   url: string;
   expect_status: number;
+  /**
+   * Regex (case-insensitive) tested against the final URL after redirects. A match
+   * means the target bounced us to its login flow → AUTH_FAIL (triggers the HITL
+   * re-login) rather than a generic failure. Set this whenever the target redirects
+   * to something the built-in heuristic misses — it only matches /login|signin|sso|
+   * oauth|saml|authgw|identity/ in the host+path, so a bounce to a bare `/` root
+   * (common for SPAs) goes undetected without an explicit pattern.
+   */
+  auth_redirect_pattern?: string;
+  /** Per-check request timeout. Default 15000. */
+  timeout_ms?: number;
 }
 
 export interface DomCheck {
@@ -44,6 +55,8 @@ export interface NetworkCheck {
   url: string;
   expect_status: number;
   body_contains?: string;
+  /** Per-check request timeout. Default 15000. */
+  timeout_ms?: number;
 }
 
 export type HealthCheck = UrlCheck | DomCheck | NetworkCheck;

--- a/packages/shared/src/config.types.ts
+++ b/packages/shared/src/config.types.ts
@@ -48,6 +48,18 @@ export interface DomCheck {
   type: 'dom_check';
   selector: string;
   exists: boolean;
+  /**
+   * What `exists` tests. Default 'attached' (DOM presence) — SPA portals render
+   * logged-in chrome that Playwright reports as hidden, so requiring CSS
+   * visibility is the most common cause of a false AUTH_FAIL here.
+   *
+   * Use 'visible' for portals that HIDE rather than unmount their logged-in
+   * markers on sign-out: there the marker stays attached on the login page, so
+   * 'attached' would report PASS on a dead session.
+   */
+  match?: 'attached' | 'visible';
+  /** Per-check timeout in ms. Default 5000. */
+  timeout_ms?: number;
 }
 
 export interface NetworkCheck {

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -14,7 +14,17 @@ export const CHROMIUM_FLAGS = [
   '--remote-debugging-address=127.0.0.1',
   '--remote-debugging-port=9222',
   '--disable-dev-shm-usage',
-  '--disable-gpu',
+  // Software WebGL via ANGLE+SwiftShader instead of '--disable-gpu'. Plain
+  // --disable-gpu leaves the page with NO WebGL context at all ("Canvas has no
+  // webgl context" on bot.sannysoft.com) — a real Chrome ALWAYS has a WebGL
+  // context, so "no context" is a hard bot signature that reCAPTCHA v3 /
+  // fingerprint SDKs flag, and it also leaves CloakBrowser nothing to spoof.
+  // These give a working software WebGL context (Chrome gates SwiftShader behind
+  // --enable-unsafe-swiftshader in recent builds) that CloakBrowser can then
+  // present with a plausible vendor/renderer.
+  '--use-gl=angle',
+  '--use-angle=swiftshader',
+  '--enable-unsafe-swiftshader',
   // Force all egress over TCP so it goes through the HTTP CONNECT egress-proxy.
   // Chrome uses QUIC/HTTP-3 (UDP) for sites that support it (e.g. Akamai-fronted
   // banks like ICICI), and QUIC CANNOT traverse an HTTP CONNECT proxy — Chrome

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -15,6 +15,13 @@ export const CHROMIUM_FLAGS = [
   '--remote-debugging-port=9222',
   '--disable-dev-shm-usage',
   '--disable-gpu',
+  // Force all egress over TCP so it goes through the HTTP CONNECT egress-proxy.
+  // Chrome uses QUIC/HTTP-3 (UDP) for sites that support it (e.g. Akamai-fronted
+  // banks like ICICI), and QUIC CANNOT traverse an HTTP CONNECT proxy — Chrome
+  // sends it DIRECTLY from the pod, bypassing the egress allowlist AND the
+  // residential upstream (the "Chrome ignores residential proxy" symptom). This
+  // makes the browser fall back to HTTP/1.1+2 over TCP, which the proxy tunnels.
+  '--disable-quic',
   // NOTE: '--enable-automation' is deliberately OMITTED. It sets
   // navigator.webdriver = true and the "controlled by automated software"
   // signals, which re-expose automation even under CloakBrowser stealth and get

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -15,7 +15,13 @@ export const CHROMIUM_FLAGS = [
   '--remote-debugging-port=9222',
   '--disable-dev-shm-usage',
   '--disable-gpu',
-  '--enable-automation',
+  // NOTE: '--enable-automation' is deliberately OMITTED. It sets
+  // navigator.webdriver = true and the "controlled by automated software"
+  // signals, which re-expose automation even under CloakBrowser stealth and get
+  // bank/anti-bot login risk engines to decline the session ("Unable to process
+  // your request"). Disabling the AutomationControlled blink feature instead
+  // keeps navigator.webdriver falsey. See gotcha #8.
+  '--disable-blink-features=AutomationControlled',
   '--password-store=basic',
   '--disable-component-extensions-with-background-pages',
   '--disable-client-side-phishing-detection',

--- a/packages/shared/src/dsl.types.ts
+++ b/packages/shared/src/dsl.types.ts
@@ -20,6 +20,7 @@ export type DslActionType =
   | 'sleep'
   | 'screenshot'
   | 'reload'
+  | 'activity'
   | 'request_human_input';
 
 export type FailureHandler =
@@ -119,6 +120,16 @@ export interface ReloadStep extends BaseDslStep {
   action: 'reload';
 }
 
+/**
+ * Human-like idle-reset keepalive: a small trusted mouse move + scroll nudge, no
+ * clicks/keys/navigation. Resets client-side idle timers (banks detect idle via
+ * DOM interaction events, not HTTP) the way a real user would, without side
+ * effects. Safe on any page.
+ */
+export interface ActivityStep extends BaseDslStep {
+  action: 'activity';
+}
+
 export interface RequestHumanInputStep extends BaseDslStep {
   action: 'request_human_input';
   input_type: HumanInputType;
@@ -145,6 +156,7 @@ export type DslStep =
   | SleepStep
   | ScreenshotStep
   | ReloadStep
+  | ActivityStep
   | RequestHumanInputStep;
 
 /** Metadata for a pending human input request, stored on session + passed via NATS. */

--- a/packages/shared/src/dsl.validator.ts
+++ b/packages/shared/src/dsl.validator.ts
@@ -18,7 +18,7 @@ export interface ValidationResult {
 const VALID_ACTIONS: DslActionType[] = [
   'goto', 'fill', 'type', 'click', 'select',
   'wait_for', 'wait_for_url', 'frame', 'main_frame',
-  'popup', 'keyboard', 'evaluate', 'sleep', 'screenshot', 'reload',
+  'popup', 'keyboard', 'evaluate', 'sleep', 'screenshot', 'reload', 'activity',
   'request_human_input',
 ];
 
@@ -154,6 +154,7 @@ function validateStep(step: DslStep, index: number, prefix: string): ValidationE
 
     case 'screenshot':
     case 'reload':
+    case 'activity':
       // No params needed
       break;
 

--- a/packages/shared/src/execute-types.ts
+++ b/packages/shared/src/execute-types.ts
@@ -30,6 +30,7 @@ export const BROWSER_COMMANDS = [
   'get_page_summary', 'get_page_info', 'screenshot',
   'wait_for_selector', 'scroll_page',
   'har_start', 'har_stop', 'har_status',
+  'list_downloads', 'get_download',
 ] as const;
 
 export type BrowserCommandName = typeof BROWSER_COMMANDS[number];

--- a/packages/shared/src/recording.types.ts
+++ b/packages/shared/src/recording.types.ts
@@ -36,6 +36,42 @@ export interface RecordedInteractionEvent {
   aria_label?: string | null;
   role_attr?: string | null;
   data_attrs_json?: string | null;
+  /**
+   * Total-order key across ALL events in the bundle (interactions and URL
+   * transitions share one counter). Strictly increasing in interaction order;
+   * gaps are normal and carry no meaning.
+   *
+   * Order by this, not by `timestamp`. The injected recorder debounces `input`
+   * by 500ms, so a field filled and submitted inside that window flushes its
+   * input event AFTER the click — and `timestamp` records that flush (see
+   * below), which puts the click first. `seq` is assigned at interaction time
+   * and is also immune to the beacon channel's delivery order and to clock
+   * granularity.
+   *
+   * Added additively — bundles recorded before it have no `seq`, so consumers
+   * must detect its presence rather than assume it.
+   */
+  seq: number;
+  /**
+   * Wall clock of the interaction itself. For `input` this is the first
+   * keystroke of the debounce burst; for every other event type it is the same
+   * clock read as `timestamp` to within a statement. Read this when you need the
+   * time an interaction happened, and `seq` when you need order. Added
+   * additively alongside `seq`.
+   */
+  event_time: string;
+  /**
+   * Wall clock at which the event payload was BUILT — for the debounced `input`
+   * handler that is the flush, up to 500ms after the keystroke; for every other
+   * event type it is the interaction itself.
+   *
+   * Semantics AND value are frozen: this field predates `seq`/`event_time` and
+   * existing consumers (notably the NoUI login compiler) read it, so each handler
+   * keeps its own original clock read in its original position rather than
+   * copying `event_time`. Never assume `event_time === timestamp`; only
+   * `event_time <= timestamp` holds. New code wanting interaction time should
+   * read `event_time`, and wanting order, `seq`.
+   */
   timestamp: string;
 }
 
@@ -43,6 +79,12 @@ export interface RecordedInteractionEvent {
 export interface RecordedUrlEvent {
   from_url: string;
   to_url: string;
+  /**
+   * Same counter as RecordedInteractionEvent.seq — clicks and navigations
+   * interleave in one total order. Added additively.
+   */
+  seq: number;
+  /** Emitted inline at navigation, so this is also the interaction time. */
   timestamp: string;
 }
 
@@ -72,8 +114,25 @@ export interface RecordedCookie {
   sameSite?: 'Strict' | 'Lax' | 'None';
 }
 
+/**
+ * Bundle schema revision. Bumped only when the event contract changes.
+ *   1 — implicit (absent). Events carry no `seq`/`event_time`.
+ *   2 — every event carries `seq`; interaction events also carry `event_time`.
+ */
+export const RECORDING_SCHEMA_VERSION = 2;
+
 /** The bundle drained on "Finish & export" and pulled by NoUI. */
 export interface RecordingBundle {
+  /**
+   * See RECORDING_SCHEMA_VERSION. Absent on bundles drained before it existed,
+   * which is what "version 1" means.
+   *
+   * Informational: it describes what the WORKER produced. Consumers should still
+   * detect `seq` per event rather than dispatch on this, because a bundle can
+   * lose the field in transit — NoUI's `/clicks` ingestion projects events onto
+   * a fixed column list, and anything not in it is dropped.
+   */
+  schema_version?: number;
   session_id: string;
   recording_mode: RecordingMode;
   started_at: string;

--- a/packages/shared/src/recording.types.ts
+++ b/packages/shared/src/recording.types.ts
@@ -48,18 +48,25 @@ export interface RecordedInteractionEvent {
    * and is also immune to the beacon channel's delivery order and to clock
    * granularity.
    *
-   * Added additively — bundles recorded before it have no `seq`, so consumers
-   * must detect its presence rather than assume it.
+   * OPTIONAL because it was added additively: this interface also describes
+   * bundles read back from storage (RecordingStore.retrieve), and anything
+   * persisted before schema_version 2 has no `seq`. It can also be lost in
+   * transit — NoUI's `/clicks` ingestion projects events onto a fixed column
+   * list. Detect it; never assume it. RecordingRunner does guarantee it on every
+   * bundle IT drains, but that is a producer guarantee, not a wire one.
    */
-  seq: number;
+  seq?: number;
   /**
    * Wall clock of the interaction itself. For `input` this is the first
    * keystroke of the debounce burst; for every other event type it is the same
    * clock read as `timestamp` to within a statement. Read this when you need the
-   * time an interaction happened, and `seq` when you need order. Added
-   * additively alongside `seq`.
+   * time an interaction happened, and `seq` when you need order.
+   *
+   * Optional for the same reason as `seq` — see there. Unlike `seq` it is never
+   * reconstructed server-side: it comes from the page, so a bundle drained by a
+   * worker older than schema_version 2 has none.
    */
-  event_time: string;
+  event_time?: string;
   /**
    * Wall clock at which the event payload was BUILT — for the debounced `input`
    * handler that is the flush, up to 500ms after the keystroke; for every other
@@ -81,9 +88,9 @@ export interface RecordedUrlEvent {
   to_url: string;
   /**
    * Same counter as RecordedInteractionEvent.seq — clicks and navigations
-   * interleave in one total order. Added additively.
+   * interleave in one total order. Optional for the same reason: see there.
    */
-  seq: number;
+  seq?: number;
   /** Emitted inline at navigation, so this is also the interaction time. */
   timestamp: string;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -344,8 +344,8 @@ importers:
         specifier: ^10.51.0
         version: 10.51.0
       cloakbrowser:
-        specifier: ^0.3.12
-        version: 0.3.12(playwright-core@1.58.2)
+        specifier: ^0.5.2
+        version: 0.5.2(playwright-core@1.58.2)
       express:
         specifier: ^4.21.2
         version: 4.22.1
@@ -828,89 +828,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1267,24 +1283,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.5.19':
     resolution: {integrity: sha512-5xTOE0lDlDCSSfp+BAif7j17VRRCjWp//ZPZy6NI0QpdrhxtQnsZguSx0xAAZ0c9XZLrLLwCe/XVe5YPrRilKw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.5.19':
     resolution: {integrity: sha512-LTxRmMgqqMv05Had879W00Fm53quiJd3Zuz8h1JSNJ3nGSlbZ/7Tjs1tKyScgN3Au3t3MyPsjPlq60fMmSHLsg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.5.19':
     resolution: {integrity: sha512-eoNQSpA5PQfB9wBO4RA47MTDXWz1fizy9Y3Z6e4DetYIF3dvjuu8sj7aIGn/bFCU6lnFzTK34NtCaffP4NsQ7Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.5.19':
     resolution: {integrity: sha512-6UNt2dFuCHOe446sm/Kp69nUe8/wIhnh9bm6Xcqw4qEWCOppLMOvhTBVgvM7invVUNr4SPpP6NOQsACtn2IN9Q==}
@@ -1333,21 +1353,25 @@ packages:
     resolution: {integrity: sha512-4ZSjvCjnBT0WpGdF12hvgLWmok4WftaE09fOWWrMm4b2m8F/5yKgU6usPFTehQa5oqTp08KW60kZMLaOQHOJQg==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-arm64-musl@21.6.10':
     resolution: {integrity: sha512-lNzlTsgr7nY56ddIpLTzYZTuNA3FoeWb9Ald07pCWc0EHSZ0W4iatJ+NNnj/QLINW8HWUehE9mAV5qZlhVFBmg==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-linux-x64-gnu@21.6.10':
     resolution: {integrity: sha512-nJxUtzcHwk8TgDdcqUmbJnEMV3baQxmdWn77d1NTP4cG677A7jdV93hbnCcw+AQonaFLUzDwJOIX8eIPZ32GLw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@nx/nx-linux-x64-musl@21.6.10':
     resolution: {integrity: sha512-+VwITTQW9wswP7EvFzNOucyaU86l2UcO6oYxFiwNvRioTlDOE5U7lxYmCgj3OHeGCmy9jhXlujdD+t3OhOT3gQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@nx/nx-win32-arm64-msvc@21.6.10':
     resolution: {integrity: sha512-kkK/0GNVs7pdcgksLfoMBT8k92XGfcePPuhhS1Tsyq+zc3gpsPo+vNIGfeIf2FumKBsUdWUHuChfpxBmjcVFVw==}
@@ -2484,19 +2508,23 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
-  cloakbrowser@0.3.12:
-    resolution: {integrity: sha512-Mw78gqFbx8HlgBgu+REbRnMH4qwxoqegBg+bd61D2D1zf0ZW2RbOy5qVtJ9VksZ4928QudtwGO8I3SzPjMf3bw==}
-    engines: {node: '>=18.0.0'}
+  cloakbrowser@0.5.2:
+    resolution: {integrity: sha512-vXMWM1HzI87CGUrOobMpTu/GqPn2eZbNcImhMMjF/48/M12iZEWVolrquY3ot0YI++ddYjoVb71hkodpRsRlIg==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
     peerDependencies:
       mmdb-lib: '>=2.0.0'
-      playwright-core: '>=1.40.0'
+      playwright-core: '>=1.53.0'
       puppeteer-core: '>=21.0.0'
+      socks-proxy-agent: '>=10.0.0'
     peerDependenciesMeta:
       mmdb-lib:
         optional: true
       playwright-core:
         optional: true
       puppeteer-core:
+        optional: true
+      socks-proxy-agent:
         optional: true
 
   clone@1.0.4:
@@ -7929,7 +7957,7 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
-  cloakbrowser@0.3.12(playwright-core@1.58.2):
+  cloakbrowser@0.5.2(playwright-core@1.58.2):
     dependencies:
       tar: 7.5.11
     optionalDependencies:


### PR DESCRIPTION
## Summary
Promotes current `dev` to `main` (52 commits). Highlights below.

### Anti-bot / fingerprinting
- Stop leaking automation + Windows fingerprint to bank anti-bot; software WebGL (SwiftShader) so the browser presents a real GPU
- `--disable-quic` so bank traffic can't bypass the egress proxy; gate activity keepalive on health to avoid recaptcha bot flags
- Human-like `activity` keepalive (idle reset without a reload); never inject keepalive input on the capped busy cycle or while an agent/human is driving

### Egress allowlists
- Allow ICICI, HSBCnet (stage + prod), `.hdfclife.com`, and local dev domains
- Raise Happy Eyeballs attempt budget so distant hosts connect

### Browser downloads
- Capture browser downloads and expose them via `execute/browser`; contain noVNC + download file reads to their roots

### Health checks
- `dom_check`: test DOM presence not CSS visibility; handle `exists:false`, multi-match selectors, and log why a check failed; a check that can't run must not report AUTH_FAIL
- `url_check` catches client-side SPA session expiry; human-readable health label instead of raw AUTH_FAIL enum

### Sessions / controller
- Release FAILED session pods; a FAILED session must not block its own replacement; don't return a TERMINATED session as current
- Allow Editor role to GET a single session; stop MinIO orphan sweep from deleting recording bundles

### Local dev
- Bootstrap, egress proxy, Swagger docs, Kind MTU/CoreDNS fixes; optional gitignored local secrets override for Kind helm

🤖 Generated with [Claude Code](https://claude.com/claude-code)