### PR TITLE
fix(recording): boot warm-pool spares browser-driven so pooled captures match fresh

### DIFF
--- a/apps/api/src/modules/recording/recording-pool.service.spec.ts
+++ b/apps/api/src/modules/recording/recording-pool.service.spec.ts
@@ -54,7 +54,7 @@ function makeService(
 }
 
 describe('RecordingPoolService.ensurePoolApp — warm spares boot browser-driven', () => {
-  it('creates the pool app browser_driven=true + downloads=true so a browser claim needs no bind-mode switch', async () => {
+  it('creates the pool app browser_driven=true so a browser claim needs no bind-mode switch', async () => {
     const { svc, appsService } = makeService(
       { size: '3' },
       { appRepoFindOne: jest.fn().mockResolvedValue(null) }, // no existing pool app -> create path
@@ -67,9 +67,50 @@ describe('RecordingPoolService.ensurePoolApp — warm spares boot browser-driven
     // The spare boots already browser-driven so adoptMode() is a no-op on a
     // browser-driven claim (the login->browser switch was dropping interactions).
     expect(input.browser_policy.browser_driven).toBe(true);
-    expect(input.browser_policy.downloads).toBe(true);
     // Still a login-mode spare: combined captures record as 'login' for whole-HAR.
     expect(input.browser_policy.recording_mode).toBe('login');
+  });
+
+  it('rewrites browser_policy on a PRE-EXISTING lean pool app (the fix must reach a live pool)', async () => {
+    // A pool app row created before this fix: browser_driven not set (lean).
+    const stale = {
+      id: 'pool-existing',
+      desired_session_count: 3,
+      browser_policy: { recording_mode: 'login', downloads: false },
+    };
+    const update = jest.fn();
+    const { svc, appRepo } = makeService(
+      { size: '3' },
+      { appRepoFindOne: jest.fn().mockResolvedValue(stale) },
+    );
+    appRepo.update = update;
+
+    await svc.ensurePoolApp(false);
+
+    // Existing-row branch must sync browser_policy (not just desired_session_count),
+    // else spares under a pre-deploy pool keep booting lean and the fix is invisible.
+    expect(update).toHaveBeenCalledWith(
+      'pool-existing',
+      expect.objectContaining({ browser_policy: expect.objectContaining({ browser_driven: true }) }),
+    );
+  });
+
+  it('does not rewrite an already browser-driven pool app (no needless write per request)', async () => {
+    const current = {
+      id: 'pool-existing',
+      desired_session_count: 3,
+      browser_policy: { recording_mode: 'login', browser_driven: true, downloads: false },
+    };
+    const update = jest.fn();
+    const { svc, appRepo } = makeService(
+      { size: '3' },
+      { appRepoFindOne: jest.fn().mockResolvedValue(current) },
+    );
+    appRepo.update = update;
+
+    await svc.ensurePoolApp(false);
+
+    expect(update).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/api/src/modules/recording/recording-pool.service.spec.ts
+++ b/apps/api/src/modules/recording/recording-pool.service.spec.ts
@@ -50,8 +50,28 @@ function makeService(
   if (prevTenants === undefined) delete process.env.RECORDING_POOL_TENANTS;
   else process.env.RECORDING_POOL_TENANTS = prevTenants;
 
-  return { svc, appRepo, dataSource, managerQuery, findOne, sessionCount };
+  return { svc, appRepo, dataSource, managerQuery, findOne, sessionCount, appsService };
 }
+
+describe('RecordingPoolService.ensurePoolApp — warm spares boot browser-driven', () => {
+  it('creates the pool app browser_driven=true + downloads=true so a browser claim needs no bind-mode switch', async () => {
+    const { svc, appsService } = makeService(
+      { size: '3' },
+      { appRepoFindOne: jest.fn().mockResolvedValue(null) }, // no existing pool app -> create path
+    );
+    appsService.create.mockResolvedValue({ app_id: 'pool-1' });
+
+    await svc.ensurePoolApp(false);
+
+    const input = appsService.create.mock.calls[0][0];
+    // The spare boots already browser-driven so adoptMode() is a no-op on a
+    // browser-driven claim (the login->browser switch was dropping interactions).
+    expect(input.browser_policy.browser_driven).toBe(true);
+    expect(input.browser_policy.downloads).toBe(true);
+    // Still a login-mode spare: combined captures record as 'login' for whole-HAR.
+    expect(input.browser_policy.recording_mode).toBe('login');
+  });
+});
 
 describe('RecordingPoolService.isEnabledForTenant', () => {
   it('is disabled when size is 0 / unset regardless of tenants', () => {

--- a/apps/api/src/modules/recording/recording-pool.service.ts
+++ b/apps/api/src/modules/recording/recording-pool.service.ts
@@ -290,10 +290,22 @@ export class RecordingPoolService implements OnModuleInit {
         ttl_seconds: 300,
       },
       browser_policy: {
-        downloads: false,
+        // Warm spares boot ALREADY browser-driven so a browser-driven claim needs
+        // NO login->browser mode switch at bind: adoptMode() sees browser_driven
+        // already true and is a no-op, so the DOM recorder + download/popup capture
+        // are armed from boot exactly like a fresh pod. The login->browser switch
+        // is what dropped ~half the interactions on pooled recordings (a claimed
+        // spare captured ~12 clicks vs ~24-28 fresh). `downloads: true` likewise
+        // arms download acceptance from boot. A login/api claim downgrades cleanly
+        // at bind -- adoptMode() flips browser_driven off and tears the rich
+        // listeners back down (see RecordingRunner.adoptMode) -- so its bundle is
+        // byte-identical to a lean-booted spare. Warm-up capture is discarded on
+        // bind either way, so booting rich costs nothing during warm-up.
+        downloads: true,
         clipboard: false,
         file_chooser: false,
         recording_mode: 'login' as RecordingMode,
+        browser_driven: true,
       },
       notification_config: {},
       desired_session_count: this.sizeFor(residential),

--- a/apps/api/src/modules/recording/recording-pool.service.ts
+++ b/apps/api/src/modules/recording/recording-pool.service.ts
@@ -118,21 +118,32 @@ export class RecordingPoolService implements OnModuleInit {
     const appName = this.appNameFor(residential);
     const size = this.sizeFor(residential);
     const tenantId = RECORDING_POOL.SYSTEM_TENANT_ID;
+    const desired = this.buildPoolAppInput(residential);
     const existing = await this.appRepo.findOne({
       where: { tenant_id: tenantId, name: appName },
     });
     if (existing) {
-      if (existing.desired_session_count !== size) {
-        await this.appRepo.update(existing.id, { desired_session_count: size });
+      const needsSize = existing.desired_session_count !== size;
+      // Sync browser_policy on the EXISTING row too. A pool app created before the
+      // browser_driven-spare fix (e.g. a live staging pool) is found here and would
+      // otherwise return early, so its spares keep booting with the old lean policy
+      // and the fix never reaches that environment. Detect the stale row by the one
+      // field that matters and rewrite the policy; only new spares the controller
+      // warms after this pick it up, so drain the pool (or let it rotate) to apply
+      // it immediately.
+      const currentDriven = (existing.browser_policy as { browser_driven?: boolean } | undefined)
+        ?.browser_driven;
+      const needsPolicy = currentDriven !== desired.browser_policy.browser_driven;
+      if (needsSize || needsPolicy) {
+        await this.appRepo.update(existing.id, {
+          ...(needsSize ? { desired_session_count: size } : {}),
+          ...(needsPolicy ? { browser_policy: desired.browser_policy } : {}),
+        });
       }
       return existing.id;
     }
     try {
-      const { app_id } = await this.appsService.create(
-        this.buildPoolAppInput(residential),
-        tenantId,
-        'system:recording-pool',
-      );
+      const { app_id } = await this.appsService.create(desired, tenantId, 'system:recording-pool');
       this.logger.log(
         `Created global ${residential ? 'residential ' : ''}recording pool app ${app_id} (size ${size})`,
       );
@@ -295,13 +306,15 @@ export class RecordingPoolService implements OnModuleInit {
         // already true and is a no-op, so the DOM recorder + download/popup capture
         // are armed from boot exactly like a fresh pod. The login->browser switch
         // is what dropped ~half the interactions on pooled recordings (a claimed
-        // spare captured ~12 clicks vs ~24-28 fresh). `downloads: true` likewise
-        // arms download acceptance from boot. A login/api claim downgrades cleanly
-        // at bind -- adoptMode() flips browser_driven off and tears the rich
+        // spare captured ~12 clicks vs ~24-28 fresh). A login/api claim downgrades
+        // cleanly at bind -- adoptMode() flips browser_driven off and tears the rich
         // listeners back down (see RecordingRunner.adoptMode) -- so its bundle is
         // byte-identical to a lean-booted spare. Warm-up capture is discarded on
         // bind either way, so booting rich costs nothing during warm-up.
-        downloads: true,
+        // (downloads stays false: main.ts forces acceptDownloads on for any
+        // recording via recording_mode, so this flag is inert here -- browser_driven
+        // is the only field that changes what gets captured.)
+        downloads: false,
         clipboard: false,
         file_chooser: false,
         recording_mode: 'login' as RecordingMode,

--- a/apps/worker/src/recording-runner.spec.ts
+++ b/apps/worker/src/recording-runner.spec.ts
@@ -27,7 +27,13 @@ function makeFakes(initialUrl: string) {
       // 'domcontentloaded' (recorder re-injection) is accepted and ignored.
     },
     evaluate: jest.fn(async () => undefined),
-    removeListener: jest.fn(),
+    // Null the tracked listener too, so hasDownloadListener() reflects teardown
+    // (existing tests only assert the call happened, which still holds).
+    removeListener: jest.fn((event: string) => {
+      if (event === 'download') downloadListener = null;
+      if (event === 'framenavigated') navListener = null;
+      if (event === 'request') requestListener = null;
+    }),
   } as unknown as import('playwright').Page;
 
   let pageListener: ((p: unknown) => void) | null = null;
@@ -37,7 +43,9 @@ function makeFakes(initialUrl: string) {
     on: jest.fn((event: string, fn: (arg: unknown) => void) => {
       if (event === 'page') pageListener = fn as typeof pageListener;
     }),
-    removeListener: jest.fn(),
+    removeListener: jest.fn((event: string) => {
+      if (event === 'page') pageListener = null;
+    }),
   } as unknown as import('playwright').BrowserContext;
 
   // Simulate the sentinel fetch() beacon the injected recorder would issue.
@@ -438,6 +446,68 @@ describe('RecordingRunner — workflow capture', () => {
     const bundle = await runner.drain();
 
     expect(bundle.download_events).toEqual([]);
+  });
+});
+
+/**
+ * Warm-pool bind. Pool spares now boot browser_driven=true (login mode) so a
+ * browser-driven claim needs NO login->browser switch at bind — that switch is
+ * what dropped ~half the interactions on pooled recordings. A login/api claim
+ * flips browser_driven off at bind and must downgrade to byte-identical lean.
+ */
+describe('RecordingRunner — warm-pool bind (adoptMode)', () => {
+  // A rich-warmed pool spare: login mode, browser_driven=true from boot.
+  const richSpare = (f: ReturnType<typeof makeFakes>) =>
+    new RecordingRunner(f.page, f.context, 'sess-p', 'login', true);
+
+  it('browser-driven claim is a no-op: rich listeners stay, download still captured', async () => {
+    const f = makeFakes('https://bank.test/login');
+    const runner = richSpare(f);
+    await runner.start();
+    expect(f.hasDownloadListener()).toBe(true);
+    expect(f.hasPageListener()).toBe(true);
+
+    // Bind for a browser-driven recording: same flag, same mode -> no churn.
+    runner.adoptMode('login', true);
+    expect(f.hasDownloadListener()).toBe(true);
+    expect(f.hasPageListener()).toBe(true);
+
+    f.download('statement.pdf', 'blob:https://bank.test/abc');
+    const bundle = await runner.drain();
+    expect(bundle.download_events).toEqual([
+      expect.objectContaining({ suggested_filename: 'statement.pdf' }),
+    ]);
+  });
+
+  it('login/api claim downgrades cleanly: rich listeners torn down, bundle login-shaped', async () => {
+    const f = makeFakes('https://bank.test/login');
+    const runner = richSpare(f);
+    await runner.start();
+    expect(f.hasDownloadListener()).toBe(true);
+    expect(f.hasPageListener()).toBe(true);
+
+    // Bind for a login/api recording: browser_driven flips off at bind.
+    runner.adoptMode('login', false);
+    expect(f.hasDownloadListener()).toBe(false);
+    expect(f.hasPageListener()).toBe(false);
+
+    // A download after the downgrade is not captured, and the bundle carries no
+    // workflow-only keys -- byte-identical to a lean-booted login recording.
+    f.download('late.pdf', 'blob:https://bank.test/late');
+    const bundle = await runner.drain();
+    expect('download_events' in bundle).toBe(false);
+  });
+
+  it('lean spare still upgrades to rich on a browser-driven claim', async () => {
+    const f = makeFakes('https://bank.test/login');
+    const runner = new RecordingRunner(f.page, f.context, 'sess-l', 'login'); // lean boot
+    await runner.start();
+    expect(f.hasDownloadListener()).toBe(false);
+    expect(f.hasPageListener()).toBe(false);
+
+    runner.adoptMode('login', true);
+    expect(f.hasDownloadListener()).toBe(true);
+    expect(f.hasPageListener()).toBe(true);
   });
 });
 

--- a/apps/worker/src/recording-runner.ts
+++ b/apps/worker/src/recording-runner.ts
@@ -604,7 +604,6 @@ export class RecordingRunner {
     return bundle;
   }
 
-  /** Detach all listeners. Safe to call on SIGTERM and after drain(). */
   /**
    * Tear down ONLY the rich-capture listeners — the `context.on('page')` popup
    * handler and every download handler (main page + any popups) tracked in
@@ -632,6 +631,7 @@ export class RecordingRunner {
     }
   }
 
+  /** Detach all listeners. Safe to call on SIGTERM and after drain(). */
   detach(): void {
     this.detachRichCapture();
     if (this.onFrameNavigated) {

--- a/apps/worker/src/recording-runner.ts
+++ b/apps/worker/src/recording-runner.ts
@@ -455,10 +455,19 @@ export class RecordingRunner {
     // changing. `browser_driven` alone turns it on -- a combined capture stays
     // in 'login' mode throughout -- and returning early on an unchanged mode
     // meant those recordings never attached download or popup capture.
-    if (this.richCapture && this.started && !this.onPopup) {
-      this.attachDownloadCapture(this.page, 0);
-      this.onPopup = (popup: Page) => this.attachPopupCapture(popup);
-      this.context.on('page', this.onPopup);
+    if (this.started) {
+      if (this.richCapture && !this.onPopup) {
+        this.attachDownloadCapture(this.page, 0);
+        this.onPopup = (popup: Page) => this.attachPopupCapture(popup);
+        this.context.on('page', this.onPopup);
+      } else if (!this.richCapture && this.onPopup) {
+        // Downgrade: a rich-warmed pool spare (browser_driven=true from boot) was
+        // claimed for a login/api recording, so bind flips browser_driven off.
+        // Tear the rich listeners back down so the recording is byte-identical to
+        // one that booted lean -- otherwise the download/popup handlers keep
+        // firing into a bundle that discards them.
+        this.detachRichCapture();
+      }
     }
     // The recorder in the CURRENT document was installed with the old flag. The
     // imminent navigation to the real target gets a fresh one via addInitScript /
@@ -596,7 +605,19 @@ export class RecordingRunner {
   }
 
   /** Detach all listeners. Safe to call on SIGTERM and after drain(). */
-  detach(): void {
+  /**
+   * Tear down ONLY the rich-capture listeners — the `context.on('page')` popup
+   * handler and every download handler (main page + any popups) tracked in
+   * `popupTeardowns` — leaving the base recorder (DOM events, URL transitions,
+   * HAR) intact.
+   *
+   * Shared by detach() (full teardown at stop) and by adoptMode() when a
+   * rich-warmed pool spare is claimed for a login/api recording and downgrades:
+   * without this the download/popup handlers would linger, firing into a bundle
+   * that (correctly) discards them, so a downgraded spare would not be
+   * byte-identical to one that booted lean.
+   */
+  private detachRichCapture(): void {
     if (this.onPopup) {
       this.context.removeListener('page', this.onPopup);
       this.onPopup = null;
@@ -609,6 +630,10 @@ export class RecordingRunner {
         /* page already closed — its listeners died with it */
       }
     }
+  }
+
+  detach(): void {
+    this.detachRichCapture();
     if (this.onFrameNavigated) {
       this.page.removeListener('framenavigated', this.onFrameNavigated);
       this.onFrameNavigated = null;


### PR DESCRIPTION
## Problem
Recording an ICICI browser skill on staging (warm pool) compiled a much poorer skill than the same flow on local (fresh, no pool): pooled recordings captured **~12 interactions vs ~24–28 fresh**, losing the radio/period selection and other clicks. Same worker image (`c390747`) on both — so it wasn't a code version. It's the warm-pool path: a spare **boots lean (`browser_driven=false`, login mode)** and must switch **login→browser at claim** (`adoptMode`), and that switch drops ~half the interactions. Infra's image check confirmed the version is fine; the fault is the boot-lean → switch-at-claim path only pooled pods take.

(The ICICI *download* itself failing is a separate, independent issue — India-only host `mccm.icicibank.com` unreachable from US egress — not addressed here.)

## Fix (2 pieces — keeps the pool's sub-second claim)
1. **`buildPoolAppInput`**: spares boot `browser_policy.browser_driven=true` + `downloads=true`. A browser-driven claim then finds `adoptMode()` a **no-op** (no teardown/reinstall churn) — the recorder + download/popup capture are armed from boot, identical to a fresh pod. Warm-up capture is discarded at bind, so booting rich costs nothing.
2. **`adoptMode()`**: on a **login/api** claim, `browser_driven` flips off (`richCapture` false), and we now **tear the rich listeners back down** (new `detachRichCapture()`, factored out of `detach()`), so a downgraded spare is **byte-identical** to a lean-booted one. Workflow-mode recordings stay rich (`isWorkflow` keeps `richCapture` true), unchanged.

## Non-browser safety
An api/login recording that claims a rich spare downgrades at bind: HAR stays whole (reduction is `browserDriven && isWorkflow`), the bundle carries no workflow-only keys, and the rich listeners are removed — same output as today. Covered by a test.

## Tests
- worker: pooled spare no-op on a browser claim (listeners stay, download captured); clean downgrade for login/api (listeners torn down, bundle login-shaped); lean spare still upgrades. (32 pass)
- api: pool app is created `browser_driven` + `downloads` on. (14 pass)
- Typecheck + full monorepo build green.

## Validation after deploy
Record the ICICI flow **pooled** and check the capture stats: interaction count should now match fresh (~24–28, not ~12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)