### PR TITLE
ci: re-run the PR-title check when a title is edited

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,13 @@ name: CI
 
 on:
   pull_request:
+    # `edited` is required so the PR Title (Conventional Commit) check re-runs when
+    # a title is corrected. Without it the trigger defaults to
+    # [opened, synchronize, reopened], the check reads the frozen event-payload
+    # title, and fixing a bad title never clears the failing check (only a new
+    # commit would). See the dev->main promotion PRs, which routinely need a
+    # title fix.
+    types: [opened, edited, synchronize, reopened]
     branches: [dev, main]
 
 concurrency:


### PR DESCRIPTION
## Problem
The `dev → main` promotion PR (#165) failed only the **PR Title (Conventional Commit)** check. Fixing the title didn't clear it: the CI `pull_request` trigger has no `types:`, so it defaults to `[opened, synchronize, reopened]` — **`edited` is absent** — and the job reads `github.event.pull_request.title` from the frozen event payload. So editing / reopening / re-running never picks up the corrected title; only a new commit (a `synchronize`) would.

## Fix
Add `types: [opened, edited, synchronize, reopened]` to the `pull_request` trigger, so a title correction re-runs the check.

## Bonus
Merging this advances `dev`, which fires a `synchronize` on #165 → its CI re-runs with the already-corrected title (`release: browser-based skill recorder + replay`) → green, unblocking the promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)